### PR TITLE
Add english messages to unsupported languages

### DIFF
--- a/tools/i18n_merge.py
+++ b/tools/i18n_merge.py
@@ -10,19 +10,27 @@ import os # Provides file-system functions
 
 os.chdir("..") # Move CWD to root of repo
 
-locales = os.listdir(r"catblock/_locales") # Load a list of all locales in the CatBlock locales folder.
-for locale in locales: # "locale" below is the locale selected for this loop
-	print "Merging i18n file for locale: " + locale
-	with open("_locales/" + locale + "/messages.json", "rU") as ab_read: # Opens the AdBlock i18n file in a secure manner for read-only
-		with open("catblock/_locales/" + locale + "/messages.json", "rU") as cb_file: # Opens the CatBlock i18n file in a secure manner
-			ab_messages = json.load(ab_read) # Creates a dict of all messages in the AdBlock file
-			cb_messages = json.load(cb_file) # Creates a dict of all messgaes in the CatBlock file
-			ab_messages.update(cb_messages) # Updates the AdBlock strings with the CatBlock ones
-			# Closes CatBlock messages file
-		# Closes AdBlock messages file
-	with open("_locales/" + locale + "/messages.json", "w") as ab_write: # Open the AdBlock i18n file as write-only (will overwite data!)
-		ab_write.write(json.dumps(ab_messages, sort_keys=True, indent=2, separators=(',', ':'))) # Writes the JSON data to the AdBlock file in an easy-to-read format
-		# Closes AdBlock messages file
-	print "Merged i18n file for locale: %s" % locale
+ab_locales = os.listdir(r"_locales") # Load a list of all locales in the AdBlock locales folder
+
+for locale in ab_locales: # "locale" below is the locale selected for this loop
+    print "Merging i18n file for locale: " + locale
+    with open("_locales/" + locale + "/messages.json", "rU") as ab_read: # Opens the AdBlock i18n file in a secure manner for read-only
+        # If we don't have CatBlock's specific language file, then merge CatBlock's english language file into AdBlock's language file
+        try:
+            with open("catblock/_locales/" + locale + "/messages.json", "rU") as cb_file: # Opens the CatBlock i18n file in a secure manner
+                ab_messages = json.load(ab_read) # Creates a dict of all messages in the AdBlock file
+                cb_messages = json.load(cb_file) # Creates a dict of all messgaes in the CatBlock file
+                ab_messages.update(cb_messages) # Updates the AdBlock strings with the CatBlock ones
+            # Closes CatBlock messages file
+        except:
+            with open("catblock/_locales/" + "en" + "/messages.json", "rU") as cb_file: # Opens the CatBlock i18n file in a secure manner
+                ab_messages = json.load(ab_read) # Creates a dict of all messages in the AdBlock file
+                cb_messages = json.load(cb_file) # Creates a dict of all messgaes in the CatBlock file
+                ab_messages.update(cb_messages) # Updates the AdBlock strings with the CatBlock ones
+            # Closes AdBlock messages file
+        with open("_locales/" + locale + "/messages.json", "w") as ab_write: # Open the AdBlock i18n file as write-only (will overwite data!)
+            ab_write.write(json.dumps(ab_messages, sort_keys=False, indent=2, separators=(',', ':'))) # Writes the JSON data to the AdBlock file in an easy-to-read format
+        # Closes AdBlock messages file
+    print "Merged i18n file for locale: %s" % locale
 
 # Done!


### PR DESCRIPTION
Actually, we don't include CB's english strings into languages, which don't have specific CB's language file located in catblock/_messages, which leads to not showing english strings in unsupported languages.
