### PR TITLE
Various (mostly) Firefox fixes

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,1283 +1,1087 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"لم يتم العثور على malware معروف."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"في هذا المتصفح، اشترك في نفس قوائم عوامل التصفية كما لديك هنا."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"في هذا المستعرض تحميل الصفحة مع الإعلان."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"السويدية"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"منع المزيد من الإعلانات:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"الروسية"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"الغاء الاشتراك."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"الصينية"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"قائمة عوامل ااتصفية المعادية للمجتمع (يزيل أزرار الوسائط الاجتماعية)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"وجدت إعلان على صفحة ويب؟ نحن سوف تساعدك على العثور على المكان المناسب لتقرير ذلك!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"إظهار عدد إعلانات المحظورة على زر AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"شفرة المصدر <a>متاحة بحرية</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"تحديث منذ 1 دقيقة"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"فشل في إحضار عامل التصفية !"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"قد يكون كمبيوترك مصاب ببرامج ضارة.  انقر <a>here</a> لمزيد من المعلومات."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"منع اعلان بواسطة عنوان URL الخاص به"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"إخفاء هذا الزر"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"أنا سوف أجلب التحديثات تلقائياً؛ يمكنك أيضا <a>تحديث الآن</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"تنسيق: ~موقع1.com|~موقع2.com|~اخبار.موقع3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"الأستونية"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"نوع"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"هناك تحديث ل AdBlock! اذهب إلى $here$ لتحديث. <br>ملاحظة: إذا كنت ترغب في تلقي التحديثات تلقائياً، انقر فوق فقط في Safari > Preferences > Extensions > Updates <br> والاختيار الخيار 'تثبيت التحديثات تلقائياً'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"ما هذا؟"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"لا تشترك على أكثر مما تحتاج  --كل واحد  يبطئ قليلاً جدا! الاعتمادات و القوائم كثيرة ويمكن الاطلاع عليها <a>هنا</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"ميزات AdBlock لا تعمل على هذا الموقع لأنه يستخدم تكنولوجيا قديمة. يمكنك اضافة موارد إلي لقائمة السوداء أو البيضاء  يدوياً في علامة التبويب 'تخصيص' من الصفحة خيارات."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"البولندية"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"معرفة المزيد حول برنامج \"إعلانات مقبولة\"."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"تحديث $seconds$ ثانية/ثواني مضت",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"كائن-subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"الهنغارية"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"ملاحظة: التقرير الخاص بك قد تصبح متاحة للجمهور. أن تبقيه في الاعتبار قبل ضم  أي شيء خاص."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"الرجاء تعطيل بعض قوائم عوامل التصفية. مزيد من المعلومات في خيارات ل AdBlock."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"الأخرى"
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"منشأ التصفية: $list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"عذراً، AdBlock معطلة على هذه الصفحة بواسطة أحد قوائم عامل التصفية الخاصة بك."
-  },
-  "filtericelandic":{
-    "description":"language",
-    "message":"أيسلندي"
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"تحذير: لا يوجد عامل التصفية محدد!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock معطل في هذه الصفحة."
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"إذا كنت تشاهد أحد إعلانات، لا تقدم تقرير عن الأخطاء، قدم <a>تقرير اعلاني</a>!"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"وتظهر الإعلانات <i>في كل مكان</i> باستثناء هذه المجالات..."
+    "message":"عندك سؤال أو فكرة جديدة؟"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"الخيارات"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"الإعلانات المحظورة:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"إضافة عوامل تصفية للغة أخرى: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"انقر فوق الإعلان، وسوف يسير لكم من خلال حظر عليه."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"عظيم! أنت جاهز."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"دعم AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"تخصيص AdBlock"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"الرجاء كتابة عامل التصفية الصحيح أدناه واضغط موافق"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"الخطوة 1: معرفة ما يجب منع"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"الدانماركية"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (مستحسن)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ على هذه الصفحة",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"الإطار المتوسط"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"تحديث منذ 1 ساعة"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"الكورية"
+    "message":"البولندية"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"أو الكروم"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"الأضافة الأكثر شعبية في  Chrome، مع ما يزيد على 40 مليون مستخدم! تمنع الأعلانات في جميع أنحاء شبكة الإنترنت."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"إظهار جميع الطلبات"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"لا ترغب في التحقق من ذلك"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"نعم"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"التراجع عن المنع الذي وضعته في هذا المجال"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"تخصيص"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"وقفه AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"هل أنت متأكد من أنك تريد الاشتراك في قائمة تصفية $title$؟",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"أو AdBlock لكروم"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"تعريف النمط"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"الإصدار التجريبي"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"تم تجاوز حد قاعدة حظر المحتوى"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"العثور على إعلانات... <br/> <br/><i>فقط هذا سوف يستغرق بعض الوقت.</i>"
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"المجال أو عنوان url AdBlock حيث لا ينبغي أن تمنع أي شيء"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"البرنامج النصي"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$  في إجمالي",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"لا"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"حدث خطأ ما. ولم يتم إرسال أي موارد. سيتم الآن إغلاق هذه الصفحة. حاول إعادة تحميل الموقع."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"الأوكرانية"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"حدثت $minutes$ دقائق مضت",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"أنت لم تعد مشترك في قائمة عوامل تصفية \"الإعلانات مقبولة\"."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"الحماية من البرامج الضارة"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"حفظ"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"تحذير: في جميع المواقع الأخرى سوف تشاهد الإعلانات!<br>هذا يلغي كافة عوامل التصفية الأخرى لتلك المواقع."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"قم بتعطيل هذه الإعلامات"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"الاشتراك في قائمة عامل التصفية..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"أنك تستخدم نسخة قديمة من AdBlock. الرجاء الذهاب إلى <a href='#'> صفحة الإضافات</a>، تمكين 'وضع المطور' وانقر فوق 'تحديث ملحقات الآن'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"خيارات AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"التحقق من البرامج الضارة التي يمكن تكون عن طريق الحقن الإعلانات:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"إظهار بيانات التصحيح في \"سجل وحدة التحكم\" (الذي يبطئ AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"لقد تجاوزت الحجم المسموح به في Dropbox. رجاء أزالة بعض الأدخالات من عوامل التصفية المخصصة او عوامل التصفية المعطلة، و حاول مرة أخري "
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"إلغاء الإيقاف المؤقت ل AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"عمل حول أشرطة الفيديو Hulu.com لا يعمل (يتطلب إعادة تشغيل المستعرض الخاص بك)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"لمطابقة CSS"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"استبعاد"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"تعطيل كافة ملحقات باستثناء AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"الائتمان للترجمة يذهب إلى:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"تحميل..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"الزر الأيمن على الأعلانات في الصغحة لمنعها--أو منعها من هنا يدوياً."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"ملاحظة: Whitelisting (السماح بالإعلانات على) صفحة أو موقع لا تعمل مع تمكين حظر المحتوى في safari."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"تعديل عوامل التصفية المعطلة:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"تمكين منع المحتوى Safari"
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"تحقق من عوامل تصفية \"الإعلانات المقبولة\":"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"لإخفاء الزر،انقر على شريط الأدوات في Safari واختر \"تخصيص شريط الأدوات\"، ثم اسحب الزر AdBlock خارج شريط الأدوات . يمكنك إظهاره  مرة أخرى عن طريق سحبه إلى شريط الأدوات."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"الصفحة"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"تم! لقد تم إعادة تحميل الصفحة مع الإعلان. الرجاء التحقق من تلك الصفحة لمعرفة إذا ما كان الإعلان قد انتهى أم لا. ثم العودة إلى هذه الصفحة، والإجابة على هذا السؤال أدناه."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"أو قم بإدخال عنوان URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"أنك تستخدم نسخة قديمة من Safari. الحصول على أحدث إصدار من أجل استخدام زر شريط الأدوات \"AdBlock\" إلى وقفه AdBlock والمواقع القائمة البيضاء، وإعلان التقرير. <a>الترقية الآن</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"انقر فوق القائمة Safari &rarr; تفضيلات &rarr; ملحقات."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"إيقاف منع الإعلانات:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"منع ذلك!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"هل لا زال الأعلان يظهر ؟"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"البلغارية"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"عظيم! الآن دعنا نكتشف أي ملحق هو السبب. من خلال الذهاب وتمكين كل ملحق واحداً تلو الآخر. الملحق الذي يعيد مستحق هو الذي تحتاج إلى إلغاء تثبيت للتخلص من الإعلانات."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"فشل!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"تحرير عوامل التصفية الخاصة بك يدوياً:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"الإيطالية"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"منبثقة"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"نوع"
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"لا ترغب في التحقق من ذلك"
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"كن حذراً: إذا كنت تجعل من خطأ هنا الكثير من عوامل التصفية الأخرى، بما في ذلك عوامل التصفية الرسمية، يمكن الحصول على كسر جداً! <br/>قراءة <a>دروس بناء جملة عوامل التصفية</a> لمعرفة كيفية إضافة خيارات متقدمة في عوامل التصفية القائمة السوداء و عوامل التصفية القائمة البيضاء ."
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"الاشتراك في قوائم عامل التصفية"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"يمكنك تشغيل هذا مرة أخرى ودعم المواقع التي تحب عن طريق تحديد \"السماح لبعض الإعلانات غير تدخلية\" أدناه."
-  },
   "checkinfirefox_5":{
     "description":"Instruction for how to check Firefox/Chrome for a reported ad",
     "message":"تظهر الإعلانات في هذا المتصفح أيضاً؟"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"لا تقم بتشغيل على هذه الصفحة"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"الليتوانية"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"اسمحوا لنا أن نعرف في <a>الموقعنا</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock متوقفة مؤقتاً."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"نحن لا يمكن منع الإعلانات داخل الفلاش والإضافات الأخرى حتى الآن. نحن في انتظار الدعم من المستعرض WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"موافق!"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"ما هو الجديد في الإصدار الأخير؟ راجع <a style='cursor:pointer;'> سجل التحديثات</a>!"
   },
   "aamessageadreport":{
     "description":"Acceptable Ads message on ad report page",
     "message":"إذا كنت لا تريد أن تري إعلانات مثل هذه، تحتاج إلي أغلاق قائمة عوامل التصفية \"مقبولة إعلان\"."
   },
-  "typeother":{
-    "description":"A resource type",
-    "message":"الأخرى"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"لا يوجد عامل التصفية المحدد!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"غير معروف"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"الصوت/الفيديو"
-  },
-  "filterjapanese":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"اليابانية"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"السماح لبعض الإعلانات الغير متطفّلة"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"إلغاء"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"يمكنك الانزلاق أدناه لتغيير بالضبط ما هي الصفحات التي لن يتم تشغيل AdBlock."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"تحقق في Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"لتقديم تقرير مختصص، يجب الاتصال بالإنترنت."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (مستحسن)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock-الإبلاغ عن الإعلان"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"قوائم عوامل تصفية حظر الإعلان"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"السماح لقنوات يوتيوب معينة"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"الطرف الثالث"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"مضايقات Fanboy's (يزيل مضايقات على شبكة الإنترنت)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock-اضغط للتفاصيل"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"حدثت $hours$ ساعات مضت",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"الروسية والأوكرانية"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"السماح لـ AdBlock بجمع بيانات واستخدام مجهولة الهوية عن قائمة التصفية"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"تم إعادة تمكين الملحقات التي تم تعطيل مسبقاً."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"اليونانية"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"السلوفاكية"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"أشرطة الفيديو وفلاش"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"ما رأيك سوف يكون صحيحاً حول هذا الإعلان في كل مرة تقوم بزيارة هذه الصفحة؟"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"تمكين AdBlock على هذه الصفحة"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"رجوع"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"قوائم عامل التصفية منع معظم الإعلانات على شبكة الإنترنت.  يمكنك أيضا:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"عرض الإعلانات على صفحة ويب أو المجال"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"يطابق العنصر <b>1</b> في هذه الصفحة."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"إخفاء قسم من صفحة ويب"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"اضافة قناة $name$ لل القائمة البيضاء",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"خيارات عامة"
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"لن يتم تشغيل AdBlock على أي صفحة مطابقة:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"ونحن ليس لدينا قائمة عوامل تصفية افتراضي لتلك اللغة. <br/>الرجاء محاولة العثور على قائمة مناسبة بأن يدعم هذه اللغة $link$ أو منع هذا الإعلان لنفسك في علامة التبويب 'تخصيص'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"اشتراك"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"أنا مستخدم متقدم، إظهار لي الخيارات المتقدمة"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"الإسبانية"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"محملة علي الصفحة مع المجال: $domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"انقر فوق هذا الخيار: <a>تحديث عوامل تصفيتي!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"كثيرة تصفية القوائم التي تستخدمها، تبطأ عمل AdBlock. استخدام قوائم كثيرة جداً يمكن أن تحطم حتى المتصفح في بعض المواقع. اضغط موافق الاشتراك في هذه القائمة على أي حال."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"الخطوة الأخيرة: ما الذي يصنع هذا إعلان؟"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"يطابق $matchcount$ البنود المدرجة في هذه الصفحة.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"لقد حصلنا على <a>الصفحة</a> لمساعدتك على معرفة الناس وراء AdBlock، جيدا!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"الإندونيسية"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"التركية"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"منع الأعلان"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"قوائم عامل التصفية مخصصة"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"عنوان الإطار: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"والغرض من هذا السؤال لتحديد الذين ينبغي أن تلقي التقرير الخاص بك. إذا كان يمكنك الإجابة على هذا السؤال بشكل غير صحيح، سيتم إرسال التقرير إلى الأشخاص الخطأ، حيث أنها قد تحصل على تجاهلها."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"إضافة عناصر إلى القائمة الزر اليمين"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"محدد"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"منع هذا الإعلان"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"هل طلب فريقنا بعض معلومات التصحيح؟ انقر <a href='#' id='debug'> هنا</a> للحصول على ذلك!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"لا تقم بتشغيل AdBlock..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"الإبلاغ عن إعلان هو عمل تطوعي. فهو يساعد الناس الآخرين عن طريق تمكين مشرفي قائمة عامل التصفية لمنع الإعلان للجميع. إذا كنت لا تشعر بمساعدة الاخرين الآن، لا مشكلة. إغلاق هذه الصفحة و </a>أمنع الاعلانات</a>لنفسك فقط."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"عنصر المخفي"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"تحديث الصفحة."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"الصفحة"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"الهولندية"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"لا تنسى حفظ!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"التحقق من وجود تحديثات (ينبغي أن يستغرق بضع ثوان فقط)..."
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"اعدادات عامة"
+    "message":"الليتوانية"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"اشترك في قائمة عوامل التصفية هذه، ثم حاول مرة أخرى: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"هل ينبغي علي AdBlock إعلامك عند الكشف عن البرامج الضارة؟"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"قد يكون كمبيوترك مصاب ببرامج ضارة.  انقر <a>here</a> لمزيد من المعلومات."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"إظهار عدد إعلانات المحظورو على قائمة AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"عرض الإعلانات على صفحة ويب أو المجال"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"الموقع:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"عوامل التصفية المخصص لي AdBlock (مستحسن)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"اللاتفية"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"تأكد من أنك تستخدم قوائم اللغة الصحيحة:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"لمطابقة CSS"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"لأخفاء الزر, أذهب إلي opera://extensions و علم علي \"إخفاء من شريط الأدوات\". يمكنك إظهاره مرة اخري بأغلاء تحديد هذا الخيار."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>غير متأكد؟</b> فقط اضغط على 'منع ذلك!' أدناه."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"تطابق عوامل التصفية"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"جلب ... يرجا الأنتضار."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"جميع الموارد"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock متحدث!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"لا تقم بتشغيل على الصفحات الموجودة في هذا المجال"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"العبرية"
+    "message":"السلوفاكية"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"حرك مربع التمرير حتى يتم حظر الإعلان بشكل صحيح على الصفحة، ومنع العناصر تبدو غير مفيدة."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"منع عنوان URLs تحتوي على هذا النص"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"عدد قواعد قائمة عامل التصفية يتجاوز حد 50,000، وقد خفضت تلقائياً. الرجاء إلغاء الاشتراك من بعض قوائم عوامل تصفية أو تعطيل \"حظر المحتوى سفاري\"!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"تحديث منذ 1 يوم"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"إعلانات مقبولة (مستحسن)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"انقر فوق هذا: <a>تعطيل إعلان المقبولة</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"النسخة $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"ثبت Adblock Plus لي Firefox $chrome$ اذا لم يكون لديك.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"حذف من القائمه"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"ونحن ليس لدينا قائمة عوامل تصفية افتراضي لتلك اللغة. <br/>الرجاء محاولة العثور على قائمة مناسبة بأن يدعم هذه اللغة $link$ أو منع هذا الإعلان لنفسك في علامة التبويب 'تخصيص'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"إخفاء"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"قوائم عامل التصفية"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"مجال الإطار: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"انقر فوق الإعلان، وسوف يسير لكم من خلال حظر عليه."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"الإطار العلوي"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"تعريف النمط"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"غير معروف"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"عذراً، AdBlock معطلة على هذه الصفحة بواسطة أحد قوائم عامل التصفية الخاصة بك."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"الطرف الثالث"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"لا يوجد عامل التصفية المحدد!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"اليونانية"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"أنك تستخدم نسخة قديمة من AdBlock. الرجاء الذهاب إلى <a href='#'> صفحة الإضافات</a>، تمكين 'وضع المطور' وانقر فوق 'تحديث ملحقات الآن'"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"عمل حول أشرطة الفيديو Hulu.com لا يعمل (يتطلب إعادة تشغيل المستعرض الخاص بك)"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"تخصيص"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"وجدت إعلان على صفحة ويب؟ نحن سوف تساعدك على العثور على المكان المناسب لتقرير ذلك!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"الأستونية"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"البلغارية"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"موارد اللائحة البيضاء"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"تم تجاوز حد قاعدة حظر المحتوى"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"لا تقم بتشغيل AdBlock..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"منع عنوان URLs تحتوي على هذا النص"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"إغلاق"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"تحقق في Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"الخطوة الأخيرة: ما الذي يصنع هذا إعلان؟"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"تخصيص AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"لم يتم العثور على malware معروف."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"الفنلندية"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"البرنامج النصي"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"الأوكرانية"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"الكورية"
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"الرجاء تعطيل بعض قوائم عوامل التصفية. مزيد من المعلومات في خيارات ل AdBlock."
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"لقد حصلنا على <a>الصفحة</a> لمساعدتك على معرفة الناس وراء AdBlock، جيدا!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"هنا"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"منبثقة"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"إذا كنت تشاهد أحد إعلانات، لا تقدم تقرير عن الأخطاء، قدم <a>تقرير اعلاني</a>!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"تحديث الصفحة."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"ما هي لغة المكتوبة في تلك الصفحة؟"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock متوقفة مؤقتاً."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"إلغاء الإيقاف المؤقت ل AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"العثور على إعلانات... <br/> <br/><i>فقط هذا سوف يستغرق بعض الوقت.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock معطل في هذه الصفحة."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"في هذا المتصفح، اشترك في نفس قوائم عوامل التصفية كما لديك هنا."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"منع الأعلان"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"تحذير: في جميع المواقع الأخرى سوف تشاهد الإعلانات!<br>هذا يلغي كافة عوامل التصفية الأخرى لتلك المواقع."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"تم إعادة تمكين الملحقات التي تم تعطيل مسبقاً."
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"انتهى!"
   },
-  "headerresource":{
-    "description":"Resource list page: title of a column",
-    "message":"المورد"
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"عوامل التصفية المخصص لي AdBlock (مستحسن)"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"منع الأعلانات على هذه الصفحة"
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"نوع"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"تأكد من قوائم عوامل التصفية الخاصة محدثة:"
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"ما هذا؟"
   },
-  "lang_english":{
+  "filterjapanese":{
     "description":"language",
-    "message":"الإنجليزية"
+    "message":"اليابانية"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"افتح صفحة الملحقات لتشغيل الملحقات التي تم تعطيل مسبقاً."
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"منشأ التصفية: $list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"المجال للصفحة تطبيق على"
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"الاشتراك في قوائم عامل التصفية"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"الموقع:"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"إضافة عوامل تصفية للغة أخرى: "
+  },
+  "headerfilter":{
+    "description":"Resource list page: title of a column",
+    "message":"تطابق عوامل التصفية"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"قوائم عامل التصفية منع معظم الإعلانات على شبكة الإنترنت.  يمكنك أيضا:"
+  },
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"لإخفاء الزر،انقر على شريط الأدوات في Safari واختر \"تخصيص شريط الأدوات\"، ثم اسحب الزر AdBlock خارج شريط الأدوات . يمكنك إظهاره  مرة أخرى عن طريق سحبه إلى شريط الأدوات."
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"لقد تجاوزت الحجم المسموح به في Dropbox. رجاء أزالة بعض الأدخالات من عوامل التصفية المخصصة او عوامل التصفية المعطلة، و حاول مرة أخري "
+  },
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"اشتراك"
+  },
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"ملاحظة: Whitelisting (السماح بالإعلانات على) صفحة أو موقع لا تعمل مع تمكين حظر المحتوى في safari."
+  },
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"عنصر المحظورة:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"الصفحة"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"الأخرى"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"انقر فوق هذا الخيار: <a>تحديث عوامل تصفيتي!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"عنصر المخفي"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"لأخفاء الزر, أذهب إلي opera://extensions و علم علي \"إخفاء من شريط الأدوات\". يمكنك إظهاره مرة اخري بأغلاء تحديد هذا الخيار."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"كائن-subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"الصفحة:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"العثور على خطأ؟"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"منع ذلك!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"السماح لقنوات يوتيوب معينة"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"نحن لا يمكن منع الإعلانات داخل الفلاش والإضافات الأخرى حتى الآن. نحن في انتظار الدعم من المستعرض WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"العربيّة"
+    "message":"الهنغارية"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"منع هذا الإعلان"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"تمكين AdBlock على هذه الصفحة"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"إظهار عدد إعلانات المحظورة على زر AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"فشل!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"وقفه AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"التشيكية"
+    "message":"الإنجليزية"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"ادفع ما تريد!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"إضافة عناصر إلى القائمة الزر اليمين"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"تريد أن ترى ما الذي يجعل AdBlock  جميل؟"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"إزالة تحذير Adblock (يزيل تحذيرات حول استخدام مانعات الاعلانات)"
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"عنوان URL غير صالح من القائمة. سوف يتم حذفه."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"الإطار"
+    "message":"الصفحة"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"تعديل"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"هل أنت متأكد من أنك تريد إزالة $count$ المنع الذي قمت بإنشائه في $host$؟",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"عندك سؤال أو فكرة جديدة؟"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"شرح: "
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>أو</b>، فقط انقر فوق هذا الزر لتمكيننا من القيام بكل ما ورد أعلاه: <a>تعطيل كافة ملحقات أخرى</a>"
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"معرفة المزيد حول البرامج الضارة"
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
   },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"إعادة تحميل الصفحة مع الإعلان."
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"الرومانية"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"تعديل عوامل التصفية المعطلة:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"الإطار المتوسط"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"تمكين منع المحتوى Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"تثبيت Firefox $chrome$ إذا لم يكن لديك ذلك.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"قوائم عامل التصفية"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"أنا مستخدم متقدم، إظهار لي الخيارات المتقدمة"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"الصينية"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"عامل التصفية غير صالحة: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"الاشتراك في قائمة عامل التصفية..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"افتح صفحة الملحقات لتشغيل الملحقات التي تم تعطيل مسبقاً."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"قم بتعطيل هذه الإعلامات"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"التركية"
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"تحديث منذ 1 ساعة"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"الإطار"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"الإندونيسية"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"الصورة"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$  في إجمالي",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"إلغاء"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"لا تنسى حفظ!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"محدد"
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"أيسلندي"
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"هل أنت متأكد من أنك تريد الاشتراك في قائمة تصفية $title$؟",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"فقط منع الإعلانات في هذه المواقع:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"محملة علي الصفحة مع المجال: $domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"هناك تحديث ل AdBlock! اذهب إلى $here$ لتحديث. <br>ملاحظة: إذا كنت ترغب في تلقي التحديثات تلقائياً، انقر فوق فقط في Safari > Preferences > Extensions > Updates <br> والاختيار الخيار 'تثبيت التحديثات تلقائياً'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"تنظيف هذه القائمة"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"المساعدة في نشر الكلمة!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"تحديثات AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"إزالة تحذير Adblock (يزيل تحذيرات حول استخدام مانعات الاعلانات)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"خيارات AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"لا تشترك على أكثر مما تحتاج  --كل واحد  يبطئ قليلاً جدا! الاعتمادات و القوائم كثيرة ويمكن الاطلاع عليها <a>هنا</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"التحقق من وجود تحديثات (ينبغي أن يستغرق بضع ثوان فقط)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"تحديث الآن"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"الزر الأيمن على الأعلانات في الصغحة لمنعها--أو منعها من هنا يدوياً."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"التحقق من البرامج الضارة التي يمكن تكون عن طريق الحقن الإعلانات:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"دعم AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"نوع"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"حرك مربع التمرير حتى يتم حظر الإعلان بشكل صحيح على الصفحة، ومنع العناصر تبدو غير مفيدة."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"تحديث منذ 1 دقيقة"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"الإطار"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"الموارد الممنوعة"
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"الدانماركية"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"تحقق من عوامل تصفية \"الإعلانات المقبولة\":"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"يمكنك تشغيل هذا مرة أخرى ودعم المواقع التي تحب عن طريق تحديد \"السماح لبعض الإعلانات غير تدخلية\" أدناه."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"جلب ... يرجا الأنتضار."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"عنوان URL غير صالح من القائمة. سوف يتم حذفه."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"خيارات عامة"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"قم بإلغاء تحديد خانة الاختيار 'تمكين' بجوار كل ملحق <b>باستثناء</b> ل AdBlock.  <b>تمكين ترك AdBlock</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"في هذا المستعرض تحميل الصفحة مع الإعلان."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"وتظهر الإعلانات <i>في كل مكان</i> باستثناء هذه المجالات..."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"لإخفاء الزر، انقر على الزر الأيمن عليه واختر \"زر إخفاء\".  يمكنك إظهار ذلك مرة أخرى في chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"العبرية"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"ميزات AdBlock لا تعمل على هذا الموقع لأنه يستخدم تكنولوجيا قديمة. يمكنك اضافة موارد إلي لقائمة السوداء أو البيضاء  يدوياً في علامة التبويب 'تخصيص' من الصفحة خيارات."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"التشيكية والسلوفاكية"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"لقد عطلنا كافة الملحقات الأخرى. وسوف نقوم بإعادة تحميل الصفحة مع الإعلان. ثانية واحدة، من فضلك."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"قوائم عامل التصفية الأخرى"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"الفرنسية"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"أنا سوف أجلب التحديثات تلقائياً؛ يمكنك أيضا <a>تحديث الآن</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"عنصر المحظورة:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"إظهار جميع الطلبات"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"كائن تفاعلي"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"كثيرة تصفية القوائم التي تستخدمها، تبطأ عمل AdBlock. استخدام قوائم كثيرة جداً يمكن أن تحطم حتى المتصفح في بعض المواقع. اضغط موافق الاشتراك في هذه القائمة على أي حال."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"عظيم! أنت جاهز."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"الإصدار التجريبي"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"تحديثات AdBlock"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"معرفة المزيد حول برنامج \"إعلانات مقبولة\"."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"هل ينبغي علي AdBlock إعلامك عند الكشف عن البرامج الضارة؟"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"تحديث الآن"
+    "message":"تحديث منذ 1 يوم"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"عنوان الإطار: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"الألمانية"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"تحديث $seconds$ ثانية/ثواني مضت",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"لا تقم بتشغيل على هذه الصفحة"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"اسمحوا لنا أن نعرف في <a>الموقعنا</a>!"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"الروسية والأوكرانية"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"موافق!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"تم! لقد تم إعادة تحميل الصفحة مع الإعلان. الرجاء التحقق من تلك الصفحة لمعرفة إذا ما كان الإعلان قد انتهى أم لا. ثم العودة إلى هذه الصفحة، والإجابة على هذا السؤال أدناه."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"جميع الموارد"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"اضافة قناة $name$ لل القائمة البيضاء",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"المورد"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"إظهار عدد إعلانات المحظورو على قائمة AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock-الإبلاغ عن الإعلان"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"لا تقم بتشغيل على الصفحات الموجودة في هذا المجال"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"قوائم عامل التصفية مخصصة"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"منع المزيد من الإعلانات:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"المجال أو عنوان url AdBlock حيث لا ينبغي أن تمنع أي شيء"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"أنت لم تعد مشترك في قائمة عوامل تصفية \"الإعلانات مقبولة\"."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"مضايقات Fanboy's (يزيل مضايقات على شبكة الإنترنت)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"قد حظر AdBlock تنزيل من موقع معروف باحتوائه على برامج ضارة."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"حفظ"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>غير متأكد؟</b> فقط اضغط على 'منع ذلك!' أدناه."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"يبدو جيد"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"السماح لـ AdBlock بجمع بيانات واستخدام مجهولة الهوية عن قائمة التصفية"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"لتقديم تقرير مختصص، يجب الاتصال بالإنترنت."
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"قوائم عوامل تصفية حظر الإعلان"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"حدثت $days$  أيام مضت",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"الإطار"
+    "message":"كائن تفاعلي"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"ما رأيك سوف يكون صحيحاً حول هذا الإعلان في كل مرة تقوم بزيارة هذه الصفحة؟"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"الإعلانات المحظورة:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"العربيّة"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"التراجع عن المنع الذي وضعته في هذا المجال"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"تحرير عوامل التصفية الخاصة بك يدوياً:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"الخطوة 1: معرفة ما يجب منع"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"الرجاء كتابة عامل التصفية الصحيح أدناه واضغط موافق"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"الائتمان للترجمة يذهب إلى:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock متحدث!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"الإنجليزية فقط"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>أو</b>، فقط انقر فوق هذا الزر لتمكيننا من القيام بكل ما ورد أعلاه: <a>تعطيل كافة ملحقات أخرى</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"ما هو الجديد في الإصدار الأخير؟ راجع <a style='cursor:pointer;'> سجل التحديثات</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (حماية الخصوصية)"
+    "message":"قائمة عوامل ااتصفية المعادية للمجتمع (يزيل أزرار الوسائط الاجتماعية)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"تقرير مخصص في هذه الصفحة"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"الحماية من البرامج الضارة"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"تنظيف هذه القائمة"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"لن يتم تشغيل AdBlock على أي صفحة مطابقة:"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"الألمانية"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"يمكنك تجاوز كمية التخزين يمكن استخدام AdBlock. يرجى إلغاء الاشتراك من قوائم عوامل تصفية بعض!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"كن حذراً: عامل التصفية هذا بحظر جميع عناصر $elementtype$ على الصفحة!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"هنا"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"تريد أن ترى ما الذي يجعل AdBlock  جميل؟"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"ما هي لغة المكتوبة في تلك الصفحة؟"
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"هل أنت متأكد من أنك تريد إزالة $count$ المنع الذي قمت بإنشائه في $host$؟",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"إخفاء قسم من صفحة ويب"
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"الصورة"
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"اعدادات عامة"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"لإخفاء الزر، انقر على الزر الأيمن عليه واختر \"زر إخفاء\".  يمكنك إظهار ذلك مرة أخرى في chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"أو AdBlock لكروم"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"الرومانية"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"أشرطة الفيديو وفلاش"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"حدث خطأ أثناء التحقق من وجود تحديثات."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"لقد عطلنا كافة الملحقات الأخرى. وسوف نقوم بإعادة تحميل الصفحة مع الإعلان. ثانية واحدة، من فضلك."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"موارد اللائحة البيضاء"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"عظيم! الآن دعنا نكتشف أي ملحق هو السبب. من خلال الذهاب وتمكين كل ملحق واحداً تلو الآخر. الملحق الذي يعيد مستحق هو الذي تحتاج إلى إلغاء تثبيت للتخلص من الإعلانات."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1289,174 +1093,410 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"التشيكية والسلوفاكية"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"أو الكروم"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"نوع الإطار: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"تنسيق: ~موقع1.com|~موقع2.com|~اخبار.موقع3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" --حدد اللغة -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"ثبت Adblock Plus لي Firefox $chrome$ اذا لم يكون لديك.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"الموارد الممنوعة"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"تظهر الإعلانات في أو قبل فيلم أو أي البرنامج المساعد الأخرى مثل لعبة فلاش؟"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$وسوف يكون $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"عامل التصفية، التي يمكن أن تتغير في صفحة خيارات:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"عامل التصفية التالية: <br/> $filter$ <br/> يحتوي علي خطأ: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"إغلاق"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"فقط منع الإعلانات في هذه المواقع:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"يمكنك تجاوز كمية التخزين يمكن استخدام AdBlock. يرجى إلغاء الاشتراك من قوائم عوامل تصفية بعض!"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"عامل التصفية غير صالحة: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"حسنا، يمكنك لا يزال حظر هذا الإعلان لنفسك في صفحة خيارات. شكرا!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"تأكيد"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"الفنلندية"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"ادفع ما تريد!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"هذه مشكلة قائمة عامل التصفية. تقرير من هنا: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"قم بإلغاء تحديد خانة الاختيار 'تمكين' بجوار كل ملحق <b>باستثناء</b> ل AdBlock.  <b>تمكين ترك AdBlock</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"ملاحظة: التقرير الخاص بك قد تصبح متاحة للجمهور. أن تبقيه في الاعتبار قبل ضم  أي شيء خاص."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"إظهار الرابط لقوائم عوامل التصفية"
+  "filteritalian":{
+    "description":"language",
+    "message":"الإيطالية"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"الإنجليزية فقط"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"المساعدة في نشر الكلمة!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"هل لا زال الأعلان يظهر ؟"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"قد حظر AdBlock تنزيل من موقع معروف باحتوائه على برامج ضارة."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"تأكد من أنك تستخدم قوائم اللغة الصحيحة:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"شرح: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"تأكد من قوائم عوامل التصفية الخاصة محدثة:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"حدث خطأ أثناء التحقق من وجود تحديثات."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"انقر فوق القائمة Safari &rarr; تفضيلات &rarr; ملحقات."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"تأكيد"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"الغاء الاشتراك."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"الصوت/الفيديو"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"اللاتفية"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"منع الأعلانات على هذه الصفحة"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"إيقاف منع الإعلانات:"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"يطابق $matchcount$ البنود المدرجة في هذه الصفحة.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"فشل في إحضار عامل التصفية !"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"يمكنك الانزلاق أدناه لتغيير بالضبط ما هي الصفحات التي لن يتم تشغيل AdBlock."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"إخفاء"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"تظهر الإعلانات في أو قبل فيلم أو أي البرنامج المساعد الأخرى مثل لعبة فلاش؟"
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"حدث خطأ ما. ولم يتم إرسال أي موارد. سيتم الآن إغلاق هذه الصفحة. حاول إعادة تحميل الموقع."
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"الإسبانية"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"كن حذراً: عامل التصفية هذا بحظر جميع عناصر $elementtype$ على الصفحة!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"تمكين وضع التوفق مع ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"لا"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"عامل التصفية، التي يمكن أن تتغير في صفحة خيارات:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"إخفاء هذا الزر"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"الأخرى"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"حسنا، يمكنك لا يزال حظر هذا الإعلان لنفسك في صفحة خيارات. شكرا!"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"تعطيل كافة ملحقات باستثناء AdBlock:"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"الروسية"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"أنك تستخدم نسخة قديمة من Safari. الحصول على أحدث إصدار من أجل استخدام زر شريط الأدوات \"AdBlock\" إلى وقفه AdBlock والمواقع القائمة البيضاء، وإعلان التقرير. <a>الترقية الآن</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (حماية الخصوصية)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$وسوف يكون $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"أو قم بإدخال عنوان URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"عامل التصفية التالية: <br/> $filter$ <br/> يحتوي علي خطأ: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"نوع الإطار: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"تحميل..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"هل طلب فريقنا بعض معلومات التصحيح؟ انقر <a href='#' id='debug'> هنا</a> للحصول على ذلك!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"عدد قواعد قائمة عامل التصفية يتجاوز حد 50,000، وقد خفضت تلقائياً. الرجاء إلغاء الاشتراك من بعض قوائم عوامل تصفية أو تعطيل \"حظر المحتوى سفاري\"!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"تقرير مخصص في هذه الصفحة"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"إظهار بيانات التصحيح في \"سجل وحدة التحكم\" (الذي يبطئ AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"مجال الإطار: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"الأضافة الأكثر شعبية في  Chrome، مع ما يزيد على 40 مليون مستخدم! تمنع الأعلانات في جميع أنحاء شبكة الإنترنت."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"العثور على خطأ؟"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"التشيكية"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"إعادة تحميل الصفحة مع الإعلان."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"إظهار الرابط لقوائم عوامل التصفية"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"السماح لبعض الإعلانات الغير متطفّلة"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"السويدية"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"حذف من القائمه"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" --حدد اللغة -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"الفرنسية"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"تعديل"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"الدعم"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"منع اعلان بواسطة عنوان URL الخاص به"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"النسخة $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"والغرض من هذا السؤال لتحديد الذين ينبغي أن تلقي التقرير الخاص بك. إذا كان يمكنك الإجابة على هذا السؤال بشكل غير صحيح، سيتم إرسال التقرير إلى الأشخاص الخطأ، حيث أنها قد تحصل على تجاهلها."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"الإبلاغ عن إعلان هو عمل تطوعي. فهو يساعد الناس الآخرين عن طريق تمكين مشرفي قائمة عامل التصفية لمنع الإعلان للجميع. إذا كنت لا تشعر بمساعدة الاخرين الآن، لا مشكلة. إغلاق هذه الصفحة و </a>أمنع الاعلانات</a>لنفسك فقط."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"نعم"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"شفرة المصدر <a>متاحة بحرية</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"الهولندية"
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"يطابق العنصر <b>1</b> في هذه الصفحة."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"حدثت $hours$ ساعات مضت",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"رجوع"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"انقر فوق هذا: <a>تعطيل إعلان المقبولة</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"المجال للصفحة تطبيق على"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"حدثت $minutes$ دقائق مضت",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"معرفة المزيد حول البرامج الضارة"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"إعلانات مقبولة (مستحسن)"
   },
   "safaricontentblockingpausemessage":{
     "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
     "message":"لإيقاف AdBlock مع \"حظر المحتوى\" تمكين، الرجاء تحديد سفاري (في شريط القوائم) > تفضيلات > ملحقات > AdBlock، وقم بإلغاء تحديد 'تمكين AdBlock'."
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock-اضغط للتفاصيل"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"يبدو جيد"
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"تحذير: لا يوجد عامل التصفية محدد!"
   }
 }

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Прикачи снимка на екрана:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Няма намерен злонамерен софтуер."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Абонирайте се за същите филтри и в този браузър."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Заредете страницата с рекламата в браузъра."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"шведски"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Да блокирате още реклами:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"руски"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Без абонамент."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"китайски"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"В случай на създаден от вас филтър чрез съветника за блокиране на реклама, моля, поставете го в полето по-долу:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Разреши противосоциалния филтър (чисти бутоните на социални мрежи)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Открихте реклама в страницата? Нека ви помогнем да я докладвате на правилното място!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Показвай броя на блокираните реклами върху бутона на AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Изходният код е <a>свободно достъпен</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"обновен преди 1 минута"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Провалено извличане на филтъра!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Моля, пуснете повторно Safari, за да завърши изключването на блокирането на съдържание."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Блокиране на реклама по адрес"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Скрий бутона"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Обновяванията се извличат автоматично, но бихте могли да ги <a>обновите</a> и сега"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Формат: ~сайт1.бг|~сайт2.бг|~новини.сайт3.бг"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"естонски"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Вид"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Има обновяване за AdBlock! Щракнете $here$ за обновяване. <br> Забележка: в случай че желаете това да става автоматично, изберете Safari > Настройки > Разширения > Обновявания <br> и отметнете „Инсталирай автоматично обновяванията“.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Какво е това?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Не се абонирайте за повече, отколкото са ви необходими — всеки нов ще ви забавя малко повече! Признания и допълнителни филтри можете да намерите <a>тук</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Функцията на AdBlock няма да работи тук, защото сайтът ползва остаряла технология. Можете да забраните или да изключите ресурсите наръка от преградка „Нагласяване“ в страницата с настройки."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"полски"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Повече за програмата Приемливи реклами"
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"обновен преди $seconds$ секунди",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"заявка object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"унгарски"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Забележка: достъпът до доклада може да бъде публичен. Имайте го предвид, ако включвате лични данни."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Моля, забранете някои от филтрите. За повече вж. Настройки на AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Филтърът е част от:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"За съжаление, AdBlock е забранен за страницата в някой от вашите филтри."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Недействителен филтър: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Внимание: няма указан филтър!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock е забранен за страницата."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Показване на реклами <i>навсякъде</i> без домейна"
+    "message":"Имате въпрос или идея?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Настройки"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"заявка xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Блокирани реклами:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Добави филтри за друг език: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Щракнете по реклама, за да изминете пътя до нейното блокиране."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Ако видите реклама, попълнете <a>доклад за реклама</a>, а не доклад за грешка!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Чудесно! Всичко е настроено."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"друг"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Поддръжка"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Нагласяване на AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Важни сведения липсват или са непълни. Моля, отговорете на въпросите, оградени в червено."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Грешка при записване на качения файл."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Моля, въведете правилния филтър по-долу и натиснете ДА:"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Първа стъпка: решете какво блокирате"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"датски"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"Разреши EasyList (препоръчително)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ — в страницата",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"подрамка"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"обновен преди 1 час"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"корейски"
+    "message":"полски"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":" или Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Вашето име?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Най-популярното разширение за Chrome с над 40 милиона потребители! Блокира реклами в световната мрежа."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Покажи заявките"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Не желая такава проверка"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Да"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Отмени блокираните за домейна"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Нагласяване"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Задръж AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Сигурен ли сте, че се абонирате за филтъра „$title$“?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Къде точно е рекламата в страницата? И как изглежда?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"или AdBlock за Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"определение за стил"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"(бета)"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Надхвърлена квота към блокиране на съдържание"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Намиране на реклами…<br/><br/><i>Това ще отнеме известно време.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Домейн или адрес, за които AdBlock не блокира нищо:"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"скрипт"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ — общо",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Готово! Ще се свържем с вас скоро, най-вероятно до ден или два, ако следват почивни. Проверете междувременно за писмо от AdBlock с препратка към вашия билет в помощния сайт, за да следите случая през е-поща, ако така предпочитате!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Не"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Нещо се обърка. Не са изпращани никакви ресурси. Сега страницата ще се затвори. Опитайте да презаредите сайта."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"украински"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"обновен преди $minutes$ минути",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Абонаментът за Приемливи реклами е прекратен, защото включихте блокиране на съдържание в Safari. По едно и също време можете да разрешите или едното, или другото. (<a>Защо?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Абонаментът ви за Приемливи реклами е прекратен."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Разреши защитата от злонамерен софтуер"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Запиши"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Внимание: във всички други сайтове ще виждате реклами!<br>Настройката заобикаля всички останали филтри за сайтовете."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Забрани уведомяването"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Абониране за филтри"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Ползвате стара версия на AdBlock. Моля, отворете <a href='#'>страницата за разширения</a>, разрешете „Режим за програмисти“ и натиснете „Актуализирайте разширенията сега“."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Настройки на AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Проверете за злонамерен софтуер, инжектиращ реклами:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Показвай предпроверочните декларации в дневника на Конзола (води до забавяне на AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Надхвърляте ограничението за размер на файла в Dropbox. Моля, премахнете някои записи от потребителските или от изключващите филтри и опитайте отново."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Освободи AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Ползвай заобиколен начин за нетръгващи клипове от Hulu.com (след повторен пуск на браузъра)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"Съвпадащ каскаден лист със стилове [CSS]:"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Изключи"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Забранете другите разширения без AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Превод на български език:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"ЗАРЕЖДАНЕ…"
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Щракнете с десен по реклама в страницата, за да я блокирате или я блокирайте тук наръка."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Забележка: позволяването на изключения в страница или сайт (за реклами) не се поддържа при разрешено блокиране на съдържание вSafari."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Ще я използваме, само ако трябва да се свържем с вас за повече информация."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Да редактирате забранените филтри:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Разреши блокиране на съдържание в Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Вашата е-поща?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"За да го скриете, щракнете с десен бутон по лентата на Safari, изберете „Нагласи лентата“ и го изхвърлете с влачене от нея. Можете да го покажете повторно с влачене към лентата."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Възникна грешка при обработване на вашата заявка."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"страница"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Готово! Страницата с рекламата е презаредена. Моля, прегледайте я дали е изчезнала. После се върнете тук и отговорете на въпроса по-долу."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Добави от адрес:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Ползвате стара версия на Safari. Осигурете си най-новата, за да използвате бутона на AdBlock в лентата на браузъра за задържане на AdBlock, за изключване на сайт от филтриране и за докладване на реклама. <a>Обнови браузъра</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Натиснете Safari &rarr; Настройки &rarr; Разширения."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Да спрете блокирането на реклами:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Блокирай!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Продължавате ли да я виждате?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"български"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Чудесно! А сега нека определим разширението, което я допуска. Проверете всяко, разрешавайки само по едно от тях. Това, което я върне, е това, което трябва да бъде премахнато, за да се отървете от рекламите."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Провалено!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Да редактирате филтрите наръка:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"италиански"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"изскачащ обект"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Вид"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"словашки"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Абониране за филтри"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Можете да го включите в подкрепа на любимите си сайтовете пак, като по-долу изберете „Позволи определени ненатрапчиви реклами“."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Продължавате ли да я виждате в браузъра?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Не изпълнявай за страницата"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"литовски"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Споделете ги в нашия <a>сайт за поддръжка</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"Задържан AdBlock."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Все още не блокираме реклами, съдържащи се във флаш или в други плъгини. Чакаме такава поддръжка да се появи в браузъра и в WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"ДА!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Общи"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Ако не желаете да виждате реклами като тази, вероятно ще оставите филтър Приемливи реклами изключен."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Компютърът може да e заразен със злонамерен софтуер. <a>Щракнете </a> за повече информация."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"друг обект"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Няма указан филтър!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"неизвестно"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"звук/видео"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"японски"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Позволи определени ненатрапчиви реклами"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Отказ"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Движете плъзгача до включване на страниците, за които AdBlock няма да се изпълнява."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Блокирането на съдържание в Safari изключи, защото избрахте ненатрапчиви реклами. По едно и също време можете да разрешите или едното, или другото. (<a>Защо?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Последна стъпка: докладвайте я на нас."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Проверете с Firefox$chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Докладването на реклама изисква да сте свързан с интернет."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"Разреши EasyList (препоръчително)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"Докладване на реклама пред AdBlock"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Блокиращи филтри"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Как става?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Позволи изключения за определени канали в YouTube"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Трета страна"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Разреши Fanboy Annoyances (премахва досадните неща)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"Натиснете бутона на AdBlock за подробности"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"обновен преди $hours$ часа",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"руски и украински"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Какво е новото в изданието — вижте <a style='cursor:pointer;'>списъка с изменения</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Забранените досега разширения са повторно разрешени."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"гръцки"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Скриване на раздел в страница"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Клипове и флаш"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Смятате ли, че всеки път когато посещавате страницата, следното ще бъде вярно за рекламата?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Разреши AdBlock за страницата"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Назад"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Филтрите блокират повечето реклами в мрежата. Можете също така:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Да проверите филтъра Приемливи реклами:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Показване на реклами в страница или домейн"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Съвпада с <b>1</b> елемент в страницата."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Не желая такава проверка"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Моля, пуснете повторно Safari, за да завърши изключването на блокирането на съдържание."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Внимание: ако допуснете грешка много от останалите филтри, в т.ч. официалните, могат също да спрат да работят!<br/>Прочетете ръководството <a>Синтаксис на филтрите</a> за разширено добавяне на позволяващи и изключващи филтри."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Изключи канал $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Продължавате ли да я виждате в браузъра?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Общи настройки"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Ако не желаете да виждате реклами като тази, вероятно ще оставите филтър Приемливи реклами изключен."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock няма да се изпълнява в страници, съвпадащи с:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Не разполагаме с филтър по подразбиране за езика.<br/>Моля, опитайте да намерите подходящия за езика $link$, или блокирайте рекламата самостоятелно от преградка „Нагласяване“.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Абонирай"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Показвай разширените настройки (аз съм опитен потребител)"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"испански"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Зареден от домейн:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Щракнете по: <a>Обнови филтрите!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Колкото повече филтри ползвате, толкова по-бавно ще работи AdBlock. Ползването на твърде много може да предизвика забиване на браузъра в определени сайтове. Натиснете ДА за абониране въпреки всичко."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Последна стъпка: кое превръща елемента в реклама?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Съвпада с $matchcount$ елемента в страницата.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"А на тази <a>страница</a> ще откриете хората, които стоят зад AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"индонезийски"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"турски"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Блокиране на реклама"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Потребителски филтри"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"Адрес на рамката: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Въпросът определя кой трябва да получи вашия доклад. Ако отговорите неправилно, докладът ви ще получат неподходящите хора и може да не бъде взет под внимание."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Добави елементи към контекстното меню (щракване с десен бутон)"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"селектор"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Блокирай рекламата"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Изискват се предпроверочни данни? Щракнете <a href='#' id='debug'>тук</a>, за да ги предадете!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Изключване на AdBlock…"
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Докладването е доброволно. Така помагате и на другите, защото позволявате доброволецът, поддържащ конкретния филтър, да я блокира за всички. Но ако не сте настроен алтруистично, всичко е наред. Затворете тази страница и <a>блокирайте рекламата</a> само за себе си."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"скрит елемент"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Презареди страницата"
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"страница"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"холандски"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Твърде дълго име на файл. Моля, дайте по-късо име на вашия файл."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Не забравяйте да запишете!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Проверка за обновяване (ще отнеме само няколко секунди)… "
+    "message":"литовски"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Абонирайте се за филтри, след което опитайте отново: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Уведомявай за установен от AdBlock злонамерен софтуер"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Компютърът може да e заразен със злонамерен софтуер. <a>Щракнете </a> за повече информация."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Показвай броя на блокираните реклами в менюто на AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Показване на реклами в страница или домейн"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Сайт:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Разреши фабричния филтър на AdBlock (препоръчително)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"латвийски"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Уверете се, че ползвате правилния филтър за езика:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"Съвпадащ каскаден лист със стилове [CSS]:"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"За да го скриете, отворете opera://extensions и отметнете „Скрий от лентата“. Можете да го покажете повторно като я снемете."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Не сте сигурен?</b> — натиснете „Блокирай!“ по-долу."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Съвпадащ филтър"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Извличане… моля, изчакайте."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Всички ресурси"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock e обновен!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Не изпълнявай за домейна"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"еврейски"
+    "message":"словашки"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Движете плъзгача до пълно блокиране на рекламата в страницата и добра ползваемост на блокирания елемент."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Блокиране на адреси, съдържащи текста:"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Надхвърляте ограничението от 50 000 правила и броят им автоматично беше намален. Моля, прекратете абонамента си за някои от филтрите или забранете блокиране на съдържание в Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"обновен преди 1 ден"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Разреши Приемливи реклами (препоръчително)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Щракнете по: <a>Забрани Приемливи реклами</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Версия $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Инсталирайте Adblock Plus за Firefox$chrome$, ако го нямате.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Премахни филтъра"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Не разполагаме с филтър по подразбиране за езика.<br/>Моля, опитайте да намерите подходящия за езика $link$, или блокирайте рекламата самостоятелно от преградка „Нагласяване“.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Файлът не е изображение. Моля, качете .png, .gif или .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Бихте ли ни изпратили <a>доклад за грешка</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"скрит обект"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Филтри"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Домейн на рамката: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Щракнете по реклама, за да изминете пътя до нейното блокиране."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"горна рамка"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"определение за стил"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"неизвестно"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"За съжаление, AdBlock е забранен за страницата в някой от вашите филтри."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Трета страна"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Няма указан филтър!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"гръцки"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Ползвате стара версия на AdBlock. Моля, отворете <a href='#'>страницата за разширения</a>, разрешете „Режим за програмисти“ и натиснете „Актуализирайте разширенията сега“."
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Вашето име?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Ползвай заобиколен начин за нетръгващи клипове от Hulu.com (след повторен пуск на браузъра)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Внимание: няма указан филтър!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Нагласяване"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Открихте реклама в страницата? Нека ви помогнем да я докладвате на правилното място!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"естонски"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Нагласяване на AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"български"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"изключен ресурс"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Надхвърлена квота към блокиране на съдържание"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Изключване на AdBlock…"
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Блокиране на адреси, съдържащи текста:"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Затвори"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Проверете с Firefox$chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Последна стъпка: кое превръща елемента в реклама?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Ако видите реклама, попълнете <a>доклад за реклама</a>, а не доклад за грешка!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"корейски"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Ползвате стара версия на Safari. Осигурете си най-новата, за да използвате бутона на AdBlock в лентата на браузъра за задържане на AdBlock, за изключване на сайт от филтриране и за докладване на реклама. <a>Обнови браузъра</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"фински"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"скрипт"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"украински"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Няма намерен злонамерен софтуер."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Моля, забранете някои от филтрите. За повече вж. Настройки на AdBlock."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Абонаментът за Приемливи реклами е прекратен, защото включихте блокиране на съдържание в Safari. По едно и също време можете да разрешите или едното, или другото. (<a>Защо?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"А на тази <a>страница</a> ще откриете хората, които стоят зад AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"тук"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"изскачащ обект"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"заявка xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Презареди страницата"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Какъв е езикът на страницата?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"Задържан AdBlock."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Освободи AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Намиране на реклами…<br/><br/><i>Това ще отнеме известно време.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock е забранен за страницата."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Абонирайте се за същите филтри и в този браузър."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Блокиране на реклама"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Внимание: във всички други сайтове ще виждате реклами!<br>Настройката заобикаля всички останали филтри за сайтовете."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Има обновяване за AdBlock! Щракнете $here$ за обновяване. <br> Забележка: в случай че желаете това да става автоматично, изберете Safari > Настройки > Разширения > Обновявания <br> и отметнете „Инсталирай автоматично обновяванията“.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Готово!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Разреши фабричния филтър на AdBlock (препоръчително)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Вид"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Какво е това?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"японски"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Филтърът е част от:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Абониране за филтри"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Вид на рамката: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Добави филтри за друг език: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Ресурс"
+    "message":"Съвпадащ филтър"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Блокирай реклама в страницата"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Филтрите блокират повечето реклами в мрежата. Можете също така:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Уверете се, че филтрите са обновени:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"За да го скриете, щракнете с десен бутон по лентата на Safari, изберете „Нагласи лентата“ и го изхвърлете с влачене от нея. Можете да го покажете повторно с влачене към лентата."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"английски"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Надхвърляте ограничението за размер на файла в Dropbox. Моля, премахнете някои записи от потребителските или от изключващите филтри и опитайте отново."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"исландски"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Абонирай"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Отворете страницата за разширения и разрешете забранените досега разширения."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Забележка: позволяването на изключения в страница или сайт (за реклами) не се поддържа при разрешено блокиране на съдържание вSafari."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Домейн на страницата:"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Блокиран елемент:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"страница"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"друг обект"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Щракнете по: <a>Обнови филтрите!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"скрит елемент"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"За да го скриете, отворете opera://extensions и отметнете „Скрий от лентата“. Можете да го покажете повторно като я снемете."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"заявка object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Страница:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Открихте грешка?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Блокирай!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Позволи изключения за определени канали в YouTube"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Все още не блокираме реклами, съдържащи се във флаш или в други плъгини. Чакаме такава поддръжка да се появи в браузъра и в WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"арабски"
+    "message":"унгарски"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Блокирай рекламата"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Разреши AdBlock за страницата"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Показвай броя на блокираните реклами върху бутона на AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Провалено!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Задръж AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"чешки"
+    "message":"английски"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Кой колкото даде!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Добави елементи към контекстното меню (щракване с десен бутон)"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Интересува ви какво движи AdBlock?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Моля, преминете в <a>нашия сайт за поддръжка</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Разреши противоадблоковия филтър (чисти предупрежденията за блокери на реклами)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Недействителен адрес на филтъра. Той ще бъде изтрит."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"рамка"
+    "message":"страница"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Редактирай"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Сигурен ли сте, че премахвате $count$ от блокираните елементи за $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Имате въпрос или идея?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Легенда: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Забравихте да прикачите снимка на екрана! Няма да сме в състояние да ви помогнем, без да видим докладваната реклама."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ИЛИ</b> щракнете по: <a>Забрани другите разширения</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"обновен преди $minutes$ минути",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Повече за злонамерения софтуер"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Прикачи снимка на екрана:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"румънски"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Да редактирате забранените филтри:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"подрамка"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Презаредете страницата с рекламата."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Разреши блокиране на съдържание в Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Инсталирайте Firefox$chrome$, ако го нямате.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Филтри"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"В случай на създаден от вас филтър чрез съветника за блокиране на реклама, моля, поставете го в полето по-долу:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Твърде голям файл. Моля, уверете се, че вашият файл е под 10 МБ."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock няма да се изпълнява в страници, съвпадащи с:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"китайски"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Недействителен филтър: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Абониране за филтри"
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Отворете страницата за разширения и разрешете забранените досега разширения."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Забрани уведомяването"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"турски"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Не се абонирайте за повече, отколкото са ви необходими — всеки нов ще ви забавя малко повече! Признания и допълнителни филтри можете да намерите <a>тук</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"рамка"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"индонезийски"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"картина"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ — общо",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Отказ"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Не забравяйте да запишете!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"селектор"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Блокирането на съдържание в Safari изключи, защото избрахте ненатрапчиви реклами. По едно и също време можете да разрешите или едното, или другото. (<a>Защо?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"исландски"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Блокиращи филтри"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Блокиране на реклами само за сайтовете:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Зареден от домейн:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Забранените досега разширения са повторно разрешени."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Оптимизирай филтрите"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Нека и другите чуят!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Обновяване на AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Разреши противоадблоковия филтър (чисти предупрежденията за блокери на реклами)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Настройки на AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Възникна грешка при обработване на вашата заявка."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"обновен преди 1 час"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Проверка за обновяване (ще отнеме само няколко секунди)… "
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"обновен току-що"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Щракнете с десен по реклама в страницата, за да я блокирате или я блокирайте тук наръка."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Проверете за злонамерен софтуер, инжектиращ реклами:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Поддръжка"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Вид"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Движете плъзгача до пълно блокиране на рекламата в страницата и добра ползваемост на блокирания елемент."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"обновен преди 1 минута"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"рамка"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"блокиран ресурс"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Следните сведения ще бъдат включени към доклада за реклама."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"датски"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Да проверите филтъра Приемливи реклами:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Можете да го включите в подкрепа на любимите си сайтовете пак, като по-долу изберете „Позволи определени ненатрапчиви реклами“."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Извличане… моля, изчакайте."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Недействителен адрес на филтъра. Той ще бъде изтрит."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Общи настройки"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Снемете отметките пред разширенията <b>без</b> тази пред AdBlock. <b>Оставете AdBlock разрешено</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Заредете страницата с рекламата в браузъра."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Показване на реклами <i>навсякъде</i> без домейна"
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Забравихте да прикачите снимка на екрана! Няма да сме в състояние да ви помогнем, без да видим докладваната реклама."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"И там наръка създайте билет, като копирате сведенията и ги поставите в полето под „Fill in any details you think will help us understand your issue“."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"За да го скриете, щракнете с десен бутон по него и посочете „Скрий бутона“. Можете да го покажете от chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"еврейски"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Функцията на AdBlock няма да работи тук, защото сайтът ползва остаряла технология. Можете да забраните или да изключите ресурсите наръка от преградка „Нагласяване“ в страницата с настройки."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"чешки и словашки"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Всички други разширения са забранени. Предстои презареждане на страницата с рекламата. Само секунда, моля."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Други филтри"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"френски"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Обновяванията се извличат автоматично, но бихте могли да ги <a>обновите</a> и сега"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Блокиран елемент:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Покажи заявките"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"интерактивен обект"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Колкото повече филтри ползвате, толкова по-бавно ще работи AdBlock. Ползването на твърде много може да предизвика забиване на браузъра в определени сайтове. Натиснете ДА за абониране въпреки всичко."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Чудесно! Всичко е настроено."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"(бета)"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Отворете <a href='#'>страницата за разширения</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Готово! Ще се свържем с вас скоро, най-вероятно до ден или два, ако следват почивни. Проверете междувременно за писмо от AdBlock с препратка към вашия билет в помощния сайт, за да следите случая през е-поща, ако така предпочитате!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Повече за програмата Приемливи реклами"
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Уведомявай за установен от AdBlock злонамерен софтуер"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"обновен току-що"
+    "message":"обновен преди 1 ден"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"Адрес на рамката: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"немски"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Твърде дълго име на файл. Моля, дайте по-късо име на вашия файл."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"обновен преди $seconds$ секунди",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Не изпълнявай за страницата"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Споделете ги в нашия <a>сайт за поддръжка</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"ДА!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Готово! Страницата с рекламата е презаредена. Моля, прегледайте я дали е изчезнала. После се върнете тук и отговорете на въпроса по-долу."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Всички ресурси"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Изключи канал $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Ресурс"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Показвай броя на блокираните реклами в менюто на AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"Докладване на реклама пред AdBlock"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Как става?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Не изпълнявай за домейна"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Потребителски филтри"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Да блокирате още реклами:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Важни сведения липсват или са непълни. Моля, отговорете на въпросите, оградени в червено."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Домейн или адрес, за които AdBlock не блокира нищо:"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Абонаментът ви за Приемливи реклами е прекратен."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Разреши Fanboy Annoyances (премахва досадните неща)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock блокира изтегляне от сайт, за който се знае, че хоства злонамерен софтуер."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Запиши"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Не сте сигурен?</b> — натиснете „Блокирай!“ по-долу."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Последна стъпка: докладвайте я на нас."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Къде точно е рекламата в страницата? И как изглежда?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Става"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Позволи анонимно събиране на данни за ползваните филтри в AdBlock"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Докладването на реклама изисква да сте свързан с интернет."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Сигурен ли сте, че се абонирате за филтъра „$title$“?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"обновен преди $days$ дни",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"рамка"
+    "message":"интерактивен обект"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Смятате ли, че всеки път когато посещавате страницата, следното ще бъде вярно за рекламата?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Блокирани реклами:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"арабски"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Отмени блокираните за домейна"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Да редактирате филтрите наръка:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Първа стъпка: решете какво блокирате"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Моля, въведете правилния филтър по-долу и натиснете ДА:"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Превод на български език:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock e обновен!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"само на английски"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ИЛИ</b> щракнете по: <a>Забрани другите разширения</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Какво е новото в изданието — вижте <a style='cursor:pointer;'>списъка с изменения</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"Разреши EasyPrivacy (защитава личната неприкосновеност)"
+    "message":"Разреши противосоциалния филтър (чисти бутоните на социални мрежи)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Докладвай реклама в страницата"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Разреши защитата от злонамерен софтуер"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Оптимизирай филтрите"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Показвай разширените настройки (аз съм опитен потребител)"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"немски"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Надхвърляте квотата, която AdBlock ползва за съхраняване на данни. Моля, прекратете абонамента си за някои от филтрите!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Внимание: филтърът блокира всички елементи $elementtype$ в страницата!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"тук"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Вашата е-поща?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Какъв е езикът на страницата?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Интересува ви какво движи AdBlock?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Сигурен ли сте, че премахвате $count$ от блокираните елементи за $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"картина"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Скриване на раздел в страница"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"И там наръка създайте билет, като копирате сведенията и ги поставите в полето под „Fill in any details you think will help us understand your issue“."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Общи"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"За да го скриете, щракнете с десен бутон по него и посочете „Скрий бутона“. Можете да го покажете от chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"или AdBlock за Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"румънски"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Клипове и флаш"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Нещо се обърка при проверката за обновяване."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Всички други разширения са забранени. Предстои презареждане на страницата с рекламата. Само секунда, моля."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"изключен ресурс"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Чудесно! А сега нека определим разширението, което я допуска. Проверете всяко, разрешавайки само по едно от тях. Това, което я върне, е това, което трябва да бъде премахнато, за да се отървете от рекламите."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"чешки и словашки"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":" или Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Вид на рамката: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Формат: ~сайт1.бг|~сайт2.бг|~новини.сайт3.бг"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"— избор на език —"
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Инсталирайте Adblock Plus за Firefox$chrome$, ако го нямате.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"блокиран ресурс"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Показва ли се рекламата във или преди филм или друг плъгин, като флаш игра?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ ще бъде $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Филтър, който може да бъде променен от страницата с настройки:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Филтърът:<br/> $filter$ <br/> съдържа грешка: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Затвори"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Блокиране на реклами само за сайтовете:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Надхвърляте квотата, която AdBlock ползва за съхраняване на данни. Моля, прекратете абонамента си за някои от филтрите!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Позволи анонимно събиране на данни за ползваните филтри в AdBlock"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"ДОБРЕ, можете да я блокирате самостоятелно в страницата с настройки. Благодарим!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Предай"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"фински"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Твърде голям файл. Моля, уверете се, че вашият файл е под 10 МБ."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Следните сведения ще бъдат включени към доклада за реклама."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Кой колкото даде!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Това е неизправност на филтъра. Докладвайте я на: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Снемете отметките пред разширенията <b>без</b> тази пред AdBlock. <b>Оставете AdBlock разрешено</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Забележка: достъпът до доклада може да бъде публичен. Имайте го предвид, ако включвате лични данни."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Показвай препратки към филтрите"
+  "filteritalian":{
+    "description":"language",
+    "message":"италиански"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"само на английски"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Нека и другите чуят!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Продължавате ли да я виждате?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock блокира изтегляне от сайт, за който се знае, че хоства злонамерен софтуер."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Уверете се, че ползвате правилния филтър за езика:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Легенда: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Уверете се, че филтрите са обновени:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Нещо се обърка при проверката за обновяване."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Натиснете Safari &rarr; Настройки &rarr; Разширения."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Предай"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Без абонамент."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"звук/видео"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"латвийски"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Блокирай реклама в страницата"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Да спрете блокирането на реклами:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Грешка при записване на качения файл."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Съвпада с $matchcount$ елемента в страницата.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Провалено извличане на филтъра!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Движете плъзгача до включване на страниците, за които AdBlock няма да се изпълнява."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"скрит обект"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Показва ли се рекламата във или преди филм или друг плъгин, като флаш игра?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"руски и украински"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"испански"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Внимание: филтърът блокира всички елементи $elementtype$ в страницата!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Разреши режим на съвместимост с ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Не"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Филтър, който може да бъде променен от страницата с настройки:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Скрий бутона"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"друг"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"ДОБРЕ, можете да я блокирате самостоятелно в страницата с настройки. Благодарим!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"руски"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Бихте ли ни изпратили <a>доклад за грешка</a>?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"Разреши EasyPrivacy (защитава личната неприкосновеност)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ ще бъде $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Добави от адрес:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Филтърът:<br/> $filter$ <br/> съдържа грешка: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"ЗАРЕЖДАНЕ…"
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Изискват се предпроверочни данни? Щракнете <a href='#' id='debug'>тук</a>, за да ги предадете!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Надхвърляте ограничението от 50 000 правила и броят им автоматично беше намален. Моля, прекратете абонамента си за някои от филтрите или забранете блокиране на съдържание в Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Докладвай реклама в страницата"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Показвай предпроверочните декларации в дневника на Конзола (води до забавяне на AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Домейн на рамката: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Най-популярното разширение за Chrome с над 40 милиона потребители! Блокира реклами в световната мрежа."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Открихте грешка?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"чешки"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Файлът не е изображение. Моля, качете .png, .gif или .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Показвай препратки към филтрите"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Позволи определени ненатрапчиви реклами"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"шведски"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Премахни филтъра"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"— избор на език —"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"френски"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Редактирай"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Поддръжка"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Моля, преминете в <a>нашия сайт за поддръжка</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Блокиране на реклама по адрес"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"За задържане на AdBlock при разрешено блокиране на съдържание, моля, изберете Safari (от менюто) > Настройки > Разширения > AdBlock и снемете отметката пред „Разреши AdBlock“."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Версия $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Въпросът определя кой трябва да получи вашия доклад. Ако отговорите неправилно, докладът ви ще получат неподходящите хора и може да не бъде взет под внимание."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Докладването е доброволно. Така помагате и на другите, защото позволявате доброволецът, поддържащ конкретния филтър, да я блокира за всички. Но ако не сте настроен алтруистично, всичко е наред. Затворете тази страница и <a>блокирайте рекламата</a> само за себе си."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Да"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Изходният код е <a>свободно достъпен</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"холандски"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Ще я използваме, само ако трябва да се свържем с вас за повече информация."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Съвпада с <b>1</b> елемент в страницата."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"обновен преди $hours$ часа",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Назад"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Щракнете по: <a>Забрани Приемливи реклами</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Домейн на страницата:"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Обновяване на AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Нещо се обърка. Не са изпращани никакви ресурси. Сега страницата ще се затвори. Опитайте да презаредите сайта."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Повече за злонамерения софтуер"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Сайт:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Разреши Приемливи реклами (препоръчително)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Става"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"За задържане на AdBlock при разрешено блокиране на съдържание, моля, изберете Safari (от менюто) > Настройки > Разширения > AdBlock и снемете отметката пред „Разреши AdBlock“."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Отворете <a href='#'>страницата за разширения</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"Натиснете бутона на AdBlock за подробности"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Забранете другите разширения без AdBlock:"
   }
 }

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Adjunta una captura de pantalla:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"No s'ha trobat programari maliciós conegut."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"En aquell navegador, subscriviu-vos a les mateixes listes de filtres que teniu aquí."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"En aquell navegador, carregueu la pàgina amb l'anunci."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Suec"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Bloquejar més anuncis:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Rus"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Subscripció cancel·lada."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Xinès"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Si has creat un filtre de treball mitjançant l'assistent \"bloqueja un anunci\", enganxeu-lo al següent quadre:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Llista de filtres antisocials (suprimeix els botons de les xarxes socials)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Has trobat un anunci en una pàgina web? T'ajudarem a trobar el lloc idoni per informar-ne!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Mostrar el nombre d'anuncis blocats al botó"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"El codi font està <a>totalment disponible</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"actualitzat fa 1 minut"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"S'ha produït un error al obtenir aquest filtre!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Reinicieu Safari per acabar de desactivar el bloqueig de contingut."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Bloquejar un anunci mitjançant la seva URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Amagar aquest botó"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Obtindré les actualitzacions automàticament; si voleu podeu <a>actualitzar ara</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~lloc1.com|~lloc2.com|~notícies.lloc3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estonià"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tipus"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Hi ha una actualització disponible per a AdBlock! Dirigiu-vos $here$ per dur-la a terme. <br> Atenció: si voleu rebre actualitzacions automàticament, cliqueu a Safari > Preferències  > Ampliacions > Actualitzacions <br> i marqueu l'opció  ' Instal·lar actualitzacions automàticament'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Què és això?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"No us subscrigueu més del que necessiteu –– cada llista us fa anar una mica més lent! Els crèdits i més llistes es poden trobar <a>aquí</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Aquesta característica de l'AdBlock no s'executa en aquest lloc perquè utilitza tecnologia obsoleta. Podeu prohibir o permetre recursos manualment a la pestanya 'personalitzar' de la pàgina d'opcions."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polonès"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Saber-ne més sobre el programa d'anuncis acceptables."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"actualitzat fa $seconds$ segons",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Hongarès"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Nota: el vostre informe pot ser que esdevingui públic. Recordeu això abans d'incloure quelcom privat."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Desactiveu algunes llistes de filtres. Més informació a les opcions d'AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Origen del filtre:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Ho sentim, l'AdBlock està deshabilitat en aquesta pàgina per una de les seves llistes de filtres."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"El filtre no és vàlid: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Alerta: no s'ha especificat cap filtre!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"L'AdBlock està desactivat en aquesta pàgina."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Mostrar els anuncis <i>a tot arreu</i> excepte en aquests dominis..."
+    "message":"Teniu alguna pregunta i/o suggeriment?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Opcions"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Anuncis bloquejats:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Afegir filtres per a un altre idioma: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Cliqueu l'anunci, i us guiaré a tavés del seu blocatje."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Si veieu un anunci, no feu un informe d'errors, feu un <a>Informe d'anunci</a>!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Fantàstic! Esteu a punt."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Altres"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Suport d'AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Personalitzar l'AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Falta informació requerida o aquesta no es vàlida. Si us plau, respongui  les preguntes que tenen la vora vermella."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Error en desar l'arxiu carregat."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Escriviu el filtre correcte a continuació i premeu 'D'acord'"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Pas 1: Identifiqueu el que s'ha de bloquejar"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Danès"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (recomanat)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ en aquesta pàgina",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Premarc"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"actualitzat fa 1 hora"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Coreà"
+    "message":"Polonès"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"o bé Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Com et dius?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"L'extensió més popular de Chrome, amb més de 40 milions d'usuaris! Bloqueja els anuncis de tota la xarxa."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Mostra totes les sol·licituds"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"No vull comprovar això"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Sí"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Desfer els meus blocatges en aquest domini"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Personalitzar"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pausar l'AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Segur que us voleu subscriure a la llista de filtres $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Exactament, on es troba l'anunci? Quin aspecte té?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"o bé AdBlock per a Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definició d'estil"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Límit de normes de bloqueig sobrepassat"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Trobant els anuncis…<br/><br/><i>Això només tardarà uns instants.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"El domini o URL en el qual l'AdBlock no hauria de bloquejar res"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ en total",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Tot a punt! Estarem en contacte aviat, molt probablement en un dia, dos si és festa. Mentrestant, cerqueu un correu electrònic de l'AdBlock. Trobareu un enllaç al vostre tiquet a la nostra pàgina de suport. Si preferiu seguir el correu electrònic, també ho podeu fer!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"No"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Alguna cosa no ha anat bé. No s'ha enviat cap recurs. Aquesta pàgina ara es tancarà. Intenteu tornar a carregar la pàgina web."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ucraïnès"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"actualitzat fa $minutes$ minuts",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Hem cancel·lat la seva subscripció dels anuncis acceptables, ja que heu activat el bloqueig de contingut de Safari. Només en podeu seleccionar un a la vegada. (<a> Per què? </a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Ja no esteu subscrits a la llista de filtres dels Anuncis Acceptables."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Protecció contra el programari maliciós"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Desar"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Alerta: a tots els altres llocs veureu anuncis!<br>Això es salta les normes de tots els altres filtres per a aquests llocs."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Desactivar aquestes notificacions"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Subscrivint-se a la llista de filtres..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Esteu utilitzant una versió antiga d'AdBlock. Aneu a la <a href='#'>pàgina d'extensions</a>, activeu el 'mode de desenvolupador' i cliqueu 'actualitza les extensions ara'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Opcions d'AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Comprova l'existència de programari maliciós sospitós d'injectar anuncis:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Mostrar les dades de depuració al registre de la consola (això alentirà l'AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Heu excedit el límit de mida de Dropbox. Elimineu algunes entrades dels vostres filtres personalitzats o desactivats i torneu-ho a intentar."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Reactivar l'AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Treballar amb els vídeos de Hulu.com que no es reprodueixin (requereix el reinici del navegador)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS a relacionar"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Excloure"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Desactiveu totes les extensions excepte l'AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Traducció al català feta per:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"CARREGANT..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Feu clic dret a un anunci en una pàgina per bloquejar-lo –– o bé bloquejeu-lo aquí manualment."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Avís: La permissivitat (permetre anuncis) a una pàgina o lloc no és compatible tenint activat el bloqueig de continguts de Safari."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Només la farem servir per contactar-te si necessitem més informació."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Editar els filtres desactivats:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Activar el bloqueig de contingut de Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Quina és la teva adreça de correu?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Per ocultar el botó, feu clic dret a la barra d'eines de Safari i escolliu Personalitzar la barra d'eines, a continuació arrosegueu el botó d'AdBlock fora de la barra d'eines. El podeu fer tornar a aparèixer arrosegant-lo cap a la barra d'eines."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"S'ha produït un error en processar la vostra sol·licitud."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"pàgina"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Fet! Hem recarregat la pàgina amb l'anunci. Aneu a la pàgina per comprovar si l'anunci ha marxat. Llavors torneu a aquesta pàgina i responeu la pregunta que es formula a continuació."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Introduïu una URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Esteu fent servir una versió antiga de Safari. Obteniu l'última versió per tal de fer servir el botó d'AdBlock de la barra d'eines per pausar l'AdBlock, permetre anuncis a llocs webs, o bé informar sobre algun anunci. <a>Actualitzeu-vos ara</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Feu clic al menú de Safari &rarr; Preferències &rarr; Ampliacions."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Aturar el bloqueig d'anuncis:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Bloquejar-ho!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Encara apareix l'anunci?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Búlgar"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Fantàstic! Ara hem d'esbrinar quina extensió n'és la causant. Aneu activant les extensions una per una. L'extensió que fa retornar l'anunci(s) és la que heu de desinstal·lar per treure-us de sobre els anuncis."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Error!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Editar manualment els vostres filtres:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italià"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"element emergent"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tipus"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Eslovac"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Subscriure's a llistes de filtres"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Podeu reactivar-ho i donar suport a les vostres pàgines web preferides seleccionant \"Permetre publicitat no intrusiva\"."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"L'anunci també apareix en aquell navegador?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"No actuar en aquesta pàgina"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Lituà"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Feu-nos-ho saber en el nostre <a>lloc web de suport</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"L'AdBlock està en pausa."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Encara no podem bloquejar els anuncis que es troben dins d'aplicacions Flash o bé dins d'altres complements. Estem a l'espera de la compatibilitat del navegador i del 'WebKit'."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"D'acord!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"General"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Si no t'agrada veure anuncis com aquest, potser voldries desactivar el filtre d'Anucis Acceptables."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"El vostre ordinador potser està infectat per programari maliciós. Cliqueu <a>aquí</a> per obtenir més informació."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"altres"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"No s'ha especificat cap filtre!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"desconegut"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"àudio/vídeo"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japonès"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Permet la publicitat no intrusiva"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Cancel·lar"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Feu lliscar el regulador per determinar en quines pàgines del domini l'AdBlock no s'executarà."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Hem desactivat el bloqueig de contingut al Safari, perquè heu optat per permetre els anuncis no intrusius. Només en podeu seleccionar un a la vegada. (<a>Per què?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Darrer pas: informeu-nos del problema."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Comproveu-ho al Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Per informar sobre un anunci, heu d'estar connectats a internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (recomanat)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Informant sobre un anunci"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Llistes de filtres per bloquejar anuncis"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Com?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permeteu la permissió d'anuncis en canals específics de YouTube"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"de tercers"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (elimina les molèsties de la xarxa)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock – cliqueu per obtenir més detalls"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"actualitzat fa $hours$ hores",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Rus i ucraïnès"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Què hi ha de nou en l'últim llançament? Vegeu <a style='cursor:pointer;'>el conjunt de canvis</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Les extensions que anteriorment estaven desactivades han estat reactivades."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grec"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Amagar una secció d'una pàgina web"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Vídeos i Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Què creieu que serà veritat sobre aquest anunci cada cop que visiteu aquesta pàgina?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Activar AdBlock en aquesta pàgina"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Enrere"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Les llistes de filtres bloquejen la majoria d'anuncis de la xarxa. També podeu:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Comprova el filtre d'Anuncis Acceptables:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Mostrar els anuncis en una pàgina web o domini"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Això es relaciona amb <b>1</b> ítem en aquesta pàgina."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"No vull comprovar això"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Reinicieu Safari per acabar de desactivar el bloqueig de contingut."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Aneu amb compte: Si cometeu un error aquí molts filtres, incloent els oficials, es podrien malmetre!<br/>Llegiu-vos el <a>tutorial de sintaxi per a filtres</a> per aprendre com afegir filtres avançats de restricció o permissió."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"El canal $name$ té permís",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"L'anunci també apareix en aquell navegador?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opcions generals"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Si no t'agrada veure anuncis com aquest, potser voldries desactivar el filtre d'Anucis Acceptables."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"L'AdBlock no s'executarà en cap pàgina del següent domini:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"No tenim una llista de filtres per a aquest idioma.<br/>Intenteu trobar una llista que sigui compatible amb aquest idioma $link$ o bé bloquegi aquest anunci vostè mateix a la pestanya 'Personalitzar'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Subscriure's"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Sóc un usuari avançat, mostrar opcions avançades"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Espanyol"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Carregat a la pàgina amb el domini: $domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Feu clic aquí: <a>Actualitzar els meus filtres!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Com més llistes de filtres utilitzeu, amb més lentitud s'executarà l'AdBlock. L'ús de masses llistes pot arribar a fer fallar el navegador en determinats llocs web. Premeu d'acord per ser subscriptor  d'aquesta llista de totes maneres."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Pas final: què fa això un anunci?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Això relaciona $matchcount$ ítems en aquesta pàgina.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Tenim una <a>pàgina</a> per tal que descobriu les persones que fan possible l'AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesi"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turc"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Bloquejar un anunci"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Llistes de filtres personalitzades"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL del marc: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"El propòsit d'aquesta pregunta és determinar qui ha de rebre el seu informe. Si contesteu aquesta pregunta de forma incorrecta, l'informe s'enviarà a les persones equivocades, i potser sou ignorats."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Afegir ítems al menú de clic amb botó dret"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"selector"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Bloquegeu aquest anunci"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"El nostre equip ha solicitat informació de depuració? Cliqueu <a href='#' id='debug'>aquí</a> per satisfer la sol·licitud!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"No executar l'AdBlock a..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Informar sobre anuncis és voluntari. Ajuda a d'altres persones amb l'activació dels mantenidors de les llistes de filtres per tal de bloquejar l'anunci per a tothom. Si ara no et sents altruista, d'acord; tanca aquesta pàgina i <a>bloqueja l'anunci</a> només per tu."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Element ocult"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Recarregar la pàgina."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"pàgina"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Holandès"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Aquest nom de fitxer és massa llarg. Si us plau, canvieu-lo a un de més curt."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"No us oblideu de desar els canvis!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Comprovant l'existència d'actualitzacions (pot tardar pocs segons)..."
+    "message":"Lituà"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Subscriviu-vos a aquesta llista de filtres, llavors torneu-ho a intentar: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Us hauria de notificar l'AdBlock quan detecti programari maliciós?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"El vostre ordinador potser està infectat per programari maliciós. Cliqueu <a>aquí</a> per obtenir més informació."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Mostrar el nombre d'anuncis blocats al menú"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Mostrar els anuncis en una pàgina web o domini"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Lloc:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Filtres personalitzats d'AdBlock (recomanat)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Letó"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Assegureu-vos que esteu fent servir els filtres d'idioma correctes:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS a relacionar"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Per ocultar el botó, dirigiu-vos a opera://extensions i seleccioneu l'opció 'Ocultar de la barra d'eines'. El podeu fer tornar a aperèixer desmarcant aquella opció."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>No n'esteu segurs?</b>doncs premeu 'Bloquejar-ho!' a continuació."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Filtre relacionat"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"S'està obtenint... espereu-vos."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Tots els recursos"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"L'AdBlock està actualitzat!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"No actuar en les pàgines d'aquest domini"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Hebreu"
+    "message":"Eslovac"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Feu lliscar el regulador fins que l'anunci sigui bloquejat correctament dins la pàgina i l'aspecte final sigui el desitjat."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Bloquejar les URL que continguin aquest text"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"El nombre de normes de filtres de llista sobrepassa el límit de 50.000, i ha estat reduïda automàticament. Deixeu algunes subscripcions a llistes de filtres o desactiveu el bloqueig de continguts de Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"actualitzat fa 1 dia"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Anuncis Acceptables (recomanat)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Clica a: <a>Desactivar Anuncis Acceptables</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versió $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Instal·leu-vos l'Adblock Plus per a Firefox $chrome$ si no el teniu.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Suprimir de la llista"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"No tenim una llista de filtres per a aquest idioma.<br/>Intenteu trobar una llista que sigui compatible amb aquest idioma $link$ o bé bloquegi aquest anunci vostè mateix a la pestanya 'Personalitzar'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Això no és un arxiu d'imatge. Si us plau carregueu un arxiu .png, .gif, o .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Per què no ens envieu un <a>informe d'error</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"amagant"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Llistes de filtres"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Domini del marc: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Cliqueu l'anunci, i us guiaré a tavés del seu blocatje."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Marc superior"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"definició d'estil"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"desconegut"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Ho sentim, l'AdBlock està deshabilitat en aquesta pàgina per una de les seves llistes de filtres."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"de tercers"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"No s'ha especificat cap filtre!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Grec"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Esteu utilitzant una versió antiga d'AdBlock. Aneu a la <a href='#'>pàgina d'extensions</a>, activeu el 'mode de desenvolupador' i cliqueu 'actualitza les extensions ara'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Com et dius?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Treballar amb els vídeos de Hulu.com que no es reprodueixin (requereix el reinici del navegador)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Alerta: no s'ha especificat cap filtre!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Personalitzar"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Has trobat un anunci en una pàgina web? T'ajudarem a trobar el lloc idoni per informar-ne!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estonià"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Personalitzar l'AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Búlgar"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Recurs permès"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Límit de normes de bloqueig sobrepassat"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"No executar l'AdBlock a..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Bloquejar les URL que continguin aquest text"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Tancar"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Comproveu-ho al Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Pas final: què fa això un anunci?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Si veieu un anunci, no feu un informe d'errors, feu un <a>Informe d'anunci</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Coreà"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Esteu fent servir una versió antiga de Safari. Obteniu l'última versió per tal de fer servir el botó d'AdBlock de la barra d'eines per pausar l'AdBlock, permetre anuncis a llocs webs, o bé informar sobre algun anunci. <a>Actualitzeu-vos ara</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finès"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ucraïnès"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"No s'ha trobat programari maliciós conegut."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Desactiveu algunes llistes de filtres. Més informació a les opcions d'AdBlock."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Hem cancel·lat la seva subscripció dels anuncis acceptables, ja que heu activat el bloqueig de contingut de Safari. Només en podeu seleccionar un a la vegada. (<a> Per què? </a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Tenim una <a>pàgina</a> per tal que descobriu les persones que fan possible l'AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"aquí"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"element emergent"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Recarregar la pàgina."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"En quin idioma està escrita la pàgina web?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"L'AdBlock està en pausa."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Reactivar l'AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Trobant els anuncis…<br/><br/><i>Això només tardarà uns instants.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"L'AdBlock està desactivat en aquesta pàgina."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"En aquell navegador, subscriviu-vos a les mateixes listes de filtres que teniu aquí."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Bloquejar un anunci"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Alerta: a tots els altres llocs veureu anuncis!<br>Això es salta les normes de tots els altres filtres per a aquests llocs."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Hi ha una actualització disponible per a AdBlock! Dirigiu-vos $here$ per dur-la a terme. <br> Atenció: si voleu rebre actualitzacions automàticament, cliqueu a Safari > Preferències  > Ampliacions > Actualitzacions <br> i marqueu l'opció  ' Instal·lar actualitzacions automàticament'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Acabat!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Filtres personalitzats d'AdBlock (recomanat)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tipus"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Què és això?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japonès"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Origen del filtre:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Subscriure's a llistes de filtres"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Tipus de marc: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Afegir filtres per a un altre idioma: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Recurs"
+    "message":"Filtre relacionat"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Bloquejar un anunci en aquesta pàgina"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Les llistes de filtres bloquejen la majoria d'anuncis de la xarxa. També podeu:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Assegureu-vos que les llistes de filtres estiguin actualitzades:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Per ocultar el botó, feu clic dret a la barra d'eines de Safari i escolliu Personalitzar la barra d'eines, a continuació arrosegueu el botó d'AdBlock fora de la barra d'eines. El podeu fer tornar a aparèixer arrosegant-lo cap a la barra d'eines."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Anglès"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Heu excedit el límit de mida de Dropbox. Elimineu algunes entrades dels vostres filtres personalitzats o desactivats i torneu-ho a intentar."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Islandès"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Subscriure's"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Obriu la pàgina de les extensions per activar les que anteriorment estaven desactivades."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Avís: La permissivitat (permetre anuncis) a una pàgina o lloc no és compatible tenint activat el bloqueig de continguts de Safari."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"El domini de la pàgina a on s'ha d'aplicar"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Element bloquejat:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"pàgina"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"altres"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Feu clic aquí: <a>Actualitzar els meus filtres!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Element ocult"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Per ocultar el botó, dirigiu-vos a opera://extensions i seleccioneu l'opció 'Ocultar de la barra d'eines'. El podeu fer tornar a aperèixer desmarcant aquella opció."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Pàgina:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Heu trobat un error?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Bloquejar-ho!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permeteu la permissió d'anuncis en canals específics de YouTube"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Encara no podem bloquejar els anuncis que es troben dins d'aplicacions Flash o bé dins d'altres complements. Estem a l'espera de la compatibilitat del navegador i del 'WebKit'."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Àrab"
+    "message":"Hongarès"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Bloquegeu aquest anunci"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Activar AdBlock en aquesta pàgina"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Mostrar el nombre d'anuncis blocats al botó"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Error!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pausar l'AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Txec"
+    "message":"Anglès"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Pagueu el que desitgeu!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Afegir ítems al menú de clic amb botó dret"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Voleu veure els engranatges que mouen l'AdBlock?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Si us plau dirigiu-vos a <a>la nostra web de suport</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Llista d'eliminació d'avisos d'AdBlocks (elimina els avisos sobre l'utilització de bloquejadors de publicitat)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"URL de llista no vàlida. Serà suprimida."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"marc"
+    "message":"pàgina"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Editar"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Esteu segur que voleu eliminar els $count$ blocatges que heu creat a $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Teniu alguna pregunta i/o suggeriment?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Llegenda: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Heu oblidat d'adjuntar una captura de pantalla! Nosaltres no us podrem ajudar sense veure l'anunci què informeu."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>O BÉ</b>, només cliqueu aquest botó per fer tot el que figura anteriorment: <a>Desactivar totes les altres extensions</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"actualitzat fa $minutes$ minuts",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Aprendre'n més sobre programari maliciós"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Adjunta una captura de pantalla:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Romanès"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Editar els filtres desactivats:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Premarc"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Tornar a carregar la pàgina amb l'anunci."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Activar el bloqueig de contingut de Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Baixeu-vos el Firefox $chrome$ si no el teniu.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Llistes de filtres"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Si has creat un filtre de treball mitjançant l'assistent \"bloqueja un anunci\", enganxeu-lo al següent quadre:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Aquest fitxer és massa gran. Assegureu-vos que el fitxer és de menys de 10 MB."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"L'AdBlock no s'executarà en cap pàgina del següent domini:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Xinès"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"El filtre no és vàlid: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Subscrivint-se a la llista de filtres..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Obriu la pàgina de les extensions per activar les que anteriorment estaven desactivades."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Desactivar aquestes notificacions"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turc"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"No us subscrigueu més del que necessiteu –– cada llista us fa anar una mica més lent! Els crèdits i més llistes es poden trobar <a>aquí</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"marc"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesi"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"imatge"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ en total",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Cancel·lar"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"No us oblideu de desar els canvis!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"selector"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Hem desactivat el bloqueig de contingut al Safari, perquè heu optat per permetre els anuncis no intrusius. Només en podeu seleccionar un a la vegada. (<a>Per què?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Islandès"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Llistes de filtres per bloquejar anuncis"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Només bloquejar els anuncis en aquests llocs:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Carregat a la pàgina amb el domini: $domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Les extensions que anteriorment estaven desactivades han estat reactivades."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Netejar aquesta llista"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Ajudeu a fer córrer la veu!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Actualització d'AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Llista d'eliminació d'avisos d'AdBlocks (elimina els avisos sobre l'utilització de bloquejadors de publicitat)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Opcions d'AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"S'ha produït un error en processar la vostra sol·licitud."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"actualitzat fa 1 hora"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Comprovant l'existència d'actualitzacions (pot tardar pocs segons)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"actualitzat ara mateix"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Feu clic dret a un anunci en una pàgina per bloquejar-lo –– o bé bloquejeu-lo aquí manualment."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Comprova l'existència de programari maliciós sospitós d'injectar anuncis:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Suport d'AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tipus"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Feu lliscar el regulador fins que l'anunci sigui bloquejat correctament dins la pàgina i l'aspecte final sigui el desitjat."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"actualitzat fa 1 minut"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"marc"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Recurs bloquejat"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"També s'inclourà la següent informació a l'informe."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Danès"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Comprova el filtre d'Anuncis Acceptables:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Podeu reactivar-ho i donar suport a les vostres pàgines web preferides seleccionant \"Permetre publicitat no intrusiva\"."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"S'està obtenint... espereu-vos."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"URL de llista no vàlida. Serà suprimida."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opcions generals"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Desactiveu les caselles de selecció que es troben al costat de cada extensió <b>excepte</b> la de l'AdBlock. <b>Deixeu la casella de l'AdBlock seleccionada</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"En aquell navegador, carregueu la pàgina amb l'anunci."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Mostrar els anuncis <i>a tot arreu</i> excepte en aquests dominis..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Heu oblidat d'adjuntar una captura de pantalla! Nosaltres no us podrem ajudar sense veure l'anunci què informeu."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"I creeu un tiquet de forma manual. Copieu i enganxeu la següent informació a la secció \"Completeu qualsevol detall que penseu que ens ajudarà a comprendre el seu problema\"."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Per amagar aquest botó, feu clic amb el botó dret i escolliu Amaga el botó. El podeu fer reaparèixer a: chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebreu"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Aquesta característica de l'AdBlock no s'executa en aquest lloc perquè utilitza tecnologia obsoleta. Podeu prohibir o permetre recursos manualment a la pestanya 'personalitzar' de la pàgina d'opcions."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Txec i eslovac"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Hem desactivat totes les altres extensions. Ara recarregarem la pàgina amb l'anunci. Un segon, si us plau."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Altres llistes de filtres"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Francès"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Obtindré les actualitzacions automàticament; si voleu podeu <a>actualitzar ara</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Element bloquejat:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Mostra totes les sol·licituds"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"objecte interactiu"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Com més llistes de filtres utilitzeu, amb més lentitud s'executarà l'AdBlock. L'ús de masses llistes pot arribar a fer fallar el navegador en determinats llocs web. Premeu d'acord per ser subscriptor  d'aquesta llista de totes maneres."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Fantàstic! Esteu a punt."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Obriu la <a href='#'>pàgina de les extensions</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Tot a punt! Estarem en contacte aviat, molt probablement en un dia, dos si és festa. Mentrestant, cerqueu un correu electrònic de l'AdBlock. Trobareu un enllaç al vostre tiquet a la nostra pàgina de suport. Si preferiu seguir el correu electrònic, també ho podeu fer!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Saber-ne més sobre el programa d'anuncis acceptables."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Us hauria de notificar l'AdBlock quan detecti programari maliciós?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"actualitzat ara mateix"
+    "message":"actualitzat fa 1 dia"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL del marc: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Alemany"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Aquest nom de fitxer és massa llarg. Si us plau, canvieu-lo a un de més curt."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"actualitzat fa $seconds$ segons",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"No actuar en aquesta pàgina"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Feu-nos-ho saber en el nostre <a>lloc web de suport</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"D'acord!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Fet! Hem recarregat la pàgina amb l'anunci. Aneu a la pàgina per comprovar si l'anunci ha marxat. Llavors torneu a aquesta pàgina i responeu la pregunta que es formula a continuació."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Tots els recursos"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"El canal $name$ té permís",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Recurs"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Mostrar el nombre d'anuncis blocats al menú"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Informant sobre un anunci"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Com?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"No actuar en les pàgines d'aquest domini"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Llistes de filtres personalitzades"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Bloquejar més anuncis:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Falta informació requerida o aquesta no es vàlida. Si us plau, respongui  les preguntes que tenen la vora vermella."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"El domini o URL en el qual l'AdBlock no hauria de bloquejar res"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Ja no esteu subscrits a la llista de filtres dels Anuncis Acceptables."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (elimina les molèsties de la xarxa)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"L'AdBlock ha bloquejat una descàrrega d'un lloc del qual se sap que conté malware."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Desar"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>No n'esteu segurs?</b>doncs premeu 'Bloquejar-ho!' a continuació."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Darrer pas: informeu-nos del problema."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Exactament, on es troba l'anunci? Quin aspecte té?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Té bon aspecte"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permet que l'AdBlock reculli anònimament dades i ús de les llistes de filtres"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Per informar sobre un anunci, heu d'estar connectats a internet."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Segur que us voleu subscriure a la llista de filtres $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"actualitzat fa $days$ dies",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"marc"
+    "message":"objecte interactiu"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Què creieu que serà veritat sobre aquest anunci cada cop que visiteu aquesta pàgina?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Anuncis bloquejats:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Àrab"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Desfer els meus blocatges en aquest domini"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Editar manualment els vostres filtres:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Pas 1: Identifiqueu el que s'ha de bloquejar"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Escriviu el filtre correcte a continuació i premeu 'D'acord'"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Traducció al català feta per:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"L'AdBlock està actualitzat!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Només en anglès"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>O BÉ</b>, només cliqueu aquest botó per fer tot el que figura anteriorment: <a>Desactivar totes les altres extensions</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Què hi ha de nou en l'últim llançament? Vegeu <a style='cursor:pointer;'>el conjunt de canvis</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (protecció de la privadesa)"
+    "message":"Llista de filtres antisocials (suprimeix els botons de les xarxes socials)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Informar sobre un anunci en aquesta pàgina"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Protecció contra el programari maliciós"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Netejar aquesta llista"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Sóc un usuari avançat, mostrar opcions avançades"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Alemany"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Heu sobrepassat el límit d'emmagatzematge que l'AdBlock pot fer servir. Deixeu la subscripció d'algunes llistes de filtres!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Aneu amb compte: aquest filtre bloqueja tots els elements $elementtype$ de la pàgina!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"aquí"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Quina és la teva adreça de correu?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"En quin idioma està escrita la pàgina web?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Voleu veure els engranatges que mouen l'AdBlock?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Esteu segur que voleu eliminar els $count$ blocatges que heu creat a $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"imatge"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Amagar una secció d'una pàgina web"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"I creeu un tiquet de forma manual. Copieu i enganxeu la següent informació a la secció \"Completeu qualsevol detall que penseu que ens ajudarà a comprendre el seu problema\"."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"General"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Per amagar aquest botó, feu clic amb el botó dret i escolliu Amaga el botó. El podeu fer reaparèixer a: chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"o bé AdBlock per a Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Romanès"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Vídeos i Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Quelcom ha anat malament durant la comprovació d'actualitzacions."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Hem desactivat totes les altres extensions. Ara recarregarem la pàgina amb l'anunci. Un segon, si us plau."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Recurs permès"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Fantàstic! Ara hem d'esbrinar quina extensió n'és la causant. Aneu activant les extensions una per una. L'extensió que fa retornar l'anunci(s) és la que heu de desinstal·lar per treure-us de sobre els anuncis."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Txec i eslovac"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"o bé Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Tipus de marc: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~lloc1.com|~lloc2.com|~notícies.lloc3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" - Seleccionar idioma - "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Instal·leu-vos l'Adblock Plus per a Firefox $chrome$ si no el teniu.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Recurs bloquejat"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Quan apareix l'anunci: abans o durant un vídeo o algun plugin com ara un joc Flash?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ serà $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"El filtre, el qual es pot canviar a la pàgina d'opcions:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"El filtre següent: <br/> $filter$ <br/> té un error: <br/>$message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Tancar"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Només bloquejar els anuncis en aquests llocs:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Heu sobrepassat el límit d'emmagatzematge que l'AdBlock pot fer servir. Deixeu la subscripció d'algunes llistes de filtres!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permet que l'AdBlock reculli anònimament dades i ús de les llistes de filtres"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"D'acord, encara podeu bloquejar aquest anunci vosaltres mateixos a la pàgina d'opcions. Gràcies!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Enviar"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finès"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Aquest fitxer és massa gran. Assegureu-vos que el fitxer és de menys de 10 MB."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"També s'inclourà la següent informació a l'informe."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Pagueu el que desitgeu!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Això és un problema de la llista de filtres. Informeu-ne aquí: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Desactiveu les caselles de selecció que es troben al costat de cada extensió <b>excepte</b> la de l'AdBlock. <b>Deixeu la casella de l'AdBlock seleccionada</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Nota: el vostre informe pot ser que esdevingui públic. Recordeu això abans d'incloure quelcom privat."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Mostrar els enllaços a les llistes de filtres"
+  "filteritalian":{
+    "description":"language",
+    "message":"Italià"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Només en anglès"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Ajudeu a fer córrer la veu!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Encara apareix l'anunci?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"L'AdBlock ha bloquejat una descàrrega d'un lloc del qual se sap que conté malware."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Assegureu-vos que esteu fent servir els filtres d'idioma correctes:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Llegenda: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Assegureu-vos que les llistes de filtres estiguin actualitzades:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Quelcom ha anat malament durant la comprovació d'actualitzacions."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Feu clic al menú de Safari &rarr; Preferències &rarr; Ampliacions."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Enviar"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Subscripció cancel·lada."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"àudio/vídeo"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Letó"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Bloquejar un anunci en aquesta pàgina"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Aturar el bloqueig d'anuncis:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Error en desar l'arxiu carregat."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Això relaciona $matchcount$ ítems en aquesta pàgina.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"S'ha produït un error al obtenir aquest filtre!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Feu lliscar el regulador per determinar en quines pàgines del domini l'AdBlock no s'executarà."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"amagant"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Quan apareix l'anunci: abans o durant un vídeo o algun plugin com ara un joc Flash?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Rus i ucraïnès"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Espanyol"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Aneu amb compte: aquest filtre bloqueja tots els elements $elementtype$ de la pàgina!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Activeu el mode de compatibilitat amb ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"No"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"El filtre, el qual es pot canviar a la pàgina d'opcions:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Amagar aquest botó"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Altres"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"D'acord, encara podeu bloquejar aquest anunci vosaltres mateixos a la pàgina d'opcions. Gràcies!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Rus"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Per què no ens envieu un <a>informe d'error</a>?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (protecció de la privadesa)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ serà $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Introduïu una URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"El filtre següent: <br/> $filter$ <br/> té un error: <br/>$message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"CARREGANT..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"El nostre equip ha solicitat informació de depuració? Cliqueu <a href='#' id='debug'>aquí</a> per satisfer la sol·licitud!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"El nombre de normes de filtres de llista sobrepassa el límit de 50.000, i ha estat reduïda automàticament. Deixeu algunes subscripcions a llistes de filtres o desactiveu el bloqueig de continguts de Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Informar sobre un anunci en aquesta pàgina"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Mostrar les dades de depuració al registre de la consola (això alentirà l'AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Domini del marc: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"L'extensió més popular de Chrome, amb més de 40 milions d'usuaris! Bloqueja els anuncis de tota la xarxa."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Heu trobat un error?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Txec"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Això no és un arxiu d'imatge. Si us plau carregueu un arxiu .png, .gif, o .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Mostrar els enllaços a les llistes de filtres"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Permet la publicitat no intrusiva"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Suec"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Suprimir de la llista"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" - Seleccionar idioma - "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francès"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Editar"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Suport"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Si us plau dirigiu-vos a <a>la nostra web de suport</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Bloquejar un anunci mitjançant la seva URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Per posar en pausa l'AdBlock amb el bloqueig de continguts activat, seleccioneu Safari (a la barra de menús) > Preferències > Extensions > AdBlock, i desmarqueu 'Activar AdBlock'."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versió $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"El propòsit d'aquesta pregunta és determinar qui ha de rebre el seu informe. Si contesteu aquesta pregunta de forma incorrecta, l'informe s'enviarà a les persones equivocades, i potser sou ignorats."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Informar sobre anuncis és voluntari. Ajuda a d'altres persones amb l'activació dels mantenidors de les llistes de filtres per tal de bloquejar l'anunci per a tothom. Si ara no et sents altruista, d'acord; tanca aquesta pàgina i <a>bloqueja l'anunci</a> només per tu."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Sí"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"El codi font està <a>totalment disponible</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holandès"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Només la farem servir per contactar-te si necessitem més informació."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Això es relaciona amb <b>1</b> ítem en aquesta pàgina."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"actualitzat fa $hours$ hores",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Enrere"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Clica a: <a>Desactivar Anuncis Acceptables</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"El domini de la pàgina a on s'ha d'aplicar"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Actualització d'AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Alguna cosa no ha anat bé. No s'ha enviat cap recurs. Aquesta pàgina ara es tancarà. Intenteu tornar a carregar la pàgina web."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Aprendre'n més sobre programari maliciós"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Lloc:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Anuncis Acceptables (recomanat)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Té bon aspecte"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Per posar en pausa l'AdBlock amb el bloqueig de continguts activat, seleccioneu Safari (a la barra de menús) > Preferències > Extensions > AdBlock, i desmarqueu 'Activar AdBlock'."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Obriu la <a href='#'>pàgina de les extensions</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock – cliqueu per obtenir més detalls"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Desactiveu totes les extensions excepte l'AdBlock:"
   }
 }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -1,715 +1,195 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Nahlášení reklamy"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Seznam filtrů pro blokování reklam"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Doména:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Povolit odblokování specifických YouTube kanálů"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Žádný známý malware nenalezen."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"V kýženém prohlížeči se přihlašte ke stejnému seznamu filtrů, jaký máte zde."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - klikněte pro podrobnosti"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"V uvedeném prohlížeči načtěte stránku s reklamou."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Švédština"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Co je nového v poslední verzi? Viz <a style='cursor:pointer;'>changelog</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blokovat více reklam:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Ruština"
+    "message":"Dánština"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Zaplať kolik chceš!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Pomozte nám rozšířit povědomí!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Odhlášeno."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blokovat reklamu dle její URL"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Řečtina"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Čínština"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Skrývat část webové stránky"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videa a Flash"
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Máme <a>stránku</a>, která vám pomůže zjistit kdo stojí za AdBlockem!"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Co si myslíte, že bude platit pro tuto reklamu pokaždé, když navštívíte tuto stránku?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Povolit AdBlock na této stránce"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Zpět"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Zobrazit počet zablokovaných reklam na tlačítku AdBlock-u"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Máte otázku nebo nový nápad?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Seznamy filtrů blokují většinu reklam na webu. Můžete také:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Zdrojový kód je <a>volně k dispozici</a>!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Zobrazovat reklamy na webové stránce nebo doméně"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Toto odpovídá <b>1</b> položce na této stránce."
-  },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Buďte opatrní: Pokud zde uděláte chybu, spousta jiných filtrů, včetně těch oficiálních, může být také poškozena!<br/>Přečtěte si <a>filter syntax tutorial (anglicky)</a>, kde se dozvíte, jak přidávat pokročilé vlastní filtry a výjimky."
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Povolit $name$ kanál",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Obecné nastavení"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Váš počítač může být ohrožen Malwarem. Klikněte <a>zde</a> pro více informací."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock se nebude spouštět na žádné stránce odpovídající:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Nemáme výchozí seznam filtrů pro daný jazyk.<br/>Prosím, zkuste najít vhodný seznam pro tento jazyk $link$ nebo si tuto reklamu zablokujte pouze pro sebe na záložce 'Přizpůsobení'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Přidat"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Jsem zkušený uživatel, ukaž mi pokročilé možnosti"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Čeština"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Skrýt toto tlačítko"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Aktualizuji se automaticky; můžete mě také <a>aktualizovat nyní</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Klikněte zde: <a>Aktualizovat filtry!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formát: ~stranka1.cz|~stranka2.cz|~zpravy.stranka3.cz"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Poslední krok: Dle čeho rozpoznat reklamu?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Toto odpovídá $matchcount$ položkám na této stránce.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (odstraní otravnosti na webu)"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonéština"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Typ"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Je dostupná aktualizace pro AdBlock! Navštivte $here$ pro aktualizaci. <br> Poznámka: Jestli chcete abych se aktualizoval sám, jděte do Safari > Nastavení > Rozšíření > Aktualizace <br> a zaškrtněte možnost 'Instalovat aktualizace automaticky'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turečtina"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Co to je?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Vlastní seznamy filtrů"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Nepřihlašujte k odběru více než potřebujete -- každý filtr navíc způsobí drobné zpomalení! Poděkování a další seznamy lze nalézt <a>zde</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definice stylu"
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Nejste si jisti?</b> Tak pouze stiskněte tlačítko 'Blokovat!' níže."
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Smyslem této otázky je určit, kdo by měl dostat vaše hlášení. Pokud odpovíte na tuto otázku chybně, může být zpráva zaslána nesprávným lidem a pak může být ignorována."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polština"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Přidat položky do nabídky po kliknutí pravým tlačítkem myši"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokovat tuto reklamu"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"aktualizováno před $hours$ hodinami",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"aktualizováno před $seconds$ sekundami",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Požádal náš tým o nějaké ladící informace? Klikněte <a href='#' id='debug'>zde</a>!"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Maďarština"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Neplatný seznam URL. Bude smazán."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Poznámka: vaše hlášení může být veřejně dostupné. Mějte to na paměti předtím, než vložíte cokoli soukromého."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Znovu načíst stránku."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"stránka"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Holandština"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Nezapomeňte uložit!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ bude $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Zavřít"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blokovaný element:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Tento filtr je neplatný: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Upozornění: Není vybrán žádný filtr!"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Chcete upozornit, když AdBlock detekuje malware?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Zobrazovat reklamy <i>všude</i> kromě těchto domén..."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Tato funkce AdBlock-u nebude fungovat na tomto webu, protože používá zastaralou technologii. Můžete povolit nebo zakázat zdroje ručně v panelu 'Přizpůsobit' na stránce Možností."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Zobrazit počet zablokovaných reklam v menu AdBlock-u"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Nastavení"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Nespouštět AdBlock na..."
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Načítám... Prosím, čekejte."
   },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Obecné"
   },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Zablokovaných reklam:"
-  },
-  "filteradblock_custom":{
+  "filterannoyances":{
     "description":"A filter list",
-    "message":"AdBlock filtry (doporučeno)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Přidat filtry pro jiný jazyk: "
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Lotyština"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Doplňky, které byly předtím vypnuty, byly opět zapnuty."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokovat URL obsahující tento text"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS obsahuje"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Pro skrytí tlačítka přejděte na adresu opera://extensions a zaškrtněte 'Skrýt z panelu nástrojů'. Můžete jej znovu zobrazit odškrtnutím tohoto tlačítka."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Klikněte na reklamu, a jám vám ji pomohu zablokovat."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Nahlásit reklamu na této stránce"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Ruské a Ukrajinské"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skript"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Podpora AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Přizpůsobte si AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock je aktuální!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"Dohromady: $count$",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Hebrejština"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Promiňte, ale AdBlock je na této stránce zakázán jedním z vašich seznamů filtrů."
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Vzít zpět blokace na této doméně"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Prosím, zadejte správný filtr a stiskněte OK"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"aktualizováno před 1 dnem"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
+    "message":"Fanboy's Annoyances (odstraní otravnosti na webu)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"Na této stránce: $count$",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"aktualizováno před 1 hodinou"
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Neplatný seznam URL. Bude smazán."
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Verze $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Polština"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Obecné nastavení"
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Odstranit ze seznamu"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Jiný"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS obsahuje"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"skrytý"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Seznamy filtrů"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Objevuje se reklama ve filmu nebo před ním nebo v jakémkoli jiném doplňku, např. ve Flashové hře?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Ostatní seznamy filtrů"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"nebo Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokovat!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Dokončeno!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blokovat reklamu na této stránce"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Zavřít"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Nechci to takhle kontrolovat"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock se nebude spouštět na žádné stránce odpovídající:"
   },
-  "lang_english":{
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Zobrazovat reklamy <i>všude</i> kromě těchto domén..."
+  },
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Buďte opatrní: Pokud zde uděláte chybu, spousta jiných filtrů, včetně těch oficiálních, může být také poškozena!<br/>Přečtěte si <a>filter syntax tutorial (anglicky)</a>, kde se dozvíte, jak přidávat pokročilé vlastní filtry a výjimky."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Angličtina"
+    "message":"Slovenština"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Přizpůsobení"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pozastavit AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Jste si jist, že se chcete přihlásit k odběru $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Otevřete stránku s doplňky pro zapnutí těch, které byly předtím zakázány."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Používat na stránkách domény"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Korejština"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Stránka:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Našel jste chybu?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Krok 1: Určete, co se bude blokovat"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Čím více seznamů filtrů si přihlásíte, tím pomaleji AdBlock poběží. Použití příliš mnoha seznamů dokonce může mít za následek pád prohlížeče na některých webových stránkách. Pro potvrzení přihlášení stiskněte tlačítko OK."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"nebo AdBlock pro Chrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokování reklamy"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Ano"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Zobrazuje se reklama také v uvedeném prohlížeči?"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Uložit"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Nepoužívat na této stránce"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Dánština"
+    "message":"Rumunština"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Chcete-li skrýt tlačítko, klikněte na něj pravým tlačítkem myši a vyberte příkaz Skrýt tlačítko. Můžete jej opět zobrazit zde chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebrejština"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Tato funkce AdBlock-u nebude fungovat na tomto webu, protože používá zastaralou technologii. Můžete povolit nebo zakázat zdroje ručně v panelu 'Přizpůsobit' na stránce Možností."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Česky a Slovensky"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Ostatní seznamy filtrů"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Nastavení"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Váš počítač může být ohrožen Malwarem. Klikněte <a>zde</a> pro více informací."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Aktualizuji se automaticky; můžete mě také <a>aktualizovat nyní</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"rámec"
+    "message":"neznámý"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Upravit"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Zobrazovat reklamy na webové stránce nebo doméně"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Hledání reklam...<br/><br/><i>Bude to trvat pouze chvilku.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turečtina"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Doména nebo url, kde AdBlock nesmí nic blokovat"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Kontrola aktualizací (toto zabere jen pár sekund)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Čím více seznamů filtrů si přihlásíte, tím pomaleji AdBlock poběží. Použití příliš mnoha seznamů dokonce může mít za následek pád prohlížeče na některých webových stránkách. Pro potvrzení přihlášení stiskněte tlačítko OK."
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Nastavte posuvník tak, aby reklama na stránce byla blokována a zbytek stránky stále vypadal uspokojivě."
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Nespouštět na stránkách na této doméně"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Načtěte znovu stránku s reklamou."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Nainstalujte prohlížeč Firefox $chrome$, pokud jej nemáte.",
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Přihlaste se k odběru tohoto seznamu filtrů a zkuste to znovu: $list_title$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Nemáme výchozí seznam filtrů pro daný jazyk.<br/>Prosím, zkuste najít vhodný seznam pro tento jazyk $link$ nebo si tuto reklamu zablokujte pouze pro sebe na záložce 'Přizpůsobení'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -717,234 +197,377 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Klikněte na reklamu, a jám vám ji pomohu zablokovat."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"definice stylu"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Aktualizace AdBlock-u"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Ne"
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Promiňte, ale AdBlock je na této stránce zakázán jedním z vašich seznamů filtrů."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Chcete upozornit, když AdBlock detekuje malware?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"aktualizováno před 1 dnem"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Není vybrán žádný filtr!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Němčina"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Seznamy filtrů"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Řečtina"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"aktualizováno před $seconds$ sekundami",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Nejste si jisti?</b> Tak pouze stiskněte tlačítko 'Blokovat!' níže."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"V uvedeném prohlížeči načtěte stránku s reklamou."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Dejte nám vědět na našich <a>stránkách podpory</a>!"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokovat reklamy pouze na těchto stránkách:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Přizpůsobení"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Pro nahlášení reklamy musíte být připojen k internetu."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Povolit $name$ kanál",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Skrývat část webové stránky"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"rámec"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Zobrazit počet zablokovaných reklam v menu AdBlock-u"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Nahlášení reklamy"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulharština"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Nespouštět na stránkách na této doméně"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Vlastní seznamy filtrů"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blokovat více reklam:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukrajinština"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"aktualizováno před $minutes$ minutami",
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Typ"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Doména nebo url, kde AdBlock nesmí nic blokovat"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Nespouštět AdBlock na..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokovat URL obsahující tento text"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Uložit"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Kontrola v prohlížeči Firefox $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "filtereasylist_plus_french":{
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Poslední krok: Dle čeho rozpoznat reklamu?"
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Pokračovat"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Přizpůsobte si AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Žádný známý malware nenalezen."
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Zástupné řešení pro nefunkční video na Hulu.com (vyžaduje restartování prohlížeče)"
+  },
+  "filtereasylist_plus_finnish":{
     "description":"language",
-    "message":"Francouzština"
+    "message":"Finština"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>NEBO</b>, prostě klikněte na toto tlačítko a my vše uděláme za Vás: <a>Zakázat všechna ostatní rozšíření</a>"
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Skrýt toto tlačítko"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktivní objekt"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"aktualizováno právě teď"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Uložit"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Upozornění: Na všech ostatních stránkách uvidíte reklamy!<br>Toto má přednost před všemi ostatními filtry pro tyto stránky."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Zakázat tato upozornění"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Přihlašování k odběru seznamu filtrů..."
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Seznam filtrů pro blokování reklam"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"aktualizováno před $days$ dny",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"rámec"
+    "message":"interaktivní objekt"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (ochrana soukromí)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Co si myslíte, že bude platit pro tuto reklamu pokaždé, když navštívíte tuto stránku?"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Další informace o malware"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Česky a Slovensky"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Používáte starou verzi AdBlock. Prosím, jděte na stránku <a href='#'>Rozšíření</a>, povolte 'Režim pro vývojáře' a klikněte na 'Aktualizovat rozšíření'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock Nastavení"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Vyčistit seznam"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Anti-sociální filtr (odstraní tlačítka na sociální sítě)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Zobrazovat debug zprávy v Console Log (tohle zpomaluje AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Překročili jste limit velikosti Dropboxu. Prosíme, odstraňte některé položky z Vašeho vlastního, či zakázaného filtru a zkuste to znovu."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Zrušit pozastavení AdBlock-u"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Němčina"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Buďte opatrní: tento filtr blokuje všechny $elementtype$ elementy na stránce!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"zde"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Ano"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Zástupné řešení pro nefunkční video na Hulu.com (vyžaduje restartování prohlížeče)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Uložit"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"V jakém jazyce je stránka napsána?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Jste si jist, že chcete odstranit $count$ blokování, které jste vytvořili na $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"obrázek"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Autorem překladu je:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"NAČÍTÁM..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Klikněte pravým tlačítkem myši na reklamu pro její zablokování -- nebo ji zablokujte ručně zde."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Chcete-li skrýt tlačítko, klikněte na něj pravým tlačítkem myši a vyberte příkaz Skrýt tlačítko. Můžete jej opět zobrazit zde chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumunština"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Upravit zakázané filtry:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Něco se pokazilo při kontrole aktualizací."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Pro skrytí tlačítka klikněte pravým tlačítkem na nástroje Safari a vyberte Upravit panel nástrojů, poté táhněte s AdBlock tlačítkem pryč z panelu nástrojů. Můžete jej znovu zobrazit táhnutím zpět do panelu nástrojů."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"aktualizováno před 1 minutou"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Zablokovaných reklam:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"stránka"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Korejština"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Vzít zpět blokace na této doméně"
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Ručně upravit vlastní filtry:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Ukaž odkazy na seznamy filtrů"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (doporučeno)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Krok 1: Určete, co se bude blokovat"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Máme <a>stránku</a>, která vám pomůže zjistit kdo stojí za AdBlockem!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Doména:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"zde"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Jestli vidíte reklamu, neposílejte hlášení o chybě, pošlete <a>hlášení o reklamě</a>!"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock je aktuální!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Znovu načíst stránku."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Pouze anglicky"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Používáte starou verzi AdBlock. Prosím, jděte na stránku <a href='#'>Rozšíření</a>, povolte 'Režim pro vývojáře' a klikněte na 'Aktualizovat rozšíření'"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock je pozastaven."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>NEBO</b>, prostě klikněte na toto tlačítko a my vše uděláme za Vás: <a>Zakázat všechna ostatní rozšíření</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Co je nového v poslední verzi? Viz <a style='cursor:pointer;'>changelog</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Anti-sociální filtr (odstraní tlačítka na sociální sítě)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Hledání reklam...<br/><br/><i>Bude to trvat pouze chvilku.</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Jsem zkušený uživatel, ukaž mi pokročilé možnosti"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"V kýženém prohlížeči se přihlašte ke stejnému seznamu filtrů, jaký máte zde."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokování reklamy"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Upozornění: Na všech ostatních stránkách uvidíte reklamy!<br>Toto má přednost před všemi ostatními filtry pro tyto stránky."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Doplňky, které byly předtím vypnuty, byly opět zapnuty."
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Chcete vědět co stojí za AdBlock-em?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock filtry (doporučeno)"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Co to je?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -956,281 +579,83 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Nebo zadejte URL:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"nebo AdBlock pro Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Používáte starou verzi Safari. Získejte nejnovější verzi, abyste mohli používat tlačítko AdBlock na panelu nástrojů pro pozastavení AdBlock, spravovat chování na webových stránkách a nahlašovat reklamy. <a>Aktualizovat nyní</a>."
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Zvolte jazyk -- "
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Autorem překladu je:"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formát: ~stranka1.cz|~stranka2.cz|~zpravy.stranka3.cz"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Klikněte na menu Safari &rarr; Nastavení &rarr; Rozšíření."
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Zrušit blokování reklam:"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videa a Flash"
   },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Nejpopulárnější rozšíření pro Chrome s více než 40 miliony uživateli! Blokujeme reklamy na celém webu."
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Seznamy filtrů blokují většinu reklam na webu. Můžete také:"
   },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Zobrazuje se stále tato reklama?"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Pro skrytí tlačítka klikněte pravým tlačítkem na nástroje Safari a vyberte Upravit panel nástrojů, poté táhněte s AdBlock tlačítkem pryč z panelu nástrojů. Můžete jej znovu zobrazit táhnutím zpět do panelu nástrojů."
   },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Ochrana proti Malware-u"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Překročili jste limit velikosti Dropboxu. Prosíme, odstraňte některé položky z Vašeho vlastního, či zakázaného filtru a zkuste to znovu."
   },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Podpora"
-  },
-  "filtereasylist_plus_bulgarian":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Bulharština"
+    "message":"Maďarština"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Chcete vědět co stojí za AdBlock-em?"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"nebo Chrome"
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Neúspěšné!"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Přidat"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filtr, který lze později změnit v Nastavení na záložce Vlastní filtr:"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Zaplať kolik chceš!"
   },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"Ručně upravit vlastní filtry:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Následující filtr:<br/> $filter$ <br/> obsahuje chybu: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Typ"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovenština"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Seznamy filtrů"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Zobrazuje se reklama také v uvedeném prohlížeči?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Nepoužívat na této stránce"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokovat reklamy pouze na těchto stránkách:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Dejte nám vědět na našich <a>stránkách podpory</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock je pozastaven."
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Překročili jste ukládací prostor, který AdBlock může použít. Prosím, odhlaste odběr některých seznamů filtrů!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Nemůžeme zatím blokovat reklamy uvnitř objektů Flash nebo v jiných doplňcích. Čekáme na podporu od prohlížeče a WebKitu."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, můžete si zablokovat tuto reklamu pouze pro sebe v Nastavení na záložce Vlastní filtr. Díky!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Obecné"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"jiný"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Odeslat"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Není vybrán žádný filtr!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"neznámý"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finština"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock je zakázán na této stránce."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japonština"
+    "message":"Upravit zakázané filtry:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Toto je chyba seznamu filtrů. Nahlašte ji zde: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Odškrtněte 'Povoleno' vedle každého rozšíření <b>kromě</b> AdBlocku. <b>Nechte AdBlock zapnutý.</b>"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blokovaný element:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Ukaž odkazy na seznamy filtrů"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Poznámka: vaše hlášení může být veřejně dostupné. Mějte to na paměti předtím, než vložíte cokoli soukromého."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Pouze anglicky"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Storno"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Pomozte nám rozšířit povědomí!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Nastavením posuvníku níže vyberte přesně ty stránky, kde se AdBlock nebude spouštět."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Kontrola v prohlížeči Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Povolit režim kompatibility ClickToFlash"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Přihlaste se k odběru tohoto seznamu filtrů a zkuste to znovu: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Pro nahlášení reklamy musíte být připojen k internetu."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (doporučeno)"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Nepodařilo se načíst tento filtr!"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italština"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Španělština"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Pokračovat"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Jestli vidíte reklamu, neposílejte hlášení o chybě, pošlete <a>hlášení o reklamě</a>!"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Máte otázku nebo nový nápad?"
+  "typepage":{
+    "description":"A resource type",
+    "message":"stránka"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1240,5 +665,620 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Zobrazuje se stále tato reklama?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"jiný"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Klikněte zde: <a>Aktualizovat filtry!</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Italština"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Pro skrytí tlačítka přejděte na adresu opera://extensions a zaškrtněte 'Skrýt z panelu nástrojů'. Můžete jej znovu zobrazit odškrtnutím tohoto tlačítka."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Něco se pokazilo při kontrole aktualizací."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Klikněte na menu Safari &rarr; Nastavení &rarr; Rozšíření."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Odeslat"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Stránka:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Načtěte znovu stránku s reklamou."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Odhlášeno."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Lotyština"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blokovat reklamu na této stránce"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokovat!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Zrušit blokování reklam:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Povolit odblokování specifických YouTube kanálů"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"V jakém jazyce je stránka napsána?"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Odškrtněte 'Povoleno' vedle každého rozšíření <b>kromě</b> AdBlocku. <b>Nechte AdBlock zapnutý.</b>"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Nahlásit reklamu na této stránce"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Odstranit ze seznamu"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Nemůžeme zatím blokovat reklamy uvnitř objektů Flash nebo v jiných doplňcích. Čekáme na podporu od prohlížeče a WebKitu."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Nastavením posuvníku níže vyberte přesně ty stránky, kde se AdBlock nebude spouštět."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"skrytý"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock je zakázán na této stránce."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Objevuje se reklama ve filmu nebo před ním nebo v jakémkoli jiném doplňku, např. ve Flashové hře?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Ruské a Ukrajinské"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Španělština"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokovat tuto reklamu"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Buďte opatrní: tento filtr blokuje všechny $elementtype$ elementy na stránce!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Povolit režim kompatibility ClickToFlash"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Ne"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Povolit AdBlock na této stránce"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filtr, který lze později změnit v Nastavení na záložce Vlastní filtr:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Zobrazit počet zablokovaných reklam na tlačítku AdBlock-u"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Neúspěšné!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pozastavit AdBlock"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Následující filtr:<br/> $filter$ <br/> obsahuje chybu: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Angličtina"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Přidat položky do nabídky po kliknutí pravým tlačítkem myši"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, můžete si zablokovat tuto reklamu pouze pro sebe v Nastavení na záložce Vlastní filtr. Díky!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Ruština"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Jste si jist, že chcete odstranit $count$ blokování, které jste vytvořili na $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Používáte starou verzi Safari. Získejte nejnovější verzi, abyste mohli používat tlačítko AdBlock na panelu nástrojů pro pozastavení AdBlock, spravovat chování na webových stránkách a nahlašovat reklamy. <a>Aktualizovat nyní</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (ochrana soukromí)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ bude $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Nebo zadejte URL:"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Dokončeno!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Zrušit pozastavení AdBlock-u"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Přidat filtry pro jiný jazyk: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"NAČÍTÁM..."
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Klikněte pravým tlačítkem myši na reklamu pro její zablokování -- nebo ji zablokujte ručně zde."
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Ochrana proti Malware-u"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Zobrazovat debug zprávy v Console Log (tohle zpomaluje AdBlock)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Nainstalujte prohlížeč Firefox $chrome$, pokud jej nemáte.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Překročili jste ukládací prostor, který AdBlock může použít. Prosím, odhlaste odběr některých seznamů filtrů!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Nejpopulárnější rozšíření pro Chrome s více než 40 miliony uživateli! Blokujeme reklamy na celém webu."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Našel jste chybu?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Další informace o malware"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skript"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Seznamy filtrů"
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Zakázat tato upozornění"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Čínština"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Tento filtr je neplatný: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Přihlašování k odběru seznamu filtrů..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Otevřete stránku s doplňky pro zapnutí těch, které byly předtím zakázány."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Toto odpovídá $matchcount$ položkám na této stránce.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"aktualizováno před 1 hodinou"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Zvolte jazyk -- "
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Nastavte posuvník tak, aby reklama na stránce byla blokována a zbytek stránky stále vypadal uspokojivě."
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonéština"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"obrázek"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Upravit"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Nepodařilo se načíst tento filtr!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"Dohromady: $count$",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Podpora"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blokovat reklamu dle její URL"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Storno"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Nezapomeňte uložit!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Verze $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Smyslem této otázky je určit, kdo by měl dostat vaše hlášení. Pokud odpovíte na tuto otázku chybně, může být zpráva zaslána nesprávným lidem a pak může být ignorována."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Jste si jist, že se chcete přihlásit k odběru $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Zdrojový kód je <a>volně k dispozici</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holandština"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Prosím, zadejte správný filtr a stiskněte OK"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Je dostupná aktualizace pro AdBlock! Navštivte $here$ pro aktualizaci. <br> Poznámka: Jestli chcete abych se aktualizoval sám, jděte do Safari > Nastavení > Rozšíření > Aktualizace <br> a zaškrtněte možnost 'Instalovat aktualizace automaticky'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Toto odpovídá <b>1</b> položce na této stránce."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japonština"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Vyčistit seznam"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"aktualizováno před $hours$ hodinami",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Zpět"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock Nastavení"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Nepřihlašujte k odběru více než potřebujete -- každý filtr navíc způsobí drobné zpomalení! Poděkování a další seznamy lze nalézt <a>zde</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Kontrola aktualizací (toto zabere jen pár sekund)..."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Jiný"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Používat na stránkách domény"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"aktualizováno právě teď"
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Požádal náš tým o nějaké ladící informace? Klikněte <a href='#' id='debug'>zde</a>!"
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"aktualizováno před $minutes$ minutami",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Čeština"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Švédština"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Podpora AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Typ"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francouzština"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"aktualizováno před 1 minutou"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"rámec"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - klikněte pro podrobnosti"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Upozornění: Není vybrán žádný filtr!"
   }
 }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -1,697 +1,199 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Raportér en reklame"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Liste over reklamefiltre"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Domæne:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Tillad whitelisting af bestemte YouTube-kanaler"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (fjerner irritationer på nettet)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - klik for at se mere"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"I den browser skal du indlæse siden med reklamen."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Svensk"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Type"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blokér flere reklamer:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Russisk"
+    "message":"Dansk"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Betal det du vil!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Hjælp med at sprede ordet!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Fjern abonnement."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Græsk"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Kinesisk"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Skjul en sektion af en hjemmeside"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videoer og Flash"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Malwarebeskyttelse"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Hvad tror du vil være sandt om denne reklame, hver gang du besøger denne side?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Aktivér AdBlock på denne side"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Tilbage"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Vis antal reklamer blokeret i AdBlock-knappen"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Har du et spørgsmål eller en ny idé?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Filterlisterne blokerer de fleste reklamer på nettet. Du kan også:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Kildekoden er <a>frit tilgængelig</a>!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Vis reklamer på en hjemmeside eller et domæne"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Det blev kun fundet <b>1</b> gang på siden."
-  },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Vær varsom: hvis du laver en fejl her, kan en stor del af disse og de officielle filtre blive ubrugelige!<br/>Læs <a>filtersyntaksguiden (engelsk)</a> for at lære hvordan man tilføjer avancerede blacklist og whitelist filtre."
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Whitelist kanalen $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Generelle indstillinger"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Din computer kan være inficeret med malware.  Klik <a>her</a> for mere information."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock vil ikke køre på nogen sider der passer med:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Vi har i øjeblikket ikke et standardfilter for det valgte sprog.<br/>Prøv venligst at finde en passende liste, der understøtter sproget $link$ eller bloker reklamen bare for dig selv under 'Tilpas'-fanen.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Abonnér"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Jeg er erfaren bruger, vis mig de avancerede indstillinger"
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blokér en reklame ud fra dens URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Skjul denne knap"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Jeg henter automatisk opdateringer; du kan også <a>opdatere nu</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Klik på denne: <a>Opdatér mine filtre!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~side1.dk|~side2.dk|~nyheder.side3.org"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Sidste trin: Hvad gør dette til en reklame?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Det blev fundet $matchcount$ gange på denne side.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Vi har også en <a>side</a> til at hjælpe dig med at finde ud af folkene bag AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesisk"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Type"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Der er en ny opdatering til AdBlock! Tjek det ud $here$.<br>OBS: Hvis du vil installere opdateringer automatisk, skal du klikke på Safari > Indstillinger > Udvidelser > Opdateringer og markere 'Installér automatisk nye opdateringer'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Tyrkisk"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Hvad er det her?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Brugerdefinerede filtreringslister"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Abonnér ikke på flere end du behøver -- hvert abonnement sløver en lille bitte smule. Credits og flere lister kan findes <a>her (engelsk)</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"stildefinition"
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Fjern fra liste"
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Formålet med dette spørgsmål er for at fastslå, hvem der bør modtage din rapportering. Hvis du besvarer spørgsmålet forkert vil rapporten blive sendt til de forkerte folk, og måske blive ignoreret."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polsk"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Tilføj muligheder til højrekliksmenuen"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokér denne reklame"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"opdateret for $hours$ timer siden",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"opdateret for $seconds$ sekunder siden",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Har vores hold spurgt efter debug-info? Klik <a href='#' id='debug'>her</a> for at få det!"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Ungarsk"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Ugyldig URL til liste. Den vil blive slettet."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Bemærk: din rapport kan blive offentligt tilgængelig. Hav det i tankerne, inden du inkluderer personlige informationer."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Genindlæs siden."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"side"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Hollandsk"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Husk at gemme!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ vil være $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Luk"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blokeret element:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filteret er ugyldigt: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Advarsel: der er ikke angivet noget filter!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock er slået fra på denne side."
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Vis rekamer <i>overalt</i> undtagen disse domæner..."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Denne AdBlock-funktion virker ikke på denne hjemmeside, fordi den anvender forældet teknologi. Du kan blackliste eller whiteliste ressourcer manuelt under fanen 'Tilpas' i indstillingerne."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Vis antal reklamer blokeret i AdBlock-knappen"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Indstillinger"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Benyt ikke AdBlock på..."
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Henter... vent venligst."
   },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Blokerede reklamer:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock-brugerdefinerede filtre (anbefalet)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Tilføj filtre for et andet sprog: "
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Lettisk"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS, der skal matches"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"For at skjule knappen, gå til opera://extensions og markér 'Skjul i værktøjslinjen'. Du kan vise det igen ved at afmarkére denne mulighed."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Klik på reklamen, og så vil jeg guide dig igennem blokeringen af den."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Raportér en reklame på denne side"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Russisk og ukrainsk"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock-support"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Tilpas AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock er ajour!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Benyt ikke på sider, på dette domæne"
-  },
-  "filterisraeli":{
+  "filterjapanese":{
     "description":"language",
-    "message":"Hebræisk"
+    "message":"Japansk"
   },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Beklager, AdBlock er slået fra på denne side via et af dine filterlister."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokér URL'er der indeholder denne tekst"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Fortryd mine blokeringer på dette domæne"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Vælg venligst det korrekte filter nedenfor, og klik OK"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"opdateret for 1 dag siden"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (fjerner irritationer på nettet)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ på denne side",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Ikke sikker?</b> klik blot 'Blokér!' nedenfor."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Ugyldig URL til liste. Den vil blive slettet."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"opdateret for 1 time siden"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Polsk"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Version $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Generelle indstillinger"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Abonnér på lister"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS, der skal matches"
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Andet"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"skjuler"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Filterlister"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Vises reklamen i eller før film, eller et andet plugin, såsom et Flash-spil?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Andre filtre"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"eller Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokér!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Færdig!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blokér en reklame på denne side"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nej"
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Fjern krydset i 'Aktivér'-feltet ud for alle udvidelser <b>bortset fra</b> AdBlock. <b>Lad AdBlock forblive aktiveret</b>."
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Jeg ønsker ikke at undersøge dette"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock vil ikke køre på nogen sider der passer med:"
   },
-  "lang_english":{
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Vis rekamer <i>overalt</i> undtagen disse domæner..."
+  },
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Vær varsom: hvis du laver en fejl her, kan en stor del af disse og de officielle filtre blive ubrugelige!<br/>Læs <a>filtersyntaksguiden (engelsk)</a> for at lære hvordan man tilføjer avancerede blacklist og whitelist filtre."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Engelsk"
+    "message":"Slovakisk"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Tilpas"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Afbryd AdBlock midlertidigt"
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domæne for side hvor blokeringen skal virke"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Koreansk"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Side:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Fundet en fejl?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Trin 1: Find ud af hvad der skal blokeres"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Tjekkisk"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Jo flere lister du vælger, des langsommere kører AdBlock. Bruger du for mange filtre kan browseren endda stoppe med at fungere på nogle sider. Klik OK for at abonnere på denne liste alligevel."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"eller AdBlock til Chrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokér en reklame"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Tjek i Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Vises reklamen også i den browser?"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Udeluk"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Gem"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Benyt ikke på denne side"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Dansk"
+    "message":"Romænsk"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"For at skjule knappen skal du højreklikke på den og vælge 'Skjul knap'. Du kan få den frem igen ved at gå til chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebræisk"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Denne AdBlock-funktion virker ikke på denne hjemmeside, fordi den anvender forældet teknologi. Du kan blackliste eller whiteliste ressourcer manuelt under fanen 'Tilpas' i indstillingerne."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Andet"
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Tjekkisk og slovakisk"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Andre filtre"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Indstillinger"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Din computer kan være inficeret med malware.  Klik <a>her</a> for mere information."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Jeg henter automatisk opdateringer; du kan også <a>opdatere nu</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"ukendt"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Redigér"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Vis reklamer på en hjemmeside eller et domæne"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Finder reklamer...<br/><br/><i>Det tager kun et øjeblik.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Tyrkisk"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domænet eller URL hvor AdBlock ikke skal blokere noget"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Tjekke om der er nye opdateringer (dette bør ikke tage lang tid)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Jo flere lister du vælger, des langsommere kører AdBlock. Bruger du for mange filtre kan browseren endda stoppe med at fungere på nogle sider. Klik OK for at abonnere på denne liste alligevel."
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Skyd glideren indtil reklamen er skjult korrekt på siden, og det blokerede element ser brugbart ud."
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ i alt",
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Vi har i øjeblikket ikke et standardfilter for det valgte sprog.<br/>Prøv venligst at finde en passende liste, der understøtter sproget $link$ eller bloker reklamen bare for dig selv under 'Tilpas'-fanen.",
     "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Genindlæs siden med reklamen."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Installér Firefox $chrome$ hvis du ikke har det.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -699,218 +201,403 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Klik på reklamen, og så vil jeg guide dig igennem blokeringen af den."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"stildefinition"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock-opdateringer"
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Fjern krydset i 'Aktivér'-feltet ud for alle udvidelser <b>bortset fra</b> AdBlock. <b>Lad AdBlock forblive aktiveret</b>."
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Beklager, AdBlock er slået fra på denne side via et af dine filterlister."
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"opdateret for 1 dag siden"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Intet filter valgt!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Tysk"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Græsk"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"opdateret for $seconds$ sekunder siden",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Ikke sikker?</b> klik blot 'Blokér!' nedenfor."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"I den browser skal du indlæse siden med reklamen."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Lad os få det at vide på vores <a>supportside</a>!"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokér kun reklamer på disse domæner:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Tilpas"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"For at rapportere annoncer, skal du have internetforbindelse."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Whitelist kanalen $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Skjul en sektion af en hjemmeside"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Vis antal reklamer blokeret i AdBlock-knappen"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Raportér en reklame"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgarsk"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Hvad er der af nye ting i den seneste udgivelse? Tjek <a style='cursor:pointer;'>ændringsloggen</a> ud."
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Benyt ikke på sider, på dette domæne"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Brugerdefinerede filtreringslister"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blokér flere reklamer:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukrainsk"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"opdateret for $minutes$ minutter siden",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domænet eller URL hvor AdBlock ikke skal blokere noget"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Advarsel: der er ikke angivet noget filter!"
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokér URL'er der indeholder denne tekst"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Luk"
   },
   "filtereasylist_plus_french":{
     "description":"language",
     "message":"Fransk"
   },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Hvis du ser en reklame, skal du ikke lave en fejlrapport, men en <a>annoncerapport</a> istedet!"
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Sidste trin: Hvad gør dette til en reklame?"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktivt objekt"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Er du sikker på du vil fjerne $count$ blokeringer, som du har oprettet på $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"opdateret"
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
   },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Gem"
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Advarsel: på alle andre sider vil reklamer blive vist!<br>Dette overskriver alle andre filtre for disse sider."
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Det ser godt ud"
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Abonnér på filterliste..."
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Tilpas AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Ingen kendt malware fundet."
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Lad os rette, at Hulu.com videoer ikke bliver afspillet (kræver genstart af browseren)"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finsk"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Skjul denne knap"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"opdateret for $days$ dage siden",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"interaktivt objekt"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (beskyttelse af privatliv)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Hvad tror du vil være sandt om denne reklame, hver gang du besøger denne side?"
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Tjekkisk og slovakisk"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Du bruger en gammel version af AdBlock. Gå venligst til <a href='#'>siden for udvidelser</a>, aktiver 'Udviklertilstand' og klik på 'Opdater udvidelser nu'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock-indstillinger"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Ryd op i denne liste"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocial-filterliste (fjerner sociale medierknapper)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Vis debuginformationer i Console Log (vil gøre AdBlock langsomere)"
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Fortsæt AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Tysk"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Pas på: dette filter blokerer alle $elementtype$ elementer på siden!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"her"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Lad os rette, at Hulu.com videoer ikke bliver afspillet (kræver genstart af browseren)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Udeluk"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Hvilket sprog er siden i?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Er du sikker på du vil fjerne $count$ blokeringer, som du har oprettet på $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"billede"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Tak for oversættelsen til:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"INDLÆSER..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Højreklik på en reklame på en side for at blokere den -- eller blokér den manuelt her."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"For at skjule knappen skal du højreklikke på den og vælge 'Skjul knap'. Du kan få den frem igen ved at gå til chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Romænsk"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Redigér deaktiverede filtre:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Noget gik galt, da vi forsøgte at tjekke for nye opdateringer."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"For at skjule knappen, skal du højreklikke på Safaris værktøjslinje og vælge Tilpas værktøjslinje, og træk knappen AdBlock ud af værktøjslinjen. Du kan vise den igen ved at trække det tilbage til værktøjslinjen."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"opdateret for 1 minut siden"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Blokerede reklamer:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"side"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Koreansk"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Fortryd mine blokeringer på dette domæne"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Redigér dine filtre manuelt:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Vis links til filterlisterne"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (anbefalet)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Trin 1: Find ud af hvad der skal blokeres"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Vi har også en <a>side</a> til at hjælpe dig med at finde ud af folkene bag AdBlock!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Domæne:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"her"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock er ajour!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Genindlæs siden."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Kun på engelsk"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Du bruger en gammel version af AdBlock. Gå venligst til <a href='#'>siden for udvidelser</a>, aktiver 'Udviklertilstand' og klik på 'Opdater udvidelser nu'"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock er midlertidigt afbrudt."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Fortsæt AdBlock"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antisocial-filterliste (fjerner sociale medierknapper)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Finder reklamer...<br/><br/><i>Det tager kun et øjeblik.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock er slået fra på denne side."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokér en reklame"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Advarsel: på alle andre sider vil reklamer blive vist!<br>Dette overskriver alle andre filtre for disse sider."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Der er en ny opdatering til AdBlock! Tjek det ud $here$.<br>OBS: Hvis du vil installere opdateringer automatisk, skal du klikke på Safari > Indstillinger > Udvidelser > Opdateringer og markere 'Installér automatisk nye opdateringer'.",
     "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Ønsker du at se i AdBlocks maskinrum?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock-brugerdefinerede filtre (anbefalet)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Type"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Hvad er det her?"
+  },
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Generelt"
+  },
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"eller AdBlock til Chrome"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Abonnér på lister"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Tak for oversættelsen til:"
+  },
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~side1.dk|~side2.dk|~nyheder.side3.org"
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videoer og Flash"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Filterlisterne blokerer de fleste reklamer på nettet. Du kan også:"
+  },
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"For at skjule knappen, skal du højreklikke på Safaris værktøjslinje og vælge Tilpas værktøjslinje, og træk knappen AdBlock ud af værktøjslinjen. Du kan vise den igen ved at trække det tilbage til værktøjslinjen."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -922,251 +609,43 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Eller indtast et URL:"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"eller Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Du benytter en gammel version af Safari. Hent den seneste version for og benytte AdBlock-værktøjslinjen, for at afbryde AdBlock midlertidigt, godkende hjemmesider, og rapportere reklamer. <a>Opdatér nu</a>."
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Abonnér"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" --Vælg sprog-- "
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Betal det du vil!"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Klik på Safari-menuen &rarr; Indstillinger &rarr; Udvidelser."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Stop blokeringen af reklamer:"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Den mest populære udvidelse til Chrome, med over 40 millioner brugere! Blokerer reklamer overalt på internettet."
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Vises reklamen stadig?"
-  },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Support"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bulgarsk"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Ønsker du at se i AdBlocks maskinrum?"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Ingen kendt malware fundet."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Fejl!"
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filteret, som kan ændres under Indstillinger:"
-  },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"Redigér dine filtre manuelt:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italiensk"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Hvad er der af nye ting i den seneste udgivelse? Tjek <a style='cursor:pointer;'>ændringsloggen</a> ud."
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovakisk"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Vises reklamen også i den browser?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Benyt ikke på denne side"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokér kun reklamer på disse domæner:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Lad os få det at vide på vores <a>supportside</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock er midlertidigt afbrudt."
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Du har overskredet den plads som AdBlock har til rådighed. Venligst fjern abonnement fra nogle af filterlisterne!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Vi kan desværre ikke blokere reklamer i Flash og andre plugins endnu. Vi afventer at dette understøttes af browseren og WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, du kan stadig blokere reklamen for dig selv på siden Indstillinger. Tak!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Generelt"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"adnet"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Intet filter valgt!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"ukendt"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finsk"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"lyd/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japansk"
+    "message":"Redigér deaktiverede filtre:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Dette er et filterlisteproblem. Rapporter det her: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Fejl ved hentning af filter!"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blokeret element:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Vis links til filterlisterne"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Bemærk: din rapport kan blive offentligt tilgængelig. Hav det i tankerne, inden du inkluderer personlige informationer."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Kun på engelsk"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Annullér"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Hjælp med at sprede ordet!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Du kan bruge skyderen(e) nedenfor til og bestemme nøjagtig hvilke sider AdBlock ikke skal benyttes  på."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Tjek i Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Abonnér til denne filterliste, og prøv så igen: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"For at rapportere annoncer, skal du have internetforbindelse."
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Har du et spørgsmål eller en ny idé?"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Ja"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Spansk"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Det ser godt ud"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (anbefalet)"
+  "typepage":{
+    "description":"A resource type",
+    "message":"side"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1176,5 +655,566 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Vises reklamen stadig?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"adnet"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Klik på denne: <a>Opdatér mine filtre!</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Italiensk"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"For at skjule knappen, gå til opera://extensions og markér 'Skjul i værktøjslinjen'. Du kan vise det igen ved at afmarkére denne mulighed."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Noget gik galt, da vi forsøgte at tjekke for nye opdateringer."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Klik på Safari-menuen &rarr; Indstillinger &rarr; Udvidelser."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Side:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Genindlæs siden med reklamen."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Fjern abonnement."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"lyd/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Lettisk"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blokér en reklame på denne side"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokér!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Stop blokeringen af reklamer:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Tillad whitelisting af bestemte YouTube-kanaler"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Hvilket sprog er siden i?"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Raportér en reklame på denne side"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Fjern fra liste"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Vi kan desværre ikke blokere reklamer i Flash og andre plugins endnu. Vi afventer at dette understøttes af browseren og WebKit."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Du kan bruge skyderen(e) nedenfor til og bestemme nøjagtig hvilke sider AdBlock ikke skal benyttes  på."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"skjuler"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Vises reklamen i eller før film, eller et andet plugin, såsom et Flash-spil?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Russisk og ukrainsk"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spansk"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokér denne reklame"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Pas på: dette filter blokerer alle $elementtype$ elementer på siden!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nej"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Aktivér AdBlock på denne side"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filteret, som kan ændres under Indstillinger:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Vis antal reklamer blokeret i AdBlock-knappen"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Fejl!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Afbryd AdBlock midlertidigt"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Abonnér til denne filterliste, og prøv så igen: $list_title$",
+    "placeholders":{
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Engelsk"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Tilføj muligheder til højrekliksmenuen"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, du kan stadig blokere reklamen for dig selv på siden Indstillinger. Tak!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Russisk"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Hvis du ser en reklame, skal du ikke lave en fejlrapport, men en <a>annoncerapport</a> istedet!"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Du benytter en gammel version af Safari. Hent den seneste version for og benytte AdBlock-værktøjslinjen, for at afbryde AdBlock midlertidigt, godkende hjemmesider, og rapportere reklamer. <a>Opdatér nu</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (beskyttelse af privatliv)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ vil være $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Eller indtast et URL:"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Færdig!"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Tilføj filtre for et andet sprog: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"INDLÆSER..."
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Højreklik på en reklame på en side for at blokere den -- eller blokér den manuelt her."
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Malwarebeskyttelse"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Vis debuginformationer i Console Log (vil gøre AdBlock langsomere)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Installér Firefox $chrome$ hvis du ikke har det.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Du har overskredet den plads som AdBlock har til rådighed. Venligst fjern abonnement fra nogle af filterlisterne!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Den mest populære udvidelse til Chrome, med over 40 millioner brugere! Blokerer reklamer overalt på internettet."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Fundet en fejl?"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Filterlister"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Jeg er erfaren bruger, vis mig de avancerede indstillinger"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Kinesisk"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filteret er ugyldigt: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Abonnér på filterliste..."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Det blev fundet $matchcount$ gange på denne side.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"opdateret for 1 time siden"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" --Vælg sprog-- "
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Skyd glideren indtil reklamen er skjult korrekt på siden, og det blokerede element ser brugbart ud."
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesisk"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"billede"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Redigér"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Fejl ved hentning af filter!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ i alt",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Support"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blokér en reklame ud fra dens URL"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Annullér"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Husk at gemme!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Version $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Formålet med dette spørgsmål er for at fastslå, hvem der bør modtage din rapportering. Hvis du besvarer spørgsmålet forkert vil rapporten blive sendt til de forkerte folk, og måske blive ignoreret."
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Liste over reklamefiltre"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Kildekoden er <a>frit tilgængelig</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Hollandsk"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Vælg venligst det korrekte filter nedenfor, og klik OK"
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Ja"
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Det blev kun fundet <b>1</b> gang på siden."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Ryd op i denne liste"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"opdateret for $hours$ timer siden",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Tilbage"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock-indstillinger"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Abonnér ikke på flere end du behøver -- hvert abonnement sløver en lille bitte smule. Credits og flere lister kan findes <a>her (engelsk)</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Tjekke om der er nye opdateringer (dette bør ikke tage lang tid)..."
+  },
+  "filterhungarian":{
+    "description":"language",
+    "message":"Ungarsk"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domæne for side hvor blokeringen skal virke"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"opdateret"
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Har vores hold spurgt efter debug-info? Klik <a href='#' id='debug'>her</a> for at få det!"
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"opdateret for $minutes$ minutter siden",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Tjekkisk"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Svensk"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock-support"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Type"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"opdateret for 1 minut siden"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - klik for at se mere"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Benyt ikke AdBlock på..."
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,1323 +1,1137 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Screenshot anhängen:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Keine bekannte Malware gefunden."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Abonnieren Sie in diesem Browser dieselben Filterlisten, die Sie hier abonniert haben."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Rufen Sie die Seite mit Werbung im gewählten Browser auf."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Schwedisch"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Weitere Werbung entfernen:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"russisch"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Abonnement beendet."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"chinesisch"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocial Filterliste (entfernt Buttons von sozialen Netzwerken)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Haben Sie Werbung auf einer Webseite entdeckt? Wir werden Ihnen helfen den richtigen Ort zu finden um diese zu melden!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Anzahl geblockter Werbung am AdBlock Button anzeigen"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Der Quellcode ist <a>frei verfügbar</a>."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"vor 1 Minute aktualisiert"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Filterlistenabruf fehlgeschlagen!"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Ihr Computer ist möglicherweise mit Malware infiziert.  Klicken Sie <a>hier</a> für weitere Informationen."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Werbung über ihre Adresse entfernen"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Diesen Button ausblenden"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Aktualisierungen werden automatisch abgerufen. Zusätzlich können Sie auch <a>jetzt aktualisieren</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~seite1.de|~seite2.com|~news.seite3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estnisch"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Typ"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Es ist ein Update für AdBlock verfügbar! Klicken Sie $here$ um AdBlock zu aktualisieren. <br> Hinweis: Um Updates automatisch zu erhalten, klicken Sie auf Safari > Einstellungen ... > Erweiterungen > Updates <br> und aktivieren die Option 'Updates automatisch installieren'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Mehr Informationen"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Abonnieren Sie nicht mehr Filterlisten, als Sie wirklich benötigen -- jede weitere Filterliste verlangsamt den Browser etwas! Credits und weitere Filterlisten finden Sie <a>hier</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Diese AdBlock Funktion funktioniert auf dieser Seite nicht, da die Seite eine veraltete Technologie nutzt. Sie können Ressourcen manuell unter \"AdBlock anpassen\" in den AdBlock Einstellungen aktivieren und deaktivieren."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"polnisch"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Erfahren Sie mehr über das \"Akzeptable Werbung-Programm\"."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"vor $seconds$ Sekunden aktualisiert",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"ungarisch"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Achtung: Ihr Bericht kann öffentlich zugänglich sein. Bitte beachten Sie dies, bevor Sie etwas Privates in Ihren Bericht einfügen."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Bitte deaktivieren Sie einige Filterlisten. Mehr Informationen dazu finden Sie in den AdBlock-Einstellungen."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Filterherkunft:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"AdBlock ist durch eine Ihrer Filterlisten auf dieser Seite deaktiviert."
-  },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Isländisch"
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Warnung: kein Filter angegeben!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock ist auf dieser Seite deaktiviert."
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Sollten Sie Werbung angezeigt bekommen, senden Sie bitte keinen Fehlerbericht sondern <a>melden Sie Werbung hier</a>!"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Werbung auf <i>allen</i> Seiten anzeigen, außer auf diesen Domains..."
+    "message":"Haben Sie eine Frage oder eine Idee für AdBlock?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Einstellungen"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Anzahl entfernter Werbung:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Filterlisten für andere Sprachen hinzufügen: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Klicken Sie auf die Werbung und dieser Assistent wird Ihnen dabei helfen, die Werbung zu entfernen."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Toll! Alles klar!"
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"nichtgelistete Sprache"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock Support"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"AdBlock anpassen"
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Speichern der hochgeladenen Datei fehlgeschlagen."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Bitte geben Sie einen korrekten Filter ein und bestätigen Sie mit OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Schritt 1: Herausfinden, was entfernt werden soll"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"dänisch"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (empfohlen)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ auf dieser Seite",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Subframe"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"vor 1 Stunde aktualisiert"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"koreanisch"
+    "message":"polnisch"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"oder Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Name"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Die beliebteste Chrome-Erweiterung, mit über 40 Millionen Nutzern!  Entfernt Werbung im ganzen Internet."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Zeige alle Anfragen"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Nicht überprüfen"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Ja"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Selbst erstellte Filter für diese Domain wieder entfernen"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Eigene Filter"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"AdBlock pausieren"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Sind Sie sicher, dass Sie die $title$ Filterliste abonnieren möchten?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Wo ist genau auf dieser Seite ist die Werbung? Wie sieht sie aus?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"oder AdBlock für Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"css"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Content Blocking Filterlimit überschritten"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Suche nach Werbung...<br/><br/><i>Dies dauert nur einen kurzen Moment.</i>"
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domain oder Adresse, für die AdBlock deaktiviert sein soll"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skript"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ gesamt",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nein"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Etwas ist schief gelaufen. Es wurden keine Ressourcen übermittelt. Diese Seite wird sich nun schließen. Versuchen Sie die Webseite neu zu laden."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"ukrainisch"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"vor $minutes$ Minuten aktualisiert",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Die \"Akzeptable Werbung\"-Filterliste ist nicht länger abonniert."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Malware-Schutz"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Speichern"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Achtung: Sie werden auf allen anderen Seiten Werbung sehen!<br>Dieser Filter überschreibt alle anderen Filter für diese Seiten."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Diese Benachrichtigungen deaktivieren"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Filterliste abonnieren..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Sie benutzen eine veraltete Version von AdBlock. Bitte rufen Sie die <a href='#'>Erweiterungen-Seite</a> auf, aktivieren Sie den \"Entwicklermodus\" und klicken Sie auf \"Erweiterungen jetzt aktualisieren\"."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock-Einstellungen"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Überprüfung auf Malware die Werbung einfügen könnte:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Debug-Berichte in der Fehlerkonsole anzeigen (verlangsamt AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Sie haben die Dateigrößenbeschränkung von Dropbox überschritten. Bitte entfernen Sie einige Einträge aus Ihrer benutzerdefinierten Filterliste, und versuchen Sie es erneut."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"AdBlock wieder starten"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Übergangslösung für nicht startende Videos auf Hulu.com aktivieren (erfordert Neustart des Browsers)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"zutreffendes CSS"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Ausnahme hinzufügen"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Deaktivieren Sie alle Erweiterungen außer AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Übersetzung von:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"LÄDT..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Klicken Sie mit einem Rechtsklick auf Seiten mit Werbung, um diese zu entfernen -- oder entfernen Sie die Werbung hier manuell."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Hinweis: Whitelisting (Werbung zulassen auf) einer Seite oder Webseite wird nicht unterstützt wenn Safari Content Blocking aktiviert ist."
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Wir werden Sie nur im Falle von fehlenden Informationen kontaktieren."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Deaktivierte Filter bearbeiten:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Safari Content Blocking aktivieren"
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Überprüfung der \"Akzeptable Werbung\"-Filter:"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Um den Button auszublenden klicken Sie mit einem Rechtsklick auf die Safari Symbolleiste, klicken auf \"Symbolleiste anpassen ...\" und ziehen dann den AdBlock Button aus der Symbolleiste. Um den Button wieder einzublenden ziehen Sie den Button einfach wieder zurück auf die Symbolleiste."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Bei der Bearbeitung Ihrer Anfrage ist ein Fehler aufgetreten."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"seite"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Fertig! Die Seite mit der Werbung wurde neu geladen. Bitte überprüfen Sie, ob die Werbung nun von der Seite entfernt ist. Kommen Sie dann zurück auf diese Seite und beantworten Sie die untenstehende Frage."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"...oder geben Sie eine Filterlistenadresse ein:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Sie benutzen eine veraltete Version von Safari. Laden Sie sich die neueste Version von Safari herunter um mit dem AdBlock Toolbar-Button AdBlock pausieren, Ausnahmeregeln für Webseiten erstellen und Werbung melden zu können. <a>Jetzt herunterladen</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Klicken Sie auf Safari (Menübar) &rarr; Einstellungen ... &rarr; Erweiterungen."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"AdBlock auf Seiten deaktivieren:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Entfernen!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Wird die Werbung noch angezeigt?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"bulgarisch"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Gut! Lassen Sie uns nun herausfinden welche Erweiterung das Problem verursacht. Aktivieren Sie eine Erweiterung nach der anderen. Die Erweiterung die die Werbung wieder erscheinen lässt muss deinstalliert werden um die Werbung endgültig zu entfernen."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Fehlgeschlagen!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Filter manuell bearbeiten:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"italienisch"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Typ"
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Nicht überprüfen"
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Achtung: Sollten Sie hier einen Fehler machen, können viele andere Filter sowie die Filter der Filterlisten beschädigt werden!<br/>Lesen Sie zuerst das <a>Filtersyntax-Tutorial</a>, um zu lernen, wie man eigene Black- und Whitelistfilter erstellt und hinzufügt."
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Filterlisten abonnieren"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Sie können dies wieder aktivieren und die Webseiten die Sie mögen unterstützen indem Sie weiter unten \"Einige nicht aufdringliche Werbung zulassen\" aktivieren."
-  },
   "checkinfirefox_5":{
     "description":"Instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Erscheint die Werbung auch in diesem Browser?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Ausnahmeregel für diese Seite hinzufügen"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Litauisch"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Teilen Sie uns Ihre Idee oder Ihre Frage auf unserer <a>Support-Seite</a> mit."
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock ist pausiert."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Werbung in Flash oder anderen Plugins kann (noch) nicht entfernt werden. Es wird noch auf die Unterstützung durch den Browser und WebKit gewartet."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Die Änderungen der aktuellen Version von AdBlock können im <a style='cursor:pointer;'>Changelog</a> eingesehen werden."
   },
   "aamessageadreport":{
     "description":"Acceptable Ads message on ad report page",
     "message":"Falls Sie Werbung wie diese nicht angezeigt bekommen möchten, dann sollten Sie möglicherweise die \"Akzeptable Werbung\"-Filter deaktiviert lassen."
   },
-  "typeother":{
-    "description":"A resource type",
-    "message":"sonstiges"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Warnung: Kein Filter angegeben!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"unbekannt"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"japanisch"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Einige nicht aufdringliche Werbung zulassen"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Abbrechen"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Sie können hier genau einstellen, auf welchen Seiten AdBlock deaktiviert sein soll."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"In Firefox $chrome$ überprüfen",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Um Werbung zu melden muss eine Internetverbindung bestehen."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (empfohlen)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Werbung melden"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Filterlisten für Werbung"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Wie?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Zulassen von Werbung auf bestimmten YouTube-Kanälen aktivieren"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Drittanbieter"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (entfernt störende/lästige Inhalte auf Webseiten)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - für weitere Optionen bitte klicken"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"vor $hours$ Stunden aktualisiert",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"russisch und ukrainisch"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"AdBlock erlauben anonyme Filterlistennutzung und andere anonyme Nutzungsdaten zu sammeln"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Die zuvor deaktivierten Erweiterungen wurden wieder aktiviert."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"griechisch"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"slowakisch"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videos und Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Welches Merkmal könnte diese Werbung bei jedem Besuch der Seite haben?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"AdBlock auf dieser Seite aktivieren"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Zurück"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Die Filterlisten entfernen die meiste Werbung im Internet.  Sie können außerdem:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Werbung auf einer Seite oder einer bestimmten Adresse anzeigen"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Dies trifft auf <b>1</b> Element dieser Seite zu."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Teil einer Seite ausblenden"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Werbung auf $name$ Kanal zulassen",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Allgemeine Einstellungen"
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock wird auf allen Seiten deaktiviert, auf die folgendes zutrifft:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"AdBlock hat keine Filterliste für diese Sprache integriert.<br/>Bitte versuchen Sie $link$ eine passende Liste zu finden, die für diese Sprache ausgelegt ist oder entfernen Sie die Werbung im Tab 'Anpassen' der AdBlock-Einstellungen.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Abonnieren"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Erweiterte Einstellungen anzeigen (für erfahrene Nutzer)"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"spanisch"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Geladen auf der Seite mit dieser Domain:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Aktualisieren Sie Ihre Filterlisten: <a>Filterlisten aktualisieren</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Je mehr Filterlisten Sie abonnieren, desto langsamer läuft AdBlock. Zuviele Filterlistenabonnements können sogar zum Browsercrash auf einigen Seiten führen. Klicken Sie auf OK, um diese Liste trotzdem zu abonnieren."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Letzter Schritt: Was macht dies zu Werbung?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Dies trifft auf $matchcount$ Elemente dieser Seite zu.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Eine Liste der Mitwirkenden von AdBlock finden Sie unter <a>\"Mitwirkende\"</a>."
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesisch"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Türkisch"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Werbung entfernen"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Benutzerdefinierte Filterlisten"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"Frame-URL: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Der Zweck dieser Frage ist herauszufinden wer Ihren Bericht erhalten soll. Sollten Sie diese Frage falsch beantworten wird der Bericht an die falschen Personen gesendet und möglicherweise ignoriert."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"AdBlock-Rechtsklickmenü aktivieren"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"Selektor"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Diese Werbung entfernen"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Hat unser Team Sie nach Debug-Informationen gefragt? Klicken Sie  <a href='#' id='debug'>hier</a> um die Informationen anzuzeigen."
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"AdBlock deaktivieren auf..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Werbung zu melden ist freiwillig. Es hilft Anderen da Filterlisten-Betreiber die Werbung für alle anderen Benutzer blocken können. Es ist in Ordnung falls Sie dies derzeit nicht tun möchten. Schließen Sie einfach diese Seiten und <a>entfernen Sie die Werbung</a> nur für Sie selbst."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Ausgeblendetes Element"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Seite neu laden"
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"seite"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"niederländisch"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Der Dateiname ist zu lang. Bitte geben Sie Ihrer Datei einen kürzeren Namen."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Vergessen Sie nicht zu speichern!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Updates werden abgefragt (dauert nur wenige Sekunden)..."
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Allgemein"
+    "message":"Litauisch"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Bitte abonnieren Sie diese Filterliste und versuchen Sie es erneut: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Soll AdBlock Sie benachrichtigen falls Malware entdeckt wird?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Ihr Computer ist möglicherweise mit Malware infiziert.  Klicken Sie <a>hier</a> für weitere Informationen."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Anzahl geblockter Werbung im AdBlock Menü anzeigen"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Werbung auf einer Seite oder einer bestimmten Adresse anzeigen"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Domain:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock-Standardfilter (empfohlen)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Lettisch"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Stellen Sie sicher, dass Sie die richtige Sprach-Filterliste(n) benutzen:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"zutreffendes CSS"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Um den Button auszublenden, gehen Sie auf opera://extensions, und aktivieren Sie die Option \"In der Symbolleiste ausblenden\". Um den Button wieder einzublenden, deaktivieren Sie die Option."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Nicht sicher?</b> Klicken Sie einfach auf 'Entfernen!'."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Zutreffender Filter"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Abrufen... bitte warten."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Alle Ressourcen"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"Keine Updates für AdBlock verfügar."
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"AdBlock auf Seiten dieser Domain deaktivieren"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"israelisch"
+    "message":"slowakisch"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Verschieben Sie den Regler so lange nach rechts, bis die Werbung komplett entfernt ist und der restliche Teil der Seite noch normal aussieht."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"URLs mit diesem Text blockieren"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Die Zahl der Filterlistenregeln überschreitet das Limit von 50.000 und wurde automatisch reduziert. Bitte deaktivieren Sie einige Filterlisten oder deaktivieren Sie Safari Content Blocking!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"vor 1 Tag aktualisiert"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Acceptable Ads (empfohlen)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Klicken Sie hier: <a>\"Akzeptable Werbung\" deaktivieren</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Version $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Installieren Sie Adblock Plus für Firefox $chrome$, falls Sie es noch nicht installiert haben.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"aus Liste entfernen"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"AdBlock hat keine Filterliste für diese Sprache integriert.<br/>Bitte versuchen Sie $link$ eine passende Liste zu finden, die für diese Sprache ausgelegt ist oder entfernen Sie die Werbung im Tab 'Anpassen' der AdBlock-Einstellungen.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Datei ist keine Bilddatei. Bitte laden Sie eine Datei hoch die mit .png, .gif, oder .jpg endet."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Warum senden Sie uns nicht einfach einen <a>Fehlerbericht</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"verborgen"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Filterlisten"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Frame-Domain: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Klicken Sie auf die Werbung und dieser Assistent wird Ihnen dabei helfen, die Werbung zu entfernen."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Top-Frame"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"css"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"unbekannt"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"AdBlock ist durch eine Ihrer Filterlisten auf dieser Seite deaktiviert."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Drittanbieter"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Warnung: Kein Filter angegeben!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"griechisch"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Sie benutzen eine veraltete Version von AdBlock. Bitte rufen Sie die <a href='#'>Erweiterungen-Seite</a> auf, aktivieren Sie den \"Entwicklermodus\" und klicken Sie auf \"Erweiterungen jetzt aktualisieren\"."
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Name"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Übergangslösung für nicht startende Videos auf Hulu.com aktivieren (erfordert Neustart des Browsers)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Warnung: kein Filter angegeben!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Eigene Filter"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Haben Sie Werbung auf einer Webseite entdeckt? Wir werden Ihnen helfen den richtigen Ort zu finden um diese zu melden!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estnisch"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"AdBlock anpassen"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"bulgarisch"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Ressource mit Ausnahmeregel"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Content Blocking Filterlimit überschritten"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"AdBlock deaktivieren auf..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"URLs mit diesem Text blockieren"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Schließen"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"In Firefox $chrome$ überprüfen",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Letzter Schritt: Was macht dies zu Werbung?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Sollten Sie Werbung angezeigt bekommen, senden Sie bitte keinen Fehlerbericht sondern <a>melden Sie Werbung hier</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"koreanisch"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Warum senden Sie uns nicht einfach einen <a>Fehlerbericht</a>?"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"finnisch"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skript"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"ukrainisch"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Keine bekannte Malware gefunden."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Bitte deaktivieren Sie einige Filterlisten. Mehr Informationen dazu finden Sie in den AdBlock-Einstellungen."
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Eine Liste der Mitwirkenden von AdBlock finden Sie unter <a>\"Mitwirkende\"</a>."
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"hier"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Seite neu laden"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"In welcher Sprache ist die Seite verfasst?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock ist pausiert."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"AdBlock wieder starten"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Suche nach Werbung...<br/><br/><i>Dies dauert nur einen kurzen Moment.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock ist auf dieser Seite deaktiviert."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Abonnieren Sie in diesem Browser dieselben Filterlisten, die Sie hier abonniert haben."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Werbung entfernen"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Achtung: Sie werden auf allen anderen Seiten Werbung sehen!<br>Dieser Filter überschreibt alle anderen Filter für diese Seiten."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Es ist ein Update für AdBlock verfügbar! Klicken Sie $here$ um AdBlock zu aktualisieren. <br> Hinweis: Um Updates automatisch zu erhalten, klicken Sie auf Safari > Einstellungen ... > Erweiterungen > Updates <br> und aktivieren die Option 'Updates automatisch installieren'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Fertig!"
   },
-  "headerresource":{
-    "description":"Resource list page: title of a column",
-    "message":"Ressource"
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock-Standardfilter (empfohlen)"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Werbung auf dieser Seite entfernen"
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Typ"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Stellen Sie sicher, dass Ihre Filterlisten auf aktuellem Stand sind:"
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Mehr Informationen"
   },
-  "lang_english":{
+  "filterjapanese":{
     "description":"language",
-    "message":"englisch"
+    "message":"japanisch"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Öffnen Sie Erweiterungen-Seite um die zuvor deaktivierten Erweiterungen wieder zu aktivieren."
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Filterherkunft:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domain der zutreffenden Seite"
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Filterlisten abonnieren"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Domain:"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Filterlisten für andere Sprachen hinzufügen: "
+  },
+  "headerfilter":{
+    "description":"Resource list page: title of a column",
+    "message":"Zutreffender Filter"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Die Filterlisten entfernen die meiste Werbung im Internet.  Sie können außerdem:"
+  },
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Um den Button auszublenden klicken Sie mit einem Rechtsklick auf die Safari Symbolleiste, klicken auf \"Symbolleiste anpassen ...\" und ziehen dann den AdBlock Button aus der Symbolleiste. Um den Button wieder einzublenden ziehen Sie den Button einfach wieder zurück auf die Symbolleiste."
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Sie haben die Dateigrößenbeschränkung von Dropbox überschritten. Bitte entfernen Sie einige Einträge aus Ihrer benutzerdefinierten Filterliste, und versuchen Sie es erneut."
+  },
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Abonnieren"
+  },
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Hinweis: Whitelisting (Werbung zulassen auf) einer Seite oder Webseite wird nicht unterstützt wenn Safari Content Blocking aktiviert ist."
+  },
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Entferntes Element:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"seite"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"sonstiges"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Aktualisieren Sie Ihre Filterlisten: <a>Filterlisten aktualisieren</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Ausgeblendetes Element"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Um den Button auszublenden, gehen Sie auf opera://extensions, und aktivieren Sie die Option \"In der Symbolleiste ausblenden\". Um den Button wieder einzublenden, deaktivieren Sie die Option."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Seite:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Haben Sie einen Fehler gefunden?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Entfernen!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Zulassen von Werbung auf bestimmten YouTube-Kanälen aktivieren"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Werbung in Flash oder anderen Plugins kann (noch) nicht entfernt werden. Es wird noch auf die Unterstützung durch den Browser und WebKit gewartet."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Arabisch"
+    "message":"ungarisch"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Diese Werbung entfernen"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"AdBlock auf dieser Seite aktivieren"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Anzahl geblockter Werbung am AdBlock Button anzeigen"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Fehlgeschlagen!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"AdBlock pausieren"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"tschechisch"
+    "message":"englisch"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Zahlen Sie, was Sie möchten!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"AdBlock-Rechtsklickmenü aktivieren"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Wollen Sie wissen wer und was hinter AdBlock steckt?"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"'Adblock Warning Removal'-Filterliste (entfernt Warnungen über die Benutzung von Werbe-Blockern)"
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Ungültige Filterlistenadresse. Dieser Filterlisteneintrag wird gelöscht."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"seite"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Bearbeiten"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Sind Sie sicher, dass Sie $count$ Filter entfernen wollen, die Sie für $host$ erstellt haben?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Haben Sie eine Frage oder eine Idee für AdBlock?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legende: "
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>Oder</b> klicken Sie einfach auf diesen Button um alles oben genannte zu tun: <a>Alle anderen Erweiterungen deaktivieren</a>"
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Mehr über Malware erfahren"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"vor $minutes$ Minuten aktualisiert",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Screenshot anhängen:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"rumänisch"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Deaktivierte Filter bearbeiten:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Subframe"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Laden Sie die Seite mit der Werbung neu."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Safari Content Blocking aktivieren"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Installieren Sie Firefox $chrome$, falls Sie es noch nicht installiert haben.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Filterlisten"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Datei ist zu groß. Bitte stellen Sie sicher, dass Ihre Datei kleiner als 10 MB ist."
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Erweiterte Einstellungen anzeigen (für erfahrene Nutzer)"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"chinesisch"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Der Filter ist ungültig: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Filterliste abonnieren..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Öffnen Sie Erweiterungen-Seite um die zuvor deaktivierten Erweiterungen wieder zu aktivieren."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Diese Benachrichtigungen deaktivieren"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Türkisch"
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"vor 1 Stunde aktualisiert"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesisch"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"grafik"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ gesamt",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Abbrechen"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Vergessen Sie nicht zu speichern!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"Selektor"
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Isländisch"
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Sind Sie sicher, dass Sie die $title$ Filterliste abonnieren möchten?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Werbung nur auf diesen Seiten entfernen:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Geladen auf der Seite mit dieser Domain:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Die zuvor deaktivierten Erweiterungen wurden wieder aktiviert."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Filter überprüfen und fehlerhafte Filter entfernen"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Teilen Sie es mit ihren Freunden!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock Updates"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"'Adblock Warning Removal'-Filterliste (entfernt Warnungen über die Benutzung von Werbe-Blockern)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock-Einstellungen"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Bei der Bearbeitung Ihrer Anfrage ist ein Fehler aufgetreten."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Abonnieren Sie nicht mehr Filterlisten, als Sie wirklich benötigen -- jede weitere Filterliste verlangsamt den Browser etwas! Credits und weitere Filterlisten finden Sie <a>hier</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Updates werden abgefragt (dauert nur wenige Sekunden)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"jetzt aktualisiert"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Klicken Sie mit einem Rechtsklick auf Seiten mit Werbung, um diese zu entfernen -- oder entfernen Sie die Werbung hier manuell."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Überprüfung auf Malware die Werbung einfügen könnte:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock Support"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Typ"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Verschieben Sie den Regler so lange nach rechts, bis die Werbung komplett entfernt ist und der restliche Teil der Seite noch normal aussieht."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"vor 1 Minute aktualisiert"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Blockierte Ressource"
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"dänisch"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Überprüfung der \"Akzeptable Werbung\"-Filter:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Sie können dies wieder aktivieren und die Webseiten die Sie mögen unterstützen indem Sie weiter unten \"Einige nicht aufdringliche Werbung zulassen\" aktivieren."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Abrufen... bitte warten."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Ungültige Filterlistenadresse. Dieser Filterlisteneintrag wird gelöscht."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Allgemeine Einstellungen"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Entfernen Sie bei allen Erweiterungen das Häkchen der \"Aktiviert\"-Checkbox <b>außer</b> bei AdBlock.  <b>Lassen Sie AdBlock aktiviert</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Rufen Sie die Seite mit Werbung im gewählten Browser auf."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Werbung auf <i>allen</i> Seiten anzeigen, außer auf diesen Domains..."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Um den Button zu verbergen, klicken Sie mit einem Rechtsklick auf den Button und wählen Sie 'Schaltfläche verbergen'. Der Button kann unter chrome://chrome/extensions wieder aktiviert werden."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"israelisch"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Diese AdBlock Funktion funktioniert auf dieser Seite nicht, da die Seite eine veraltete Technologie nutzt. Sie können Ressourcen manuell unter \"AdBlock anpassen\" in den AdBlock Einstellungen aktivieren und deaktivieren."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"tschechisch und slowakisch"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Alle anderen Erweiterungen wurden deaktiviert. Die Seite mit Werbung wird nun neu geladen. Eine Sekunde bitte."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Andere Filterlisten"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"französisch"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Aktualisierungen werden automatisch abgerufen. Zusätzlich können Sie auch <a>jetzt aktualisieren</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Entferntes Element:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Zeige alle Anfragen"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktives objekt"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Je mehr Filterlisten Sie abonnieren, desto langsamer läuft AdBlock. Zuviele Filterlistenabonnements können sogar zum Browsercrash auf einigen Seiten führen. Klicken Sie auf OK, um diese Liste trotzdem zu abonnieren."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Toll! Alles klar!"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock Updates"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Erfahren Sie mehr über das \"Akzeptable Werbung-Programm\"."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Soll AdBlock Sie benachrichtigen falls Malware entdeckt wird?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"jetzt aktualisiert"
+    "message":"vor 1 Tag aktualisiert"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"Frame-URL: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"deutsch"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Der Dateiname ist zu lang. Bitte geben Sie Ihrer Datei einen kürzeren Namen."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"vor $seconds$ Sekunden aktualisiert",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Ausnahmeregel für diese Seite hinzufügen"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Teilen Sie uns Ihre Idee oder Ihre Frage auf unserer <a>Support-Seite</a> mit."
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Fertig! Die Seite mit der Werbung wurde neu geladen. Bitte überprüfen Sie, ob die Werbung nun von der Seite entfernt ist. Kommen Sie dann zurück auf diese Seite und beantworten Sie die untenstehende Frage."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Alle Ressourcen"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Werbung auf $name$ Kanal zulassen",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Ressource"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Anzahl geblockter Werbung im AdBlock Menü anzeigen"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Werbung melden"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Wie?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"AdBlock auf Seiten dieser Domain deaktivieren"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Benutzerdefinierte Filterlisten"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Weitere Werbung entfernen:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domain oder Adresse, für die AdBlock deaktiviert sein soll"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Die \"Akzeptable Werbung\"-Filterliste ist nicht länger abonniert."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (entfernt störende/lästige Inhalte auf Webseiten)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock hat einen Download von einer Website blockiert die für die Verbreitung von Malware bekannt ist."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Speichern"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Nicht sicher?</b> Klicken Sie einfach auf 'Entfernen!'."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Der Zweck dieser Frage ist herauszufinden wer Ihren Bericht erhalten soll. Sollten Sie diese Frage falsch beantworten wird der Bericht an die falschen Personen gesendet und möglicherweise ignoriert."
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Sieht gut aus!"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"AdBlock erlauben anonyme Filterlistennutzung und andere anonyme Nutzungsdaten zu sammeln"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Um Werbung zu melden muss eine Internetverbindung bestehen."
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Filterlisten für Werbung"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"vor $days$ Tagen aktualisiert",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"interaktives objekt"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Welches Merkmal könnte diese Werbung bei jedem Besuch der Seite haben?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Anzahl entfernter Werbung:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arabisch"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Selbst erstellte Filter für diese Domain wieder entfernen"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Filter manuell bearbeiten:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Schritt 1: Herausfinden, was entfernt werden soll"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Bitte geben Sie einen korrekten Filter ein und bestätigen Sie mit OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Übersetzung von:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"Keine Updates für AdBlock verfügar."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"nur auf Englisch"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>Oder</b> klicken Sie einfach auf diesen Button um alles oben genannte zu tun: <a>Alle anderen Erweiterungen deaktivieren</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Die Änderungen der aktuellen Version von AdBlock können im <a style='cursor:pointer;'>Changelog</a> eingesehen werden."
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (Privatsphärenschutz)"
+    "message":"Antisocial Filterliste (entfernt Buttons von sozialen Netzwerken)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Werbung auf dieser Seite melden"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Malware-Schutz"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Filter überprüfen und fehlerhafte Filter entfernen"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock wird auf allen Seiten deaktiviert, auf die folgendes zutrifft:"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"deutsch"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Sie haben den Speicherplatz, der AdBlock zur Verfügung steht, überschritten. Bitte beenden Sie einige Filterlistenabonnements!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Achtung: Dieser Filter entfernt alle $elementtype$-Elemente auf dieser Seite!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"hier"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"E-Mail-Adresse"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"In welcher Sprache ist die Seite verfasst?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Wollen Sie wissen wer und was hinter AdBlock steckt?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Sind Sie sicher, dass Sie $count$ Filter entfernen wollen, die Sie für $host$ erstellt haben?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"grafik"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Teil einer Seite ausblenden"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Um den Button zu verbergen, klicken Sie mit einem Rechtsklick auf den Button und wählen Sie 'Schaltfläche verbergen'. Der Button kann unter chrome://chrome/extensions wieder aktiviert werden."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Allgemein"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"rumänisch"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"oder AdBlock für Chrome"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Bei der Überprüfung auf Updates ist ein Fehler aufgetreten."
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videos und Flash"
   },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Alle anderen Erweiterungen wurden deaktiviert. Die Seite mit Werbung wird nun neu geladen. Eine Sekunde bitte."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Ressource mit Ausnahmeregel"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Gut! Lassen Sie uns nun herausfinden welche Erweiterung das Problem verursacht. Aktivieren Sie eine Erweiterung nach der anderen. Die Erweiterung die die Werbung wieder erscheinen lässt muss deinstalliert werden um die Werbung endgültig zu entfernen."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1329,182 +1143,408 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"tschechisch und slowakisch"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"oder Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Frame-Typ:"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~seite1.de|~seite2.com|~news.seite3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Sprache auswählen --"
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Installieren Sie Adblock Plus für Firefox $chrome$, falls Sie es noch nicht installiert haben.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Blockierte Ressource"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Erscheint die Werbung vor oder in einem Video oder einem anderen Plugin, wie z.B. einem Flash-Spiel?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ wird $value$ sein",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filter (kann in den AdBlock-Einstellungen bearbeitet werden):"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Der folgende Filter: <br/> $filter$ <br/> hat einen Fehler: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Schließen"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Werbung nur auf diesen Seiten entfernen:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Sie haben den Speicherplatz, der AdBlock zur Verfügung steht, überschritten. Bitte beenden Sie einige Filterlistenabonnements!"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Der Filter ist ungültig: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"Sie können die Werbung auch im Tab 'Anpassen' der AdBlock-Einstellungen entfernen. Danke!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Senden"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"finnisch"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Datei ist zu groß. Bitte stellen Sie sicher, dass Ihre Datei kleiner als 10 MB ist."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Zahlen Sie, was Sie möchten!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Dies ist ein Filterlistenproblem. Bitte melden Sie es hier: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Entfernen Sie bei allen Erweiterungen das Häkchen der \"Aktiviert\"-Checkbox <b>außer</b> bei AdBlock.  <b>Lassen Sie AdBlock aktiviert</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Achtung: Ihr Bericht kann öffentlich zugänglich sein. Bitte beachten Sie dies, bevor Sie etwas Privates in Ihren Bericht einfügen."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Links zu den Filterlisten anzeigen"
+  "filteritalian":{
+    "description":"language",
+    "message":"italienisch"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"nur auf Englisch"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Teilen Sie es mit ihren Freunden!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Wird die Werbung noch angezeigt?"
   },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"E-Mail-Adresse"
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Stellen Sie sicher, dass Sie die richtige Sprach-Filterliste(n) benutzen:"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock hat einen Download von einer Website blockiert die für die Verbreitung von Malware bekannt ist."
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Stellen Sie sicher, dass Ihre Filterlisten auf aktuellem Stand sind:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legende: "
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Bei der Überprüfung auf Updates ist ein Fehler aufgetreten."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Klicken Sie auf Safari (Menübar) &rarr; Einstellungen ... &rarr; Erweiterungen."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Senden"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Abonnement beendet."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Lettisch"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Werbung auf dieser Seite entfernen"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"AdBlock auf Seiten deaktivieren:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Speichern der hochgeladenen Datei fehlgeschlagen."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Dies trifft auf $matchcount$ Elemente dieser Seite zu.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Filterlistenabruf fehlgeschlagen!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Sie können hier genau einstellen, auf welchen Seiten AdBlock deaktiviert sein soll."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"verborgen"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Erscheint die Werbung vor oder in einem Video oder einem anderen Plugin, wie z.B. einem Flash-Spiel?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"russisch und ukrainisch"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"spanisch"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Achtung: Dieser Filter entfernt alle $elementtype$-Elemente auf dieser Seite!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"ClickToFlash Kompatibilitätsmodus aktivieren"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nein"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filter (kann in den AdBlock-Einstellungen bearbeitet werden):"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Diesen Button ausblenden"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"nichtgelistete Sprache"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"Sie können die Werbung auch im Tab 'Anpassen' der AdBlock-Einstellungen entfernen. Danke!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"russisch"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Sie benutzen eine veraltete Version von Safari. Laden Sie sich die neueste Version von Safari herunter um mit dem AdBlock Toolbar-Button AdBlock pausieren, Ausnahmeregeln für Webseiten erstellen und Werbung melden zu können. <a>Jetzt herunterladen</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (Privatsphärenschutz)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ wird $value$ sein",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"...oder geben Sie eine Filterlistenadresse ein:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Der folgende Filter: <br/> $filter$ <br/> hat einen Fehler: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Frame-Typ:"
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"LÄDT..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Hat unser Team Sie nach Debug-Informationen gefragt? Klicken Sie  <a href='#' id='debug'>hier</a> um die Informationen anzuzeigen."
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Die Zahl der Filterlistenregeln überschreitet das Limit von 50.000 und wurde automatisch reduziert. Bitte deaktivieren Sie einige Filterlisten oder deaktivieren Sie Safari Content Blocking!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Werbung auf dieser Seite melden"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Debug-Berichte in der Fehlerkonsole anzeigen (verlangsamt AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Frame-Domain: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Die beliebteste Chrome-Erweiterung, mit über 40 Millionen Nutzern!  Entfernt Werbung im ganzen Internet."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Haben Sie einen Fehler gefunden?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"tschechisch"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Datei ist keine Bilddatei. Bitte laden Sie eine Datei hoch die mit .png, .gif, oder .jpg endet."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Links zu den Filterlisten anzeigen"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Einige nicht aufdringliche Werbung zulassen"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Schwedisch"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"aus Liste entfernen"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Sprache auswählen --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"französisch"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Bearbeiten"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Support"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Werbung über ihre Adresse entfernen"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Version $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Wo ist genau auf dieser Seite ist die Werbung? Wie sieht sie aus?"
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Werbung zu melden ist freiwillig. Es hilft Anderen da Filterlisten-Betreiber die Werbung für alle anderen Benutzer blocken können. Es ist in Ordnung falls Sie dies derzeit nicht tun möchten. Schließen Sie einfach diese Seiten und <a>entfernen Sie die Werbung</a> nur für Sie selbst."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Ja"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Der Quellcode ist <a>frei verfügbar</a>."
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"niederländisch"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Wir werden Sie nur im Falle von fehlenden Informationen kontaktieren."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Dies trifft auf <b>1</b> Element dieser Seite zu."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"vor $hours$ Stunden aktualisiert",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Zurück"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Klicken Sie hier: <a>\"Akzeptable Werbung\" deaktivieren</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domain der zutreffenden Seite"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Etwas ist schief gelaufen. Es wurden keine Ressourcen übermittelt. Diese Seite wird sich nun schließen. Versuchen Sie die Webseite neu zu laden."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Mehr über Malware erfahren"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Acceptable Ads (empfohlen)"
   },
   "safaricontentblockingpausemessage":{
     "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
     "message":"Um AdBlock mit aktiviertem Content Blocking zu pausieren, klicken Sie bitte auf Safari (in der Menüleiste) > Einstellungen ... > Erweiterungen > AdBlock, und entfernen Sie den Haken unter \"AdBlock aktivieren\"."
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - für weitere Optionen bitte klicken"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Sieht gut aus!"
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Deaktivieren Sie alle Erweiterungen außer AdBlock:"
   }
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Επισυνάψτε στιγμιότυπο οθόνης:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Δεν βρέθηκε γνωστό κακόβουλο λογισμικό."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Σε εκείνο τον περιηγητή, εγγραφείτε στις ίδιες λίστες φίλτρων όπως έχετε εδώ."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Σε εκείνο τον περιηγητή, φορτώστε τη σελίδα με την διαφήμιση."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Σουηδικά"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Να μπλοκάρετε κι άλλες διαφημίσεις:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Ρωσικά"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Αναίρεση εγγραφής"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Κινεζικά"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Εάν έχετε δημιουργήσει ένα φίλτρο εργασίας, χρησιμοποιώντας τον οδηγό \"μπλοκάρισμα μίας διαφήμισης\", επικολλήστε το στο παρακάτω πλαίσιο:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Λίστα φίλτρου Antisocial (αφαιρεί τα κουμπιά κοινωνικής δικτύωσης)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Βρήκατε διαφήμιση σε μια ιστοσελίδα; Εμείς θα σας βοηθήσουμε να βρείτε το σωστό μέρος για να το αναφέρετε!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Εμφάνιση αριθμού μπλοκαρισμένων διαφημίσεων στο κουμπί AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Ο πηγαίος κώδικας είναι <a>ελεύθερα διαθέσιμος</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"ανανεώθηκε πριν 1 λεπτό"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Σφάλμα στην ανάκτηση αυτού του φίλτρου!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Παρακαλούμε κάντε επανεκκίνηση το Safari για να ολοκληρώσετε την απενεργοποίηση φραγής περιεχομένου."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Μπλοκάρισμα μιας διαφήμισης από την διεύθυνση URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Απόκρυψη του κουμπιού"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Θα κάνω ενημερώσεις αυτόματα. Μπορείτε επίσης να <a>ενημερώσετε τώρα</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Μορφή: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Εσθονικά"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Τύπος"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Υπάρχει μια ενημέρωση για το AdBlock! Πηγαίνετε $here$ για να ενημερώσετε. <br> Σημείωση: Αν θέλετε να λαμβάνετε ενημερώσεις αυτόματα, απλά κάντε κλικ στο Safari > Προτιμήσεις > Επεκτάσεις > Ενημερώσεις <br> και επιλέξτε το 'Αυτόματη εγκατάσταση ενημερώσεων'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Τι είναι αυτό;"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Μην εγγραφείτε σε περισσότερα φίλτρα από όσα χρειάζεστε -- το καθένα σας καθυστερεί και από λίγο! <br/>Εύσημα και περισσότερες λίστες μπορούν να βρεθούν <a>εδώ</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Αυτό το χαρακτηριστικό του AdBlock δεν λειτουργεί σε αυτή την ιστοσελίδα, επειδή χρησιμοποιεί παρωχημένη τεχνολογία. Μπορείτε να αποκλείσετε ή να επιτρέψετε πόρους χειροκίνητα στην καρτέλα 'Προσαρμογή' της σελίδας επιλογών."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Πολωνικά"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Μάθετε περισσότερα για το πρόγραμμα αποδεκτών διαφημίσεων."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"ανανεώθηκε πριν $seconds$ δευτερόλεπτα",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Ουγγαρικά"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Σημείωση: η αναφορά σας μπορεί να γίνει δημόσια. Έχετέ το κατά νου πριν συμπεριλάβετε οποιαδήποτε ιδιωτική πληροφορία."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Παρακαλούμε απενεργοποιήστε ορισμένες λίστες φίλτρων. Περισσότερες πληροφορίες στις επιλογές του AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Φίλτρο προέλευσης:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Συγνώμη, το AdBlock απενεργοποιήθηκε σε αυτήν την σελίδα λόγω μιας από τις λίστες φίλτρων σας."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Το φίλτρο δεν είναι έγκυρο: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Προσοχή: Δεν προσδιορίστηκε φίλτρο!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"Το AdBlock είναι απενεργοποιημένο σε αυτήν την σελίδα."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Εμφάνιση διαφημίσεων <i>παντού</i> εκτός από αυτούς τους τομείς..."
+    "message":"Έχετε μια ερώτηση ή νέα ιδέα;"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Επιλογές"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Μπλοκαρισμένες διαφημίσεις:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Προσθέστε φίλτρα για άλλη γλώσσα: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Κάντε κλικ στη διαφήμιση, και θα σας καθοδηγήσω στο μπλοκάρισμα της."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Αν βλέπετε μια διαφήμιση, μην κάνετε αναφορά σφάλματος, κάντε μια <a>αναφορά διαφήμισης</a>!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Εξαιρετικά! Είστε έτοιμοι."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Άλλη"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Υποστήριξη AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Προσαρμόστε το AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Λείπουν οι απαιτούμενες πληροφορίες ή είναι άκυρες.  Παρακαλούμε συμπληρώστε τις ερωτήσεις που έχουν κόκκινο περίγραμμα."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Σφάλμα αποθήκευσης του μεταφορτωμένου αρχείου."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Παρακαλούμε πληκτρολογήστε σωστά το φίλτρο παρακάτω και πατήστε OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Βήμα 1ο: Επιλέξτε τι θα μπλοκάρετε"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Δανικά"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (προτείνεται)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ σε αυτή τη σελίδα",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Υποπλαίσιο"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"ανανεώθηκε πριν 1 ώρα"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Κορεατικά"
+    "message":"Πολωνικά"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"ή το Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Ποιό είναι το όνομά σας;"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Η πιο δημοφιλής επέκταση Chrome, με πάνω από 40 εκατομμύρια χρήστες! Μπλοκάρει διαφημίσεις σε όλο τον ιστό."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Εμφάνιση όλων των αιτήσεων"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Δεν θέλω να το ελέγξω αυτό"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Ναι"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Αναίρεση των μπλοκ μου σε αυτόν τον τομέα"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"ΠΡΟΣΑΡΜΟΓΗ"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Παύση του AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Είστε βέβαιοι ότι θέλετε να εγγραφείτε στη λίστα φίλτρου $title$;",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Ακριβώς που στη συγκεκριμένη σελίδα είναι η διαφήμιση; Πως μοιάζει;"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"ή το AdBlock για Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"ορισμός στυλ"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Δοκιμαστική"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Υπέρβαση ορίου κανόνων αποκλεισμού περιεχομένου"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Αναζήτηση διαφημίσεων...<br/><br/><i>Αυτό θα πάρει μερικά δευτερόλεπτα.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Ο τομέας ή η URL διεύθυνση όπου το AdBlock δε θα μπλοκάρει τίποτα"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"σενάριο"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ συνολικά",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Όλα έτοιμα!  Θα έρθουμε σε επαφή σύντομα, πιθανότατα μέσα σε μια μέρα, δύο αν είναι διακοπές. Εν τω μεταξύ, αναζητήστε ένα μήνυμα ηλεκτρονικού ταχυδρομείου από το AdBlock. Εκεί θα βρείτε έναν σύνδεσμο για το εισιτήριο σας στην ιστοσελίδα βοήθειας. Εάν προτιμάτε να ακολουθήσετε με ηλεκτρονικό ταχυδρομείο, μπορείτε να το κάνετε και αυτό!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Όχι"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Κάτι πήγε λάθος. Κανένας πόρος δεν έχει αποσταλεί. Αυτή η σελίδα θα κλείσει τώρα. Δοκιμάστε να φορτώσετε ξανά την ιστοσελίδα."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ουκρανικά"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"ανανεώθηκε πριν $minutes$ λεπτά",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Αναιρέσαμε την εγγραφή σας από τις αποδεκτές διαφημίσεις, διότι έχετε ενεργοποιήσει την Φραγή Περιεχομένου Safari. Μπορείτε να επιλέξετε μόνο ένα κάθε φορά. (<a>Γιατί;</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Δεν είστε πλέον συνδρομητής στη λίστα φίλτρου αποδεκτών διαφημίσεων."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Προστασία από κακόβουλο λογισμικό"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Αποθήκευση"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Προσοχή: σε όλες τις άλλες ιστοσελίδες θα βλέπετε διαφημίσεις!<br>Αυτό υπερισχύει όλων των άλλων φίλτρων για αυτές τις ιστοσελίδες."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Απενεργοποιήστε αυτές τις ειδοποιήσεις"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Γίνεται εγγραφή σε λίστα φίλτρων..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Χρησιμοποιείτε παλιά έκδοση του AdBlock. Πηγαίνετε στη <a href='#'>σελίδα επεκτάσεων</a>, ενεργοποιήστε την 'Λειτουργία για προγραμματιστές' και κάντε κλικ στο 'Ενημέρωση επεκτάσεων τώρα'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Επιλογές του AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Έλεγχος για κακόβουλο λογισμικό που θα μπορούσε να βάλει διαφημίσεις:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Εμφάνιση στοιχείων αποσφαλμάτωσης στο αρχείο κονσόλας (καθυστερεί το AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Έχετε υπερβεί το όριο μεγέθους του Dropbox. Παρακαλούμε αφαιρέστε κάποιες καταχωρήσεις από τα προσαρμοσμένα ή απενεργοποιημένα φίλτρα, και προσπαθήστε ξανά."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Αναίρεση παύσης του AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Επίλυση μη αναπαραγωγής βίντεο από Hulu.com (απαιτεί επανεκκίνηση του περιηγητή σας)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS για ταίριασμα"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Εξαίρεση"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Απενεργοποίηση όλων των επεκτάσεων εκτός από το AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Εύσημα για την μετάφραση δίνονται σε:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"ΦΟΡΤΩΝΕΙ..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Κάντε δεξί κλικ σε μια διαφήμιση για να την μπλοκάρετε -- ή κάντε το εδώ χειροκίνητα."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Σημείωση: η καταχώρηση στη λευκή λίστα (που επιτρέπει διαφημίσεις) μιας σελίδας ή ενός ιστότοπου, δεν υποστηρίζεται με ενεργοποιημένο αποκλεισμό περιεχομένου Safari."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Θα το χρησιμοποιήσουμε μόνο για να επικοινωνήσουμε μαζί σας εάν χρειαστούμε περισσότερες πληροφορίες."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Επεξεργασία απενεργοποιημένων φίλτρων:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Ενεργοποίηση αποκλεισμού περιεχομένου Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Ποιά είναι η διεύθυνση του ηλεκτρονικού ταχυδρομείου σας;"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Για να κρύψετε το κουμπί, κάντε δεξί κλικ στη γραμμή εργαλείων του Safari και επιλέξτε Προσαρμογή γραμμής εργαλείων, στη συνέχεια σύρετε το κουμπί AdBlock έξω από τη γραμμή εργαλείων. Μπορείτε να το εμφανίσετε ξανά σύροντάς το πίσω στην γραμμή εργαλείων."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Παρουσιάστηκε ένα σφάλμα κατά την επεξεργασία του αιτήματός σας."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"σελίδα"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Έγινε! Ξαναφορτώσαμε τη σελίδα με τη διαφήμιση. Παρακαλώ ελέγξτε τη σελίδα για να δείτε αν η διαφήμιση έχει φύγει. Στη συνέχεια γυρίστε πίσω σε αυτή τη σελίδα και απαντήστε στην παρακάτω ερώτηση."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"ή εισάγετε μια διεύθυνση URL σελίδας φίλτρων:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Χρησιμοποιείτε μια παλιά έκδοση του Safari. Αποκτήστε την τελευταία έκδοση για να χρησιμοποιήσετε το κουμπί AdBlock της γραμμής εργαλείων για παύση του AdBlock, ιστοσελίδες στη λευκή λίστα, και να αναφέρετε τις διαφημίσεις. <a>Αναβάθμιση τώρα</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Κάντε κλικ στο μενού Safari &rarr; Προτιμήσεις &rarr; Επεκτάσεις."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Να σταματήσετε το μπλοκάρισμα διαφημίσεων:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Μπλοκάρετέ το!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Η διαφήμιση συνεχίζει να υπάρχει;"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Βουλγαρικά"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Εξαιρετικά! Τώρα ας μάθουμε ποια επέκταση είναι η αιτία. Ενεργοποίηση κάθε επέκτασης μία προς μία. Η επέκταση που φέρνει πίσω την διαφήμιση είναι αυτή που πρέπει να καταργήσετε για να απαλλαγείτε από τις διαφημίσεις."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Απέτυχε!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Επεξεργαστείτε χειροκίνητα τα φίλτρα σας:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Ιταλικά"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"Αναδυόμενο παράθυρο"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Τύπος"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Σλοβακικά"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Εγγραφείτε σε λίστες φίλτρων"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Μπορείτε να το ενεργοποιήσετε ξανά παρακάτω και να υποστηρίζετε τις ιστοσελίδες που αγαπάτε επιλέγοντας \"Να επιτρέπονται ορισμένες μη-παρεμβατικές διαφημίσεις\"."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Εμφανίζεται η διαφήμιση και σε άλλον περιηγητή;"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Εκτός λειτουργίας σε αυτή τη σελίδα"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Λιθουανικά"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Ενημερώστε μας στην <a>ιστοσελίδα υποστήριξης</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"Το AdBlock είναι σε παύση."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Ακόμη δεν μπορούμε να μπλοκάρουμε διαφημίσεις μέσα σε Flash και άλλα πρόσθετα. Περιμένουμε υποστήριξη από τον περιηγητή και την WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"ΓΕΝΙΚΑ"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Αν προτιμάτε να μην βλέπετε διαφημίσεις όπως αυτή, μπορείτε αν θέλετε να αφήσετε τη λίστα φίλτρων αποδεκτών διαφημίσεων απενεργοποιημένη."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Ο υπολογιστής σας μπορεί να μολυνθεί από malware. Κάντε κλικ <a>εδώ</a> για περισσότερες πληροφορίες."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"άλλο"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Δεν προσδιορίστηκε φίλτρο!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"άγνωστο"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"ήχος/βίντεο"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Ιαπωνικά"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Να επιτρέπονται μερικές μη-παρεμβατικές διαφημίσεις"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Άκυρο"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Μπορείτε να σύρετε παρακάτω για να αλλάξετε ακριβώς σε ποιες σελίδες δεν θα τρέχει το AdBlock."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Απενεργοποιήσαμε την Φραγή Περιεχομένου Safari επειδή έχετε επιλέξει να επιτρέπονται μη παρεμβατικές διαφημίσεις. Μπορείτε να επιλέξετε μόνο ένα κάθε φορά. (<a>Γιατί;</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Τελευταίο βήμα: αναφέρετε το πρόβλημα σε εμάς."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Ελέγξτε στο Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Για να αναφέρετε μια διαφήμιση, πρέπει να είστε συνδεδεμένοι στον ιστό."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (προτείνεται)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Αναφορά μιας διαφήμισης"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Λίστες φίλτρων μπλοκαρίσματος διαφημίσεων"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Πώς;"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Να επιτρέπεται η καταχώρηση στη λευκή λίστα συγκεκριμένων καναλιών του YouTube"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Τρίτων"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (αφαιρεί ενοχλήσεις στον ιστό)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - κλικ για λεπτομέρειες"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"ανανεώθηκε πριν $hours$ ώρες",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Ρωσικά και Ουκρανικά"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Τι νέο υπάρχει στην τελευταία έκδοση; Δείτε το <a style='cursor:pointer;'>αρχείο αλλαγών</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Οι επεκτάσεις που είχαν προηγουμένως απενεργοποιηθεί έχουν ενεργοποιηθεί ξανά."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Ελληνικά"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Απόκρυψη μιας περιοχής της ιστοσελίδας"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Βίντεο και Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Τι νομίζετε ότι θα ισχύει σε αυτήν την διαφήμιση κάθε φορά που θα επισκέπτεστε αυτήν τη σελίδα;"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Ενεργοποίηση του AdBlock σε αυτή τη σελίδα"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Πίσω"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Οι λίστες φίλτρων μπλοκάρουν τις περισσότερες διαφημίσεις στον ιστό. Μπορείτε επίσης:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Έλεγχος των φίλτρων αποδεκτών διαφημίσεων:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Εμφάνιση διαφημίσεων σε μια ιστοσελίδα ή τομέα"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Αυτό αντιστοιχεί σε μόνο <b>1</b> αντικείμενο στη σελίδα."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Δεν θέλω να το ελέγξω αυτό"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Παρακαλούμε κάντε επανεκκίνηση το Safari για να ολοκληρώσετε την απενεργοποίηση φραγής περιεχομένου."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"ΠΡΟΣΟΧΗ: αν κάνετε ένα λάθος εδώ, πολλά άλλα φίλτρα, συμπεριλαμβανομένων των επίσημων, μπορεί να πάθουν ζημιά! <br/>Διαβάστε τις<a> οδηγίες για σύνταξη φίλτρων</a> για να μάθετε πώς να προσθέσετε προηγμένες μαύρες και λευκές λίστες φίλτρων."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Στη λευκή λίστα το κανάλι $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Εμφανίζεται η διαφήμιση και σε άλλον περιηγητή;"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Γενικές επιλογές"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Αν προτιμάτε να μην βλέπετε διαφημίσεις όπως αυτή, μπορείτε αν θέλετε να αφήσετε τη λίστα φίλτρων αποδεκτών διαφημίσεων απενεργοποιημένη."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"Το AdBlock δεν θα λειτουργεί σε σελίδες που αντιστοιχούν σε:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Δεν έχουμε ακόμη μια προεπιλεγμένη λίστα φίλτρων για αυτή τη γλώσσα.<br/>Προσπαθήστε να βρείτε μια λίστα φίλτρων που να υποστηρίζει αυτή τη γλώσσα $link$ ή μπλοκάρετέ την για τον εαυτό σας στην καρτέλα 'Προσαρμογή'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Εγγραφή"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Είμαι προχωρημένος χρήστης, δείξε μου προηγμένες επιλογές"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Ισπανικά"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Φορτώθηκε σε σελίδα με τομέα:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Πατήστε εδώ: <a>Ανανέωσε τα φίλτρα μου!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Όσο περισσότερα φίλτρα χρησιμοποιείτε,τόσο πιο αργά τρέχει το AdBlock. Χρησιμοποιώντας πολλά φίλτρα μπορεί ακόμα και να κολλήσει ο περιηγητής σας σε μερικές ιστοσελίδες. Πάτησε OK για να εγγραφείτε σε αυτή τη λίστα φίλτρων όπως και να έχει."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Τελευταίο βήμα: Τι καθιστά αυτό διαφήμιση;"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Αυτό αντιστοιχεί σε $matchcount$ αντικείμενα στη σελίδα.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Επίσης, έχουμε μια <a>σελίδα</a> για να σας βοηθήσει να ανακαλύψετε τους ανθρώπους πίσω από το AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Ινδονησιακά"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Τουρκικά"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Μπλοκάρισμα μιας διαφήμισης"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Προσαρμοσμένες λίστες φίλτρων"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"Πλαίσιο URL: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Ο σκοπός αυτής της ερώτησης είναι να καθοριστεί ποιος πρέπει να λάβει την αναφορά σας. Αν δεν απαντήσετε σωστά σε αυτή την ερώτηση, η αναφορά θα αποσταλεί σε λάθος άνθρωπους, έτσι ώστε να μπορεί να αγνοηθεί."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Προσθήκη στοιχείων στο μενού του δεξιού κλικ"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"επιλογέας"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Μπλοκάρισμα αυτής της διαφήμισης"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Έχει ζητήσει η ομάδα μας κάποιες πληροφορίες εντοπισμού σφαλμάτων; Κάντε κλικ <a href='#' id='debug'>εδώ</a> για αυτό!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Να μην λειτουργεί το AdBlock σε..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Η αναφορά διαφημίσεων είναι εθελοντική. Βοηθά άλλους ανθρώπους με την ενεργοποίηση των συντηρητών λίστας φίλτρων, να μπλοκάρουν τη διαφήμιση για όλους. Αν δεν αισθάνεστε αλτρουιστικά αυτή τη στιγμή, δεν πειράζει. Κλείστε αυτή τη σελίδα και <a>μπλοκάρετε τη διαφήμιση</a> μόνο για εσάς."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Κρυφό στοιχείο"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Ανανέωση της σελίδας."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"σελίδα"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Ολλανδικά"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Αυτό το όνομα αρχείου είναι πολύ μεγάλο. Παρακαλούμε δώστε στο αρχείο σας ένα μικρότερο όνομα."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Μην ξεχάσετε να αποθηκεύσετε!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Έλεγχος για ενημερώσεις (πρέπει να διαρκέσει μόνο λίγα δευτερόλεπτα)..."
+    "message":"Λιθουανικά"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Εγγραφείτε σε αυτή τη λίστα φίλτρων, και μετά ξαναπροσπαθήστε: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Να σας ειδοποιεί το AdBlock όταν ανιχνεύει κακόβουλο λογισμικό;"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Ο υπολογιστής σας μπορεί να μολυνθεί από malware. Κάντε κλικ <a>εδώ</a> για περισσότερες πληροφορίες."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Εμφάνιση αριθμού μπλοκαρισμένων διαφημίσεων στο μενού του AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Εμφάνιση διαφημίσεων σε μια ιστοσελίδα ή τομέα"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Ιστοσελίδα:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Προσαρμοσμένα φίλτρα του AdBlock (προτείνεται)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Λετονικά"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Βεβαιωθείτε ότι χρησιμοποιείτε το σωστό φίλτρο γλώσσας:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS για ταίριασμα"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Για να κρύψετε το κουμπί, πηγαίνετε στο opera://extensions και επιλέξτε το 'Απόκρυψη από τη γραμμή εργαλείων'. Μπορείτε να το εμφανίσετε ξανά αναιρώντας αυτή την επιλογή."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Δεν είστε σίγουρος;</b> Απλώς πατήστε 'Μπλοκάρετέ το!' παρακάτω."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Ταιριασμένο φίλτρο"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Ανάκτηση... Παρακαλώ περιμένετε."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Όλοι οι πόροι"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"Το AdBlock είναι ενημερωμένο!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Εκτός λειτουργίας σε σελίδες αυτού του τομέα"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Εβραϊκά"
+    "message":"Σλοβακικά"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Σύρετε τον δείκτη ώσπου η διαφήμιση να μπλοκαριστεί σωστά στην σελίδα, και το μπλοκαρισμένο στοιχείο να φαίνεται εντάξει."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Μπλοκάρετε URL διευθύνσεις με αυτό το κείμενο"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Ο αριθμός των κανόνων στη λίστα φίλτρου υπερβαίνει το όριο των 50.000, και έχει μειωθεί αυτόματα. Παρακαλώ αναιρέστε την εγγραφή σας από μερικές λίστες φίλτρων ή απενεργοποιήστε τον Αποκλεισμό Περιεχομένου Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"ανανεώθηκε πριν 1 μέρα"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Αποδεκτές διαφημίσεις (προτείνεται)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Κάντε κλικ εδώ για: <a>Απενεργοποίηση αποδεκτών διαφημίσεων</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Έκδοση $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Εγκαταστήστε το Adblock Plus για Firefox $chrome$ αν δεν το έχετε.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Αφαίρεση από τη λίστα"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Δεν έχουμε ακόμη μια προεπιλεγμένη λίστα φίλτρων για αυτή τη γλώσσα.<br/>Προσπαθήστε να βρείτε μια λίστα φίλτρων που να υποστηρίζει αυτή τη γλώσσα $link$ ή μπλοκάρετέ την για τον εαυτό σας στην καρτέλα 'Προσαρμογή'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Αυτό δεν είναι αρχείο εικόνας. Παρακαλούμε αποστείλτε ένα αρχείο .png, .gif ή .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Γιατί δεν μας στέλνετε μια <a>αναφορά σφάλματος</a>;"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"απόκρυψη"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"ΛΙΣΤΕΣ ΦΙΛΤΡΩΝ"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Πλαίσιο τομέα: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Κάντε κλικ στη διαφήμιση, και θα σας καθοδηγήσω στο μπλοκάρισμα της."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Πάνω πλαίσιο"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"ορισμός στυλ"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"άγνωστο"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Συγνώμη, το AdBlock απενεργοποιήθηκε σε αυτήν την σελίδα λόγω μιας από τις λίστες φίλτρων σας."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Τρίτων"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Δεν προσδιορίστηκε φίλτρο!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Ελληνικά"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Χρησιμοποιείτε παλιά έκδοση του AdBlock. Πηγαίνετε στη <a href='#'>σελίδα επεκτάσεων</a>, ενεργοποιήστε την 'Λειτουργία για προγραμματιστές' και κάντε κλικ στο 'Ενημέρωση επεκτάσεων τώρα'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Ποιό είναι το όνομά σας;"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Επίλυση μη αναπαραγωγής βίντεο από Hulu.com (απαιτεί επανεκκίνηση του περιηγητή σας)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Προσοχή: Δεν προσδιορίστηκε φίλτρο!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"ΠΡΟΣΑΡΜΟΓΗ"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Βρήκατε διαφήμιση σε μια ιστοσελίδα; Εμείς θα σας βοηθήσουμε να βρείτε το σωστό μέρος για να το αναφέρετε!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Εσθονικά"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Προσαρμόστε το AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Βουλγαρικά"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Εγκεκριμένος πόρος"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Υπέρβαση ορίου κανόνων αποκλεισμού περιεχομένου"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Να μην λειτουργεί το AdBlock σε..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Μπλοκάρετε URL διευθύνσεις με αυτό το κείμενο"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Κλείσιμο"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Ελέγξτε στο Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Τελευταίο βήμα: Τι καθιστά αυτό διαφήμιση;"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Αν βλέπετε μια διαφήμιση, μην κάνετε αναφορά σφάλματος, κάντε μια <a>αναφορά διαφήμισης</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Κορεατικά"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Χρησιμοποιείτε μια παλιά έκδοση του Safari. Αποκτήστε την τελευταία έκδοση για να χρησιμοποιήσετε το κουμπί AdBlock της γραμμής εργαλείων για παύση του AdBlock, ιστοσελίδες στη λευκή λίστα, και να αναφέρετε τις διαφημίσεις. <a>Αναβάθμιση τώρα</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Φινλανδικά"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"σενάριο"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ουκρανικά"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Δεν βρέθηκε γνωστό κακόβουλο λογισμικό."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Παρακαλούμε απενεργοποιήστε ορισμένες λίστες φίλτρων. Περισσότερες πληροφορίες στις επιλογές του AdBlock."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Αναιρέσαμε την εγγραφή σας από τις αποδεκτές διαφημίσεις, διότι έχετε ενεργοποιήσει την Φραγή Περιεχομένου Safari. Μπορείτε να επιλέξετε μόνο ένα κάθε φορά. (<a>Γιατί;</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Επίσης, έχουμε μια <a>σελίδα</a> για να σας βοηθήσει να ανακαλύψετε τους ανθρώπους πίσω από το AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"εδώ"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"Αναδυόμενο παράθυρο"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Ανανέωση της σελίδας."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Σε τι γλώσσα είναι αυτή η σελίδα;"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"Το AdBlock είναι σε παύση."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Αναίρεση παύσης του AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Αναζήτηση διαφημίσεων...<br/><br/><i>Αυτό θα πάρει μερικά δευτερόλεπτα.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"Το AdBlock είναι απενεργοποιημένο σε αυτήν την σελίδα."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Σε εκείνο τον περιηγητή, εγγραφείτε στις ίδιες λίστες φίλτρων όπως έχετε εδώ."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Μπλοκάρισμα μιας διαφήμισης"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Προσοχή: σε όλες τις άλλες ιστοσελίδες θα βλέπετε διαφημίσεις!<br>Αυτό υπερισχύει όλων των άλλων φίλτρων για αυτές τις ιστοσελίδες."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Υπάρχει μια ενημέρωση για το AdBlock! Πηγαίνετε $here$ για να ενημερώσετε. <br> Σημείωση: Αν θέλετε να λαμβάνετε ενημερώσεις αυτόματα, απλά κάντε κλικ στο Safari > Προτιμήσεις > Επεκτάσεις > Ενημερώσεις <br> και επιλέξτε το 'Αυτόματη εγκατάσταση ενημερώσεων'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Ολοκληρώθηκε!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Προσαρμοσμένα φίλτρα του AdBlock (προτείνεται)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Τύπος"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Τι είναι αυτό;"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Ιαπωνικά"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Φίλτρο προέλευσης:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Εγγραφείτε σε λίστες φίλτρων"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Τύπος πλαισίου: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Προσθέστε φίλτρα για άλλη γλώσσα: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Πόρος"
+    "message":"Ταιριασμένο φίλτρο"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Μπλοκάρισμα μίας διαφήμισης σε αυτή τη σελίδα"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Οι λίστες φίλτρων μπλοκάρουν τις περισσότερες διαφημίσεις στον ιστό. Μπορείτε επίσης:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Βεβαιωθείτε πως οι λίστες φίλτρων σας είναι ενημερωμένες:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Για να κρύψετε το κουμπί, κάντε δεξί κλικ στη γραμμή εργαλείων του Safari και επιλέξτε Προσαρμογή γραμμής εργαλείων, στη συνέχεια σύρετε το κουμπί AdBlock έξω από τη γραμμή εργαλείων. Μπορείτε να το εμφανίσετε ξανά σύροντάς το πίσω στην γραμμή εργαλείων."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Αγγλικά"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Έχετε υπερβεί το όριο μεγέθους του Dropbox. Παρακαλούμε αφαιρέστε κάποιες καταχωρήσεις από τα προσαρμοσμένα ή απενεργοποιημένα φίλτρα, και προσπαθήστε ξανά."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Ισλανδικά"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Εγγραφή"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Ανοίξτε τη σελίδα της επέκτασης για να ενεργοποιήσετε τις επεκτάσεις που είχαν προηγουμένως απενεργοποιηθεί."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Σημείωση: η καταχώρηση στη λευκή λίστα (που επιτρέπει διαφημίσεις) μιας σελίδας ή ενός ιστότοπου, δεν υποστηρίζεται με ενεργοποιημένο αποκλεισμό περιεχομένου Safari."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Τομέας της σελίδας για εφαρμογή"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Μπλοκαρισμένο στοιχείο:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"σελίδα"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"άλλο"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Πατήστε εδώ: <a>Ανανέωσε τα φίλτρα μου!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Κρυφό στοιχείο"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Για να κρύψετε το κουμπί, πηγαίνετε στο opera://extensions και επιλέξτε το 'Απόκρυψη από τη γραμμή εργαλείων'. Μπορείτε να το εμφανίσετε ξανά αναιρώντας αυτή την επιλογή."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Σελίδα:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Βρήκατε σφάλμα;"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Μπλοκάρετέ το!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Να επιτρέπεται η καταχώρηση στη λευκή λίστα συγκεκριμένων καναλιών του YouTube"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Ακόμη δεν μπορούμε να μπλοκάρουμε διαφημίσεις μέσα σε Flash και άλλα πρόσθετα. Περιμένουμε υποστήριξη από τον περιηγητή και την WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Αραβικά"
+    "message":"Ουγγαρικά"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Μπλοκάρισμα αυτής της διαφήμισης"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Ενεργοποίηση του AdBlock σε αυτή τη σελίδα"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Εμφάνιση αριθμού μπλοκαρισμένων διαφημίσεων στο κουμπί AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Απέτυχε!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Παύση του AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Τσεχικά"
+    "message":"Αγγλικά"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Πληρώστε ό,τι θέλετε!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Προσθήκη στοιχείων στο μενού του δεξιού κλικ"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Θέλετε να δείτε τι κάνει το AdBlock να ξεχωρίζει;"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Παρακαλούμε μεταβείτε στην <a>ιστοσελίδα υποστήριξης</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Λίστα αφαίρεσης Προειδοποιήσεων AdBlock (αφαιρεί τα μηνύματα που αφορούν τη χρήση AdBlock)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Μη έγκυρη διεύθυνση URL λίστας. Θα διαγραφεί."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"πλαίσιο"
+    "message":"σελίδα"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Επεξεργασία"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Είστε βέβαιοι ότι θέλετε να καταργήσετε τα $count$ μπλοκ που έχετε δημιουργήσει στο $host$;",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Έχετε μια ερώτηση ή νέα ιδέα;"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Υπόμνημα: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Ξεχάσατε να επισυνάψετε ένα στιγμιότυπο οθόνης! Δεν μπορούμε να σας βοηθήσουμε χωρίς να δούμε την διαφήμιση που θέλετε να αναφέρετε."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>Ή</b>, απλά κάντε κλικ σε αυτό το κουμπί για να κάνουμε όλα τα παραπάνω: <a>Απενεργοποίηση όλων των άλλων επεκτάσεων</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"ανανεώθηκε πριν $minutes$ λεπτά",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Μάθετε περισσότερα για το κακόβουλο λογισμικό"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Επισυνάψτε στιγμιότυπο οθόνης:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Ρουμανικά"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Επεξεργασία απενεργοποιημένων φίλτρων:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Υποπλαίσιο"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Ανανεώστε τη σελίδα που έχει τη διαφήμιση."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Ενεργοποίηση αποκλεισμού περιεχομένου Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Εγκαταστήστε το Firefox $chrome$ αν δεν το έχετε ήδη.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"ΛΙΣΤΕΣ ΦΙΛΤΡΩΝ"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Εάν έχετε δημιουργήσει ένα φίλτρο εργασίας, χρησιμοποιώντας τον οδηγό \"μπλοκάρισμα μίας διαφήμισης\", επικολλήστε το στο παρακάτω πλαίσιο:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Αυτό το αρχείο είναι πολύ μεγάλο. Παρακαλούμε βεβαιωθείτε ότι το αρχείο είναι μικρότερο από 10 MB."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"Το AdBlock δεν θα λειτουργεί σε σελίδες που αντιστοιχούν σε:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Κινεζικά"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Το φίλτρο δεν είναι έγκυρο: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Γίνεται εγγραφή σε λίστα φίλτρων..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Ανοίξτε τη σελίδα της επέκτασης για να ενεργοποιήσετε τις επεκτάσεις που είχαν προηγουμένως απενεργοποιηθεί."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Απενεργοποιήστε αυτές τις ειδοποιήσεις"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Τουρκικά"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Μην εγγραφείτε σε περισσότερα φίλτρα από όσα χρειάζεστε -- το καθένα σας καθυστερεί και από λίγο! <br/>Εύσημα και περισσότερες λίστες μπορούν να βρεθούν <a>εδώ</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"πλαίσιο"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Ινδονησιακά"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"εικόνα"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ συνολικά",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Άκυρο"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Μην ξεχάσετε να αποθηκεύσετε!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"επιλογέας"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Απενεργοποιήσαμε την Φραγή Περιεχομένου Safari επειδή έχετε επιλέξει να επιτρέπονται μη παρεμβατικές διαφημίσεις. Μπορείτε να επιλέξετε μόνο ένα κάθε φορά. (<a>Γιατί;</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Ισλανδικά"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Λίστες φίλτρων μπλοκαρίσματος διαφημίσεων"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Μπλοκάρισμα διαφημίσεων μόνο σε αυτές τις ιστοσελίδες:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Φορτώθηκε σε σελίδα με τομέα:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Οι επεκτάσεις που είχαν προηγουμένως απενεργοποιηθεί έχουν ενεργοποιηθεί ξανά."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Καθαρίστε αυτή τη λίστα"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Βοηθήστε να το διαδώσουμε!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Ενημερώσεις AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Λίστα αφαίρεσης Προειδοποιήσεων AdBlock (αφαιρεί τα μηνύματα που αφορούν τη χρήση AdBlock)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Επιλογές του AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Παρουσιάστηκε ένα σφάλμα κατά την επεξεργασία του αιτήματός σας."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"ανανεώθηκε πριν 1 ώρα"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Έλεγχος για ενημερώσεις (πρέπει να διαρκέσει μόνο λίγα δευτερόλεπτα)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"ανανεώθηκε μόλις τώρα"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Κάντε δεξί κλικ σε μια διαφήμιση για να την μπλοκάρετε -- ή κάντε το εδώ χειροκίνητα."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Έλεγχος για κακόβουλο λογισμικό που θα μπορούσε να βάλει διαφημίσεις:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Υποστήριξη AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Τύπος"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Σύρετε τον δείκτη ώσπου η διαφήμιση να μπλοκαριστεί σωστά στην σελίδα, και το μπλοκαρισμένο στοιχείο να φαίνεται εντάξει."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"ανανεώθηκε πριν 1 λεπτό"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"πλαίσιο"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Αποκλεισμένος πόρος"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Οι ακόλουθες πληροφορίες θα συμπεριληφθούν επίσης στην αναφορά διαφήμισης."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Δανικά"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Έλεγχος των φίλτρων αποδεκτών διαφημίσεων:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Μπορείτε να το ενεργοποιήσετε ξανά παρακάτω και να υποστηρίζετε τις ιστοσελίδες που αγαπάτε επιλέγοντας \"Να επιτρέπονται ορισμένες μη-παρεμβατικές διαφημίσεις\"."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Ανάκτηση... Παρακαλώ περιμένετε."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Μη έγκυρη διεύθυνση URL λίστας. Θα διαγραφεί."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Γενικές επιλογές"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Καταργήστε την επιλογή 'Ενεργοποιημένο' στο πλαίσιο ελέγχου δίπλα σε κάθε επέκταση <b>εκτός</b> του AdBlock. <b>Αφήστε το AdBlock ενεργοποιημένο</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Σε εκείνο τον περιηγητή, φορτώστε τη σελίδα με την διαφήμιση."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Εμφάνιση διαφημίσεων <i>παντού</i> εκτός από αυτούς τους τομείς..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Ξεχάσατε να επισυνάψετε ένα στιγμιότυπο οθόνης! Δεν μπορούμε να σας βοηθήσουμε χωρίς να δούμε την διαφήμιση που θέλετε να αναφέρετε."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Και δημιουργήστε ένα εισιτήριο χειροκίνητα, και αντιγράψτε και επικολλήστε τις παρακάτω πληροφορίες στην ενότητα \"Σημπληρώστε τυχόν λεπτομέρειες που νομίζετε ότι θα μας βοηθήσουν να κατανοήσουμε το πρόβλημά σας\"."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Για να κρύψετε το κουμπί, κάντε δεξί κλικ στο κουμπί και επιλογή Απόκρυψη κουμπιού. Μπορείτε να το επανεμφανίσετε από chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Εβραϊκά"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Αυτό το χαρακτηριστικό του AdBlock δεν λειτουργεί σε αυτή την ιστοσελίδα, επειδή χρησιμοποιεί παρωχημένη τεχνολογία. Μπορείτε να αποκλείσετε ή να επιτρέψετε πόρους χειροκίνητα στην καρτέλα 'Προσαρμογή' της σελίδας επιλογών."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Τσεχικά και Σλοβακικά"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Έχουμε απενεργοποιήσει όλες τις άλλες επεκτάσεις. Τώρα θα ξαναφορτώσουμε τη σελίδα με τη διαφήμιση. Ένα δευτερόλεπτο, παρακαλώ."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Άλλες λίστες φίλτρων"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Γαλλικά"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Θα κάνω ενημερώσεις αυτόματα. Μπορείτε επίσης να <a>ενημερώσετε τώρα</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Μπλοκαρισμένο στοιχείο:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Εμφάνιση όλων των αιτήσεων"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"διαδραστικό αντικείμενο"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Όσο περισσότερα φίλτρα χρησιμοποιείτε,τόσο πιο αργά τρέχει το AdBlock. Χρησιμοποιώντας πολλά φίλτρα μπορεί ακόμα και να κολλήσει ο περιηγητής σας σε μερικές ιστοσελίδες. Πάτησε OK για να εγγραφείτε σε αυτή τη λίστα φίλτρων όπως και να έχει."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Εξαιρετικά! Είστε έτοιμοι."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Δοκιμαστική"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Ανοίξτε τη <a href='#'>σελίδα επεκτάσεων</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Όλα έτοιμα!  Θα έρθουμε σε επαφή σύντομα, πιθανότατα μέσα σε μια μέρα, δύο αν είναι διακοπές. Εν τω μεταξύ, αναζητήστε ένα μήνυμα ηλεκτρονικού ταχυδρομείου από το AdBlock. Εκεί θα βρείτε έναν σύνδεσμο για το εισιτήριο σας στην ιστοσελίδα βοήθειας. Εάν προτιμάτε να ακολουθήσετε με ηλεκτρονικό ταχυδρομείο, μπορείτε να το κάνετε και αυτό!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Μάθετε περισσότερα για το πρόγραμμα αποδεκτών διαφημίσεων."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Να σας ειδοποιεί το AdBlock όταν ανιχνεύει κακόβουλο λογισμικό;"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"ανανεώθηκε μόλις τώρα"
+    "message":"ανανεώθηκε πριν 1 μέρα"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"Πλαίσιο URL: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Γερμανικά"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Αυτό το όνομα αρχείου είναι πολύ μεγάλο. Παρακαλούμε δώστε στο αρχείο σας ένα μικρότερο όνομα."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"ανανεώθηκε πριν $seconds$ δευτερόλεπτα",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Εκτός λειτουργίας σε αυτή τη σελίδα"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Ενημερώστε μας στην <a>ιστοσελίδα υποστήριξης</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Έγινε! Ξαναφορτώσαμε τη σελίδα με τη διαφήμιση. Παρακαλώ ελέγξτε τη σελίδα για να δείτε αν η διαφήμιση έχει φύγει. Στη συνέχεια γυρίστε πίσω σε αυτή τη σελίδα και απαντήστε στην παρακάτω ερώτηση."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Όλοι οι πόροι"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Στη λευκή λίστα το κανάλι $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Πόρος"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Εμφάνιση αριθμού μπλοκαρισμένων διαφημίσεων στο μενού του AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Αναφορά μιας διαφήμισης"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Πώς;"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Εκτός λειτουργίας σε σελίδες αυτού του τομέα"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Προσαρμοσμένες λίστες φίλτρων"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Να μπλοκάρετε κι άλλες διαφημίσεις:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Λείπουν οι απαιτούμενες πληροφορίες ή είναι άκυρες.  Παρακαλούμε συμπληρώστε τις ερωτήσεις που έχουν κόκκινο περίγραμμα."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Ο τομέας ή η URL διεύθυνση όπου το AdBlock δε θα μπλοκάρει τίποτα"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Δεν είστε πλέον συνδρομητής στη λίστα φίλτρου αποδεκτών διαφημίσεων."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (αφαιρεί ενοχλήσεις στον ιστό)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"Το AdBlock έχει μπλοκάρει μια λήψη από μια τοποθεσία που είναι γνωστό ότι φιλοξενεί κακόβουλο λογισμικό."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Αποθήκευση"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Δεν είστε σίγουρος;</b> Απλώς πατήστε 'Μπλοκάρετέ το!' παρακάτω."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Τελευταίο βήμα: αναφέρετε το πρόβλημα σε εμάς."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Ακριβώς που στη συγκεκριμένη σελίδα είναι η διαφήμιση; Πως μοιάζει;"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Φαίνεται εντάξει"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Να επιτρέπεται στο AdBlock να συγκεντρώνει ανώνυμα χρήση και δεδομένα λίστας φίλτρων"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Για να αναφέρετε μια διαφήμιση, πρέπει να είστε συνδεδεμένοι στον ιστό."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Είστε βέβαιοι ότι θέλετε να εγγραφείτε στη λίστα φίλτρου $title$;",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"ανανεώθηκε πριν $days$ μέρες",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"πλαίσιο"
+    "message":"διαδραστικό αντικείμενο"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Τι νομίζετε ότι θα ισχύει σε αυτήν την διαφήμιση κάθε φορά που θα επισκέπτεστε αυτήν τη σελίδα;"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Μπλοκαρισμένες διαφημίσεις:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Αραβικά"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Αναίρεση των μπλοκ μου σε αυτόν τον τομέα"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Επεξεργαστείτε χειροκίνητα τα φίλτρα σας:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Βήμα 1ο: Επιλέξτε τι θα μπλοκάρετε"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Παρακαλούμε πληκτρολογήστε σωστά το φίλτρο παρακάτω και πατήστε OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Εύσημα για την μετάφραση δίνονται σε:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"Το AdBlock είναι ενημερωμένο!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Μόνο Αγγλικά"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>Ή</b>, απλά κάντε κλικ σε αυτό το κουμπί για να κάνουμε όλα τα παραπάνω: <a>Απενεργοποίηση όλων των άλλων επεκτάσεων</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Τι νέο υπάρχει στην τελευταία έκδοση; Δείτε το <a style='cursor:pointer;'>αρχείο αλλαγών</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (προστασία προσωπικών δεδομένων)"
+    "message":"Λίστα φίλτρου Antisocial (αφαιρεί τα κουμπιά κοινωνικής δικτύωσης)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Αναφέρετε μια διαφήμιση σε αυτή τη σελίδα"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Προστασία από κακόβουλο λογισμικό"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Καθαρίστε αυτή τη λίστα"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Είμαι προχωρημένος χρήστης, δείξε μου προηγμένες επιλογές"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Γερμανικά"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Ξεπεράσατε το όριο αποθήκευσης που το AdBlock μπορεί να κάνει χρήση. Παρακαλούμε αναιρέστε την εγγραφή σας από μερικές λίστες φίλτρων."
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Προσοχή: αυτό το φίλτρο μπλοκάρει όλα τα στοιχεία τύπου $elementtype$ στη σελίδα!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"εδώ"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Ποιά είναι η διεύθυνση του ηλεκτρονικού ταχυδρομείου σας;"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Σε τι γλώσσα είναι αυτή η σελίδα;"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Θέλετε να δείτε τι κάνει το AdBlock να ξεχωρίζει;"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Είστε βέβαιοι ότι θέλετε να καταργήσετε τα $count$ μπλοκ που έχετε δημιουργήσει στο $host$;",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"εικόνα"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Απόκρυψη μιας περιοχής της ιστοσελίδας"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Και δημιουργήστε ένα εισιτήριο χειροκίνητα, και αντιγράψτε και επικολλήστε τις παρακάτω πληροφορίες στην ενότητα \"Σημπληρώστε τυχόν λεπτομέρειες που νομίζετε ότι θα μας βοηθήσουν να κατανοήσουμε το πρόβλημά σας\"."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"ΓΕΝΙΚΑ"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Για να κρύψετε το κουμπί, κάντε δεξί κλικ στο κουμπί και επιλογή Απόκρυψη κουμπιού. Μπορείτε να το επανεμφανίσετε από chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"ή το AdBlock για Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Ρουμανικά"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Βίντεο και Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Κάτι πήγε στραβά κατά τον έλεγχο ενημερώσεων."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Έχουμε απενεργοποιήσει όλες τις άλλες επεκτάσεις. Τώρα θα ξαναφορτώσουμε τη σελίδα με τη διαφήμιση. Ένα δευτερόλεπτο, παρακαλώ."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Εγκεκριμένος πόρος"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Εξαιρετικά! Τώρα ας μάθουμε ποια επέκταση είναι η αιτία. Ενεργοποίηση κάθε επέκτασης μία προς μία. Η επέκταση που φέρνει πίσω την διαφήμιση είναι αυτή που πρέπει να καταργήσετε για να απαλλαγείτε από τις διαφημίσεις."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Τσεχικά και Σλοβακικά"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"ή το Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Τύπος πλαισίου: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Μορφή: ~site1.com|~site2.com|~news.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Επιλέξτε γλώσσα -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Εγκαταστήστε το Adblock Plus για Firefox $chrome$ αν δεν το έχετε.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Αποκλεισμένος πόρος"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Εμφανίζεται αυτή η διαφήμιση μέσα ή πριν μια ταινία ή άλλο πρόσθετο σαν ένα παιχνίδι Flash;"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ θα είναι $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Το φίλτρο, το οποίο μπορεί να αλλαχθεί στη σελίδα επιλογών:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Το παρακάτω φίλτρο: <br/> $filter$ <br/> έχει ένα σφάλμα: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Κλείσιμο"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Μπλοκάρισμα διαφημίσεων μόνο σε αυτές τις ιστοσελίδες:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Ξεπεράσατε το όριο αποθήκευσης που το AdBlock μπορεί να κάνει χρήση. Παρακαλούμε αναιρέστε την εγγραφή σας από μερικές λίστες φίλτρων."
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Να επιτρέπεται στο AdBlock να συγκεντρώνει ανώνυμα χρήση και δεδομένα λίστας φίλτρων"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"Εντάξει, μπορείτε ακόμα να μπλοκάρετε αυτή τη διαφήμιση μόνο για εσάς στην σελίδα επιλογών. Ευχαριστούμε!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Αποστολή"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Φινλανδικά"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Αυτό το αρχείο είναι πολύ μεγάλο. Παρακαλούμε βεβαιωθείτε ότι το αρχείο είναι μικρότερο από 10 MB."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Οι ακόλουθες πληροφορίες θα συμπεριληφθούν επίσης στην αναφορά διαφήμισης."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Πληρώστε ό,τι θέλετε!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Αυτό είναι ένα πρόβλημα στις λίστες φίλτρων. Αναφέρτε το εδώ: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Καταργήστε την επιλογή 'Ενεργοποιημένο' στο πλαίσιο ελέγχου δίπλα σε κάθε επέκταση <b>εκτός</b> του AdBlock. <b>Αφήστε το AdBlock ενεργοποιημένο</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Σημείωση: η αναφορά σας μπορεί να γίνει δημόσια. Έχετέ το κατά νου πριν συμπεριλάβετε οποιαδήποτε ιδιωτική πληροφορία."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Εμφάνιση συνδέσμων στις λίστες φίλτρων"
+  "filteritalian":{
+    "description":"language",
+    "message":"Ιταλικά"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Μόνο Αγγλικά"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Βοηθήστε να το διαδώσουμε!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Η διαφήμιση συνεχίζει να υπάρχει;"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"Το AdBlock έχει μπλοκάρει μια λήψη από μια τοποθεσία που είναι γνωστό ότι φιλοξενεί κακόβουλο λογισμικό."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Βεβαιωθείτε ότι χρησιμοποιείτε το σωστό φίλτρο γλώσσας:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Υπόμνημα: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Βεβαιωθείτε πως οι λίστες φίλτρων σας είναι ενημερωμένες:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Κάτι πήγε στραβά κατά τον έλεγχο ενημερώσεων."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Κάντε κλικ στο μενού Safari &rarr; Προτιμήσεις &rarr; Επεκτάσεις."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Αποστολή"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Αναίρεση εγγραφής"
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"ήχος/βίντεο"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Λετονικά"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Μπλοκάρισμα μίας διαφήμισης σε αυτή τη σελίδα"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Να σταματήσετε το μπλοκάρισμα διαφημίσεων:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Σφάλμα αποθήκευσης του μεταφορτωμένου αρχείου."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Αυτό αντιστοιχεί σε $matchcount$ αντικείμενα στη σελίδα.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Σφάλμα στην ανάκτηση αυτού του φίλτρου!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Μπορείτε να σύρετε παρακάτω για να αλλάξετε ακριβώς σε ποιες σελίδες δεν θα τρέχει το AdBlock."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"απόκρυψη"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Εμφανίζεται αυτή η διαφήμιση μέσα ή πριν μια ταινία ή άλλο πρόσθετο σαν ένα παιχνίδι Flash;"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Ρωσικά και Ουκρανικά"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Ισπανικά"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Προσοχή: αυτό το φίλτρο μπλοκάρει όλα τα στοιχεία τύπου $elementtype$ στη σελίδα!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Ενεργοποίηση της λειτουργίας συμβατότητας του ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Όχι"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Το φίλτρο, το οποίο μπορεί να αλλαχθεί στη σελίδα επιλογών:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Απόκρυψη του κουμπιού"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Άλλη"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"Εντάξει, μπορείτε ακόμα να μπλοκάρετε αυτή τη διαφήμιση μόνο για εσάς στην σελίδα επιλογών. Ευχαριστούμε!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Ρωσικά"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Γιατί δεν μας στέλνετε μια <a>αναφορά σφάλματος</a>;"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (προστασία προσωπικών δεδομένων)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ θα είναι $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"ή εισάγετε μια διεύθυνση URL σελίδας φίλτρων:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Το παρακάτω φίλτρο: <br/> $filter$ <br/> έχει ένα σφάλμα: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"ΦΟΡΤΩΝΕΙ..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Έχει ζητήσει η ομάδα μας κάποιες πληροφορίες εντοπισμού σφαλμάτων; Κάντε κλικ <a href='#' id='debug'>εδώ</a> για αυτό!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Ο αριθμός των κανόνων στη λίστα φίλτρου υπερβαίνει το όριο των 50.000, και έχει μειωθεί αυτόματα. Παρακαλώ αναιρέστε την εγγραφή σας από μερικές λίστες φίλτρων ή απενεργοποιήστε τον Αποκλεισμό Περιεχομένου Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Αναφέρετε μια διαφήμιση σε αυτή τη σελίδα"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Εμφάνιση στοιχείων αποσφαλμάτωσης στο αρχείο κονσόλας (καθυστερεί το AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Πλαίσιο τομέα: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Η πιο δημοφιλής επέκταση Chrome, με πάνω από 40 εκατομμύρια χρήστες! Μπλοκάρει διαφημίσεις σε όλο τον ιστό."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Βρήκατε σφάλμα;"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Τσεχικά"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Αυτό δεν είναι αρχείο εικόνας. Παρακαλούμε αποστείλτε ένα αρχείο .png, .gif ή .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Εμφάνιση συνδέσμων στις λίστες φίλτρων"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Να επιτρέπονται μερικές μη-παρεμβατικές διαφημίσεις"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Σουηδικά"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Αφαίρεση από τη λίστα"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Επιλέξτε γλώσσα -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Γαλλικά"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Επεξεργασία"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"ΥΠΟΣΤΗΡΙΞΗ"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Παρακαλούμε μεταβείτε στην <a>ιστοσελίδα υποστήριξης</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Μπλοκάρισμα μιας διαφήμισης από την διεύθυνση URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Για παύση του AdBlock με ενεργοποιημένο αποκλεισμό περιεχομένου Safari, παρακαλούμε επιλέξτε Safari (στο μενού) > Προτιμήσεις > Επεκτάσεις > AdBlock, και αποεπιλέξτε το 'Ενεργοποίηση AdBlock'."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Έκδοση $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Ο σκοπός αυτής της ερώτησης είναι να καθοριστεί ποιος πρέπει να λάβει την αναφορά σας. Αν δεν απαντήσετε σωστά σε αυτή την ερώτηση, η αναφορά θα αποσταλεί σε λάθος άνθρωπους, έτσι ώστε να μπορεί να αγνοηθεί."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Η αναφορά διαφημίσεων είναι εθελοντική. Βοηθά άλλους ανθρώπους με την ενεργοποίηση των συντηρητών λίστας φίλτρων, να μπλοκάρουν τη διαφήμιση για όλους. Αν δεν αισθάνεστε αλτρουιστικά αυτή τη στιγμή, δεν πειράζει. Κλείστε αυτή τη σελίδα και <a>μπλοκάρετε τη διαφήμιση</a> μόνο για εσάς."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Ναι"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Ο πηγαίος κώδικας είναι <a>ελεύθερα διαθέσιμος</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Ολλανδικά"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Θα το χρησιμοποιήσουμε μόνο για να επικοινωνήσουμε μαζί σας εάν χρειαστούμε περισσότερες πληροφορίες."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Αυτό αντιστοιχεί σε μόνο <b>1</b> αντικείμενο στη σελίδα."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"ανανεώθηκε πριν $hours$ ώρες",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Πίσω"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Κάντε κλικ εδώ για: <a>Απενεργοποίηση αποδεκτών διαφημίσεων</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Τομέας της σελίδας για εφαρμογή"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Ενημερώσεις AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Κάτι πήγε λάθος. Κανένας πόρος δεν έχει αποσταλεί. Αυτή η σελίδα θα κλείσει τώρα. Δοκιμάστε να φορτώσετε ξανά την ιστοσελίδα."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Μάθετε περισσότερα για το κακόβουλο λογισμικό"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Ιστοσελίδα:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Αποδεκτές διαφημίσεις (προτείνεται)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Φαίνεται εντάξει"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Για παύση του AdBlock με ενεργοποιημένο αποκλεισμό περιεχομένου Safari, παρακαλούμε επιλέξτε Safari (στο μενού) > Προτιμήσεις > Επεκτάσεις > AdBlock, και αποεπιλέξτε το 'Ενεργοποίηση AdBlock'."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Ανοίξτε τη <a href='#'>σελίδα επεκτάσεων</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - κλικ για λεπτομέρειες"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Απενεργοποίηση όλων των επεκτάσεων εκτός από το AdBlock:"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Attach a screenshot:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"No known malware found."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"In that browser, subscribe to the same filter lists as you have here."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"In that browser, load the page with the ad."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Swedish"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Block more ads:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Russian"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Unsubscribed."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Chinese"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"If you have created a working filter using the \"block an ad\" wizard, paste it in the box below:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocial filter list (removes social media buttons)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Found an ad on a web page? We'll help you find the right place to report it!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show number of ads blocked on AdBlock button"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"The source code is <a>freely available</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"updated 1 minute ago"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Failed to fetch this filter!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Please restart Safari to finish turning off content blocking."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Block an ad by its URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Hide this button"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"I will fetch updates automatically; you can also <a>update now</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estonian"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Type"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"There's an update for AdBlock! Go $here$ to update. <br> Note: If you want to receive updates automatically, just click on Safari > Preferences > Extensions > Updates <br> and check option 'Install updates automatically'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"What's this?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Don't subscribe to more than you need -- every one slows you down a tiny bit! Credits and more lists can be found <a>here</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This AdBlock feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polish"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Find out more about the Acceptable Ads program."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"updated $seconds$ seconds ago",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Hungarian"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Note: your report may become publicly available. Keep that in mind before including anything private."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Please disable some filter lists. More information in AdBlock's Options."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Filter origin:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, AdBlock is disabled on this page by one of your filter lists."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"The filter is invalid: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Warning: no filter specified!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock is disabled on this page."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Show ads <i>everywhere</i> except for these domains..."
+    "message":"Got a question or new idea?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Options"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Blocked ads:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Add filters for another language: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Click the ad, and I'll walk you through blocking it."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"If you're seeing an ad, don't make a bug report, make an <a>ad report</a>!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Great! You're all set."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Other"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock Support"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Required information is missing or invalid.  Please fill in the questions that have a red border."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Error saving the uploaded file."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Please type the correct filter below and press OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Step 1: Figure out what to block"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Danish"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (recommended)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ on this page",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Subframe"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"updated 1 hour ago"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Korean"
+    "message":"Polish"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"or Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"What's your name?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"The most popular Chrome extension, with over 40 million users! Blocks ads all over the web."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Show all requests"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"I don't want to check this"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Yes"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Undo my blocks on this domain"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Customize"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pause AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Are you sure that you want to subscribe to the $title$ filter list?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Exactly where on that page is the ad? What does it look like?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"or AdBlock for Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"style definition"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Content Blocking rule limit exceeded"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Finding ads...<br/><br/><i>This'll only take a moment.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where AdBlock shouldn't block anything"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ in total",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"All set!  We'll be in touch soon, most likely within a day, two if it's a holiday. In the meantime, look for an email from AdBlock. You'll find a link to your ticket on our help site there. If you prefer to follow along by email, you can do that, too!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"No"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Something went wrong. No resources have been sent through. This page will now close. Try reloading the website."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ukrainian"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"updated $minutes$ minutes ago",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"We unsubscribed you from Acceptable Ads because you turned on Safari Content Blocking. You can only select one at a time. (<a>Why?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"You're no longer subscribed to the Acceptable Ads filter list."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Malware protection"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Save"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Warning: on all other sites you will see ads!<br>This overrules all other filters for those sites."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Disable these notifications"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Subscribing to filter list..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"You are using an old version of AdBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock Options"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Check for malware that could be injecting ads:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"You have exceeded the Dropbox size limit. Please remove some entries from your custom or disabled filters, and try again."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Unpause AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Work around Hulu.com videos not playing (requires restarting your browser)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS to match"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Exclude"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Credit for translation goes to:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"Loading..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Right click an ad on a page to block it -- or block it here manually."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Note:  Whitelisting (allowing ads on) a page or site is not supported with Safari Content Blocking enabled."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"We'll only use this to contact you if we need more information."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Edit disabled filters:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Enable Safari Content Blocking"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"What's your email address?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the AdBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"There was an error processing your request."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"page"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Done! We reloaded the page with the ad. Please check that page to see whether the ad is gone. Then come back to this page and answer the question below."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Or enter a URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the AdBlock toolbar button to pause AdBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Click the Safari menu &rarr; Preferences &rarr; Extensions."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Stop blocking ads:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Block it!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Does the ad still appear?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bulgarian"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Great! Now let's find out which extension is the cause. Go through and enable each extension one by one. The extension that brings back the ad(s) is the one you need to uninstall to get rid of the ads."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Failed!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Manually edit your filters:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italian"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Type"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovak"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Subscribe to filter lists"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"You can turn this back on and support the websites you love by selecting \"Allow some non-intrusive advertising\" below."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Does the ad appear in that browser too?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Don't run on this page"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Lithuanian"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Let us know on our <a>support site</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock is paused."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"We can't block ads inside Flash and other plugins yet. We are awaiting support from the browser and WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"General"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"If you'd rather not see ads like this one, you may want to leave the Acceptable Ads filter list turned off."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Your computer may be infected by malware.  Click <a>here</a> for more information."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"other"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"No filter specified!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"unknown"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japanese"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Allow some non-intrusive advertising"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Cancel"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages AdBlock won't run on."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"We turned off Safari Content Blocking because you opted to allow non-intrusive ads. You can only select one at a time. (<a>Why?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Last step: report the issue to us."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Check in Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"To report an ad, you must be connected to the Internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (recommended)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Reporting an ad"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Ad Blocking Filter Lists"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"How?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Allow whitelisting of specific YouTube channels"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Third-party"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (removes annoyances on the Web)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - click for details"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"updated $hours$ hours ago",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Russian and Ukrainian"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"What's new in the latest release? See the <a style='cursor:pointer;'>changelog</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"The extensions that were previously disabled have been re-enabled."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Greek"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Hide a section of a webpage"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videos and Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"What do you think will be true about this ad every time you visit this page?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Enable AdBlock on this page"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Back"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"The filter lists block most ads on the web.  You can also:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Check the Acceptable Ads filters:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Show ads on a webpage or domain"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"That matches <b>1</b> item on this page."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"I don't want to check this"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Please restart Safari to finish turning off content blocking."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Be careful: if you make a mistake here a lot of other filters, including the official filters, could get broken too!<br/>Read the <a>filter syntax tutorial</a> to learn how to add advanced blacklist and whitelist filters."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Whitelist $name$ channel",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Does the ad appear in that browser too?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"General options"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"If you'd rather not see ads like this one, you may want to leave the Acceptable Ads filter list turned off."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock won't run on any page matching:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"We don't have a default filter list for that language.<br/>Please try to find a suitable list that supports this language $link$ or block this ad for yourself on the 'Customize' tab.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Subscribe"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"I'm an advanced user, show me advanced options"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Spanish"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Loaded on page with domain:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Click this: <a>Update my filters!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower AdBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Last step: What makes this an ad?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"That matches $matchcount$ items on this page.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out the people behind AdBlock, as well!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesian"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turkish"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Block an ad"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Custom Filter Lists"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"Frame URL: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"The purpose of this question is to determine who should receive your report. If you answer this question incorrectly, the report will be sent to the wrong people, so it may get ignored."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Add items to the right click menu"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"selector"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Block this ad"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Have our team requested some debug info? Click <a href='#' id='debug'>here</a> for that!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run AdBlock on..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Reporting ads is voluntary. It helps other people by enabling the filter list maintainers to block the ad for everyone. If you're not feeling altruistic right now, that's okay. Close this page and <a>block the ad</a> just for yourself."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Hidden element"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Reload the page."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"page"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Dutch"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"That file name is too long. Please give your file a shorter name."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Don't forget to save!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Checking for updates (should only take a few seconds)..."
+    "message":"Lithuanian"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Subscribe to this filter list, then try again: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should AdBlock notify you when it detects malware?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Your computer may be infected by malware.  Click <a>here</a> for more information."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on AdBlock menu"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Show ads on a webpage or domain"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Site:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock custom filters (recommended)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Latvian"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Make sure you're using the right language filter(s):"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS to match"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"To hide the button, go to opera://extensions and check the 'Hide from toolbar' option. You can show it again by unchecking that option."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Not sure?</b> just press 'Block it!' below."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Matched filter"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Fetching... please wait."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"All Resources"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock is up-to-date!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Don't run on pages on this domain"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Hebrew"
+    "message":"Slovak"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Slide the slider until the ad is blocked correctly on the page, and the blocked element looks useful."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Block URLs containing this text"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"The number of filter list rules exceeds the 50,000 limit, and has been automatically reduced. Please unsubscribe from some filter lists or disable Safari Content Blocking!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"updated 1 day ago"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Acceptable Ads (recommended)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Click this: <a>Disable Acceptable Ads</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Version $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Install Adblock Plus for Firefox $chrome$ if you don't have it.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Remove from list"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"We don't have a default filter list for that language.<br/>Please try to find a suitable list that supports this language $link$ or block this ad for yourself on the 'Customize' tab.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"That's not an image file. Please upload a .png, .gif, or .jpg file."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Why don't you send us a <a>bug report</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"hiding"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Filter lists"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Frame domain: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Click the ad, and I'll walk you through blocking it."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Top frame"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"style definition"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"unknown"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, AdBlock is disabled on this page by one of your filter lists."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Third-party"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"No filter specified!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Greek"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of AdBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"What's your name?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Work around Hulu.com videos not playing (requires restarting your browser)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Warning: no filter specified!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Customize"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Found an ad on a web page? We'll help you find the right place to report it!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estonian"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgarian"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Whitelisted resource"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Content Blocking rule limit exceeded"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run AdBlock on..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Block URLs containing this text"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Close"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Check in Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Last step: What makes this an ad?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"If you're seeing an ad, don't make a bug report, make an <a>ad report</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Korean"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the AdBlock toolbar button to pause AdBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finnish"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ukrainian"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"No known malware found."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in AdBlock's Options."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"We unsubscribed you from Acceptable Ads because you turned on Safari Content Blocking. You can only select one at a time. (<a>Why?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out the people behind AdBlock, as well!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"here"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Reload the page."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"In what language is that page written?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock is paused."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Unpause AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Finding ads...<br/><br/><i>This'll only take a moment.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock is disabled on this page."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"In that browser, subscribe to the same filter lists as you have here."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Block an ad"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Warning: on all other sites you will see ads!<br>This overrules all other filters for those sites."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"There's an update for AdBlock! Go $here$ to update. <br> Note: If you want to receive updates automatically, just click on Safari > Preferences > Extensions > Updates <br> and check option 'Install updates automatically'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Finished!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock custom filters (recommended)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Type"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"What's this?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japanese"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Filter origin:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Subscribe to filter lists"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Frame type: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Add filters for another language: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Resource"
+    "message":"Matched filter"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Block an ad on this page"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"The filter lists block most ads on the web.  You can also:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Make sure your filter lists are up to date:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the AdBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"English"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"You have exceeded the Dropbox size limit. Please remove some entries from your custom or disabled filters, and try again."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Icelandic"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Subscribe"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Open the extensions page to enable the extensions that were previously disabled."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Note:  Whitelisting (allowing ads on) a page or site is not supported with Safari Content Blocking enabled."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domain of page to apply on"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blocked element:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"page"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"other"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Click this: <a>Update my filters!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Hidden element"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"To hide the button, go to opera://extensions and check the 'Hide from toolbar' option. You can show it again by unchecking that option."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Page:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Found a bug?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Block it!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Allow whitelisting of specific YouTube channels"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"We can't block ads inside Flash and other plugins yet. We are awaiting support from the browser and WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Arabic"
+    "message":"Hungarian"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Block this ad"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Enable AdBlock on this page"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show number of ads blocked on AdBlock button"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Failed!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pause AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Czech"
+    "message":"English"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Pay what you want!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Add items to the right click menu"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes AdBlock tick?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Please go to <a>our support website</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Adblock Warning Removal list (removes warnings about using ad blockers)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Invalid list URL. It'll be deleted."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"page"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Edit"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Are you sure you want to remove the $count$ blocks that you have created on $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Got a question or new idea?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legend: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"You forgot to attach a screenshot! We can't help you without seeing the ad(s) you're reporting."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>OR</b>, just click this button for us to do all of the above: <a>Disable all other extensions</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"updated $minutes$ minutes ago",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Learn more about malware"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Attach a screenshot:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Romanian"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Edit disabled filters:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Subframe"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Reload the page with the ad."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Enable Safari Content Blocking"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Install Firefox $chrome$ if you don't have it.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Filter lists"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"If you have created a working filter using the \"block an ad\" wizard, paste it in the box below:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"That file is too big. Please make sure your file is less than 10 MB."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock won't run on any page matching:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Chinese"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"The filter is invalid: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Subscribing to filter list..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Open the extensions page to enable the extensions that were previously disabled."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Disable these notifications"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turkish"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Don't subscribe to more than you need -- every one slows you down a tiny bit! Credits and more lists can be found <a>here</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesian"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"image"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ in total",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Cancel"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Don't forget to save!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"selector"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"We turned off Safari Content Blocking because you opted to allow non-intrusive ads. You can only select one at a time. (<a>Why?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Icelandic"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Ad Blocking Filter Lists"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Only block ads on these sites:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Loaded on page with domain:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"The extensions that were previously disabled have been re-enabled."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Clean up this list"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Help spread the word!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock updates"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Adblock Warning Removal list (removes warnings about using ad blockers)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock Options"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"There was an error processing your request."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"updated 1 hour ago"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Checking for updates (should only take a few seconds)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"updated right now"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Right click an ad on a page to block it -- or block it here manually."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Check for malware that could be injecting ads:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock Support"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Type"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Slide the slider until the ad is blocked correctly on the page, and the blocked element looks useful."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"updated 1 minute ago"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Blocked resource"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"The following information will also be included in the ad report."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Danish"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Check the Acceptable Ads filters:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"You can turn this back on and support the websites you love by selecting \"Allow some non-intrusive advertising\" below."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Fetching... please wait."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Invalid list URL. It'll be deleted."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"General options"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the \"Enabled\" checkbox next to every extension <b>except</b> for AdBlock.  <b>Leave AdBlock enabled</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"In that browser, load the page with the ad."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Show ads <i>everywhere</i> except for these domains..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"You forgot to attach a screenshot! We can't help you without seeing the ad(s) you're reporting."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"And manually create a ticket, and copy and paste the information below into the \"Fill in any details you think will help us understand your issue\" section."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"To hide the button, right click it and choose Hide Button.  You can show it again under chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebrew"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This AdBlock feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Czech and Slovak"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"We've disabled all other extensions. Now we'll reload the page with the ad. One second, please."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Other Filter Lists"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"French"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"I will fetch updates automatically; you can also <a>update now</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blocked element:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Show all requests"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interactive object"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower AdBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Great! You're all set."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Open the <a href='#'>extensions page</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"All set!  We'll be in touch soon, most likely within a day, two if it's a holiday. In the meantime, look for an email from AdBlock. You'll find a link to your ticket on our help site there. If you prefer to follow along by email, you can do that, too!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Find out more about the Acceptable Ads program."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should AdBlock notify you when it detects malware?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"updated right now"
+    "message":"updated 1 day ago"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"Frame URL: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"German"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"That file name is too long. Please give your file a shorter name."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"updated $seconds$ seconds ago",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Don't run on this page"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Let us know on our <a>support site</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Done! We reloaded the page with the ad. Please check that page to see whether the ad is gone. Then come back to this page and answer the question below."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"All Resources"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Whitelist $name$ channel",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Resource"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on AdBlock menu"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Reporting an ad"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"How?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Don't run on pages on this domain"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Custom Filter Lists"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Block more ads:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Required information is missing or invalid.  Please fill in the questions that have a red border."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where AdBlock shouldn't block anything"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"You're no longer subscribed to the Acceptable Ads filter list."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (removes annoyances on the Web)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock has blocked a download from a site known to host malware."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Save"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Not sure?</b> just press 'Block it!' below."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Last step: report the issue to us."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Exactly where on that page is the ad? What does it look like?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Looks good"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Allow AdBlock to collect anonymous filter list usage and data"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"To report an ad, you must be connected to the Internet."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Are you sure that you want to subscribe to the $title$ filter list?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"updated $days$ days ago",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"interactive object"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"What do you think will be true about this ad every time you visit this page?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Blocked ads:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arabic"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Undo my blocks on this domain"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Manually edit your filters:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Step 1: Figure out what to block"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Please type the correct filter below and press OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Credit for translation goes to:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock is up-to-date!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"English only"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>OR</b>, just click this button for us to do all of the above: <a>Disable all other extensions</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"What's new in the latest release? See the <a style='cursor:pointer;'>changelog</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (privacy protection)"
+    "message":"Antisocial filter list (removes social media buttons)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Report an ad on this page"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Malware protection"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Clean up this list"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"I'm an advanced user, show me advanced options"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"German"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage AdBlock can use. Please unsubscribe from some filter lists!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Be careful: this filter blocks all $elementtype$ elements on the page!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"here"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"What's your email address?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"In what language is that page written?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes AdBlock tick?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Are you sure you want to remove the $count$ blocks that you have created on $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"image"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Hide a section of a webpage"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"And manually create a ticket, and copy and paste the information below into the \"Fill in any details you think will help us understand your issue\" section."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"General"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"To hide the button, right click it and choose Hide Button.  You can show it again under chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"or AdBlock for Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Romanian"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videos and Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Something went wrong while checking updates."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"We've disabled all other extensions. Now we'll reload the page with the ad. One second, please."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Whitelisted resource"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Great! Now let's find out which extension is the cause. Go through and enable each extension one by one. The extension that brings back the ad(s) is the one you need to uninstall to get rid of the ads."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Czech and Slovak"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"or Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Frame type: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~site1.com|~site2.com|~news.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Select Language -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Install Adblock Plus for Firefox $chrome$ if you don't have it.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Blocked resource"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Does the ad appear in or before a film or any other plugin like a Flash game?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ will be $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"The filter, which can be changed on the Options page:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"The following filter:<br/> $filter$ <br/> has an error: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Close"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Only block ads on these sites:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage AdBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Allow AdBlock to collect anonymous filter list usage and data"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, you can still block this ad for yourself on the Options page. Thanks!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Submit"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finnish"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"That file is too big. Please make sure your file is less than 10 MB."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"The following information will also be included in the ad report."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Pay what you want!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"This is a filter list problem. Report it here: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the \"Enabled\" checkbox next to every extension <b>except</b> for AdBlock.  <b>Leave AdBlock enabled</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Note: your report may become publicly available. Keep that in mind before including anything private."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Show links to the filter lists"
+  "filteritalian":{
+    "description":"language",
+    "message":"Italian"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"English only"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Help spread the word!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Does the ad still appear?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock has blocked a download from a site known to host malware."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Make sure you're using the right language filter(s):"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legend: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Make sure your filter lists are up to date:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Something went wrong while checking updates."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Click the Safari menu &rarr; Preferences &rarr; Extensions."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Submit"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Unsubscribed."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Latvian"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Block an ad on this page"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Stop blocking ads:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Error saving the uploaded file."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"That matches $matchcount$ items on this page.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Failed to fetch this filter!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages AdBlock won't run on."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"hiding"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Does the ad appear in or before a film or any other plugin like a Flash game?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Russian and Ukrainian"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spanish"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Be careful: this filter blocks all $elementtype$ elements on the page!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Enable ClickToFlash compatibility mode"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"No"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"The filter, which can be changed on the Options page:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Hide this button"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Other"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, you can still block this ad for yourself on the Options page. Thanks!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Russian"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Why don't you send us a <a>bug report</a>?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (privacy protection)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ will be $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Or enter a URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"The following filter:<br/> $filter$ <br/> has an error: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"Loading..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Have our team requested some debug info? Click <a href='#' id='debug'>here</a> for that!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"The number of filter list rules exceeds the 50,000 limit, and has been automatically reduced. Please unsubscribe from some filter lists or disable Safari Content Blocking!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Report an ad on this page"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Frame domain: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"The most popular Chrome extension, with over 40 million users! Blocks ads all over the web."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Found a bug?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Czech"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"That's not an image file. Please upload a .png, .gif, or .jpg file."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Show links to the filter lists"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Allow some non-intrusive advertising"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Swedish"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Remove from list"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Select Language -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"French"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Edit"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Support"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Please go to <a>our support website</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Block an ad by its URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"To pause AdBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > AdBlock, and uncheck 'Enable AdBlock'."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Version $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"The purpose of this question is to determine who should receive your report. If you answer this question incorrectly, the report will be sent to the wrong people, so it may get ignored."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Reporting ads is voluntary. It helps other people by enabling the filter list maintainers to block the ad for everyone. If you're not feeling altruistic right now, that's okay. Close this page and <a>block the ad</a> just for yourself."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Yes"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"The source code is <a>freely available</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Dutch"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"We'll only use this to contact you if we need more information."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"That matches <b>1</b> item on this page."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"updated $hours$ hours ago",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Back"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Click this: <a>Disable Acceptable Ads</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domain of page to apply on"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock updates"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Something went wrong. No resources have been sent through. This page will now close. Try reloading the website."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Learn more about malware"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Site:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Acceptable Ads (recommended)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Looks good"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause AdBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > AdBlock, and uncheck 'Enable AdBlock'."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Open the <a href='#'>extensions page</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - click for details"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for AdBlock:"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,719 +1,195 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Informar de un anuncio"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Lista de filtros de bloqueo de publicidad"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Sitio:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permitir no bloquear anuncios en canales específicos de Youtube"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (elimina las molestias en internet)"
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"En ese navegador, suscríbete a las mismas listas que tengas en éste."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - Haz click para más detalles"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"En ese navegador, carga la página con el anuncio."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Sueco"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"¿Qué novedades hay en la última versión? ¡Compruébalo en la <a>lista de cambios</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Bloquear más anuncios:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Ruso"
+    "message":"Danés"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"¡Paga lo que quieras!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"¡Ayuda a correr la voz!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Subscripción desactivada."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Bloquear un anuncio por su URL"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Griego"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Chino"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Vídeos y Flash"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Protección contra software malicioso"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"¿Qué crees que es correcto sobre este anuncio cada vez que visitas la página?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Habilitar AdBlock en esta página"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Atrás"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Mostrar número de anuncios bloqueados en el botón de AdBlock"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"¿Tienes alguna pregunta o idea nueva?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Las listas de filtros bloquean la mayoría de los anuncios de la red. También puedes:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"¡El código fuente está <a>disponible para todos</a>!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Mostrar anuncios en una web o dominio"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Eso incluye <b>1</b> elemento en la página."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Ocultar una sección de la página"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"No se bloquean anuncios en el canal $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opciones generales"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Tu ordenador puede estar infectado por malware. Haz click <a>aquí</a> para obtener más información."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock no actuará en ninguna de estas páginas:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"No tenemos un filtro determinado para ese idioma.<br/>Por favor, busca un link con este idioma $link$ o bloquea este anuncio por ti mismo en la pestaña de 'Personalizar'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Suscribirse"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Soy un usuario avanzado, muéstrame opciones avanzadas"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Ocultar este botón"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Recibiré actualizaciones automáticamente, aunque también puedes <a>actualizar ahora</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Haz clic aquí: <a>¡Actualizar mis filtros!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formato: ~sitio1.com|~sitio2.com|~noticias.sitio3.org"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock está pausado."
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Eso incluye $matchcount$ elementos en la página.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"¡También tenemos una <a>página</a> en la que puedes echar un vistazo a toda la gente que hace posible AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesio"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tipo"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"¡Hay una actualización disponible para AdBlock! Dirígete $here$ para actualizar. <br> Atención: Si quieres recibir actualizaciones automáticamente, haz clic en Safari > Preferencias > Extensiones > Actualizaciones <br> y marca la opción 'Instalar actualizaciones automáticamente'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turco"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"¿Qué es esto?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Lista de filtros elegidos"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"No te sucribas a más de los que necesitas, ¡cada uno ralentiza un poquito tu navegación! Los créditos y otras listas las puedes encontrar <a>aquí</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definición de estilo"
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Esta característica de AdBlock no funciona en este sitio porque utiliza tecnología obsoleta. Puedes prohibir o permitir recursos manualmente en la pestaña 'Personalizar' de la página de opciones."
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"El propósito de esta pregunta es determinar quién debe recibir su informe. Si contestas de forma equivocada, el informe se enviará a las personas equivocadas, y podría ser ignorado."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polaco"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Añadir elementos al menú de clic derecho"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Bloquear este anuncio"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"Actualizado hace $hours$ horas",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"Actualizado hace $seconds$ segundos",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"¿Nuestro equipo te ha solicitado información de depuración? ¡Haz clic <a href='#' id='debug'>aquí</a> para enviárnosla!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"objeto interactivo"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Húngaro"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"URL de lista inválida. Será eliminada."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Nota: su informe puede hacerse público. Téngalo en cuenta antes de incluir algo privado."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Recargar la página."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"página"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Holandés"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"¡No te olvides de guardar!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ será $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Cerrar"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Elemento bloqueado:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"El filtro es inválido: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Aviso: ¡No se ha especificado un filtro!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permitir que AdBlock recoja anónimamente datos sobre el uso de las listas de filtros"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"¿Deseas que AdBlock te notifique cuando detecte malware?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Mostrar anuncios <i>en todas partes</i> excepto en estos dominios..."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Mostrar número de anuncios bloqueados en el menú de AdBlock"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Opciones"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"No utilizar AdBlock en..."
-  },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Anuncios bloqueados:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Filtros personalizados de AdBlock (recomendado)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Añadir filtros para otro idioma: "
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Letón"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Las extensiones que habían sido deshabilitadas han sido activadas de nuevo."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Bloquear las URLs que contengan este texto"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS que bloquear"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Para ocultar el botón, vaya a opera://externsions y marque la opción 'Ocultar de la barra de herramientas'. Puedes mostrarlo de nuevo desmarcando esta opción."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Haz clic en el anuncio, y te echaré una mano para bloquearlo."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Informar de un anuncio en esta página"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Ruso y ucraniano"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Recibiendo... Por favor, espera."
   },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Ten cuidado: ¡si cometes un error muchos filtros, incluyendo los oficiales, podrían estropearse también!<br/>Lee el <a>tutorial de la sintaxis de filtros</a> para aprender como añadir filtros avanzados a la lista negra y blanca."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"General"
   },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Soporte de AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Personalizar AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"¡AdBlock está actualizado!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ en total",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Hebreo"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Lo siento, AdBlock está desactivado en esta página por una de tus listas de filtros."
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Deshacer mis bloqueos en este dominio"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Por favor escribe el filtro correcto debajo y pulsa Aceptar"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"Actualizado hace un día"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (elimina las molestias en internet)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ en esta página",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>¿No estás seguro?</b> Tan solo pulsa '¡Bloquéalo!' debajo."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"URL de lista inválida. Será eliminada."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"Actualizado hace una hora"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Polaco"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versión $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opciones generales"
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Borrar de la lista"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Otro"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS que bloquear"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"ocultando"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Listas de filtros"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"¿El anuncio aparece antes del vídeo o plugin (como un juego en Flash), o aparece en él?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Otras listas de filtros"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"o Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"¡Bloquéalo!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"¡Completado!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Bloquear un anuncio en esta página"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Cerrar"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"No quiero comprobar esto"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock no actuará en ninguna de estas páginas:"
   },
-  "lang_english":{
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Mostrar anuncios <i>en todas partes</i> excepto en estos dominios..."
+  },
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Ten cuidado: ¡si cometes un error muchos filtros, incluyendo los oficiales, podrían estropearse también!<br/>Lee el <a>tutorial de la sintaxis de filtros</a> para aprender como añadir filtros avanzados a la lista negra y blanca."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Inglés"
+    "message":"Eslovaco"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Personalizar"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pausar AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"¿Estás seguro de que deseas suscribirte a la lista de filtros $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Abre la página de extensiones para activar las extensiones que fueron desactivadas anteriormente."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Dominio de la página que bloquear"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Coreano"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Página:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"¿Has encontrado un error?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Paso 1: Averigua qué bloquear"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Checho"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Cuantas más listas de filtros uses, más lentamente se ejecutará AdBlock. Utilizar demasiadas listas podría incluso llegar a hacer que el navegador se cerrase inesperadamente en determinados sitios web. Pulsa 'De acuerdo' para ser suscriptor de esta lista de todas formas."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"o AdBlock para Chrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Bloquear un anuncio"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Sí"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"¿Aparece el anuncio también en ese navegador?"
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Último paso: ¿Qué hace esto un anuncio?"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"No actuar en esta página"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Danés"
+    "message":"Rumano"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Para ocultar el botón haz click derecho y elige \"Ocultar botón\". Puedes volverlo a mostrar en chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebreo"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Esta característica de AdBlock no funciona en este sitio porque utiliza tecnología obsoleta. Puedes prohibir o permitir recursos manualmente en la pestaña 'Personalizar' de la página de opciones."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Checo y Eslovaco"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Otras listas de filtros"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Opciones"
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Tu ordenador puede estar infectado por malware. Haz click <a>aquí</a> para obtener más información."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Recibiré actualizaciones automáticamente, aunque también puedes <a>actualizar ahora</a>"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"marco"
+    "message":"desconocido"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Editar"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Mostrar anuncios en una web o dominio"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Encontrando anuncios...<br/><br/><i>Esto solo tardará un momento.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turco"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"El dominio o URL en el cual AdBlock no debería bloquear nada"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Comprobando la existencia de actualizaciones (sólo debe tardar unos pocos segundos)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Cuantas más listas de filtros uses, más lentamente se ejecutará AdBlock. Utilizar demasiadas listas podría incluso llegar a hacer que el navegador se cerrase inesperadamente en determinados sitios web. Pulsa 'De acuerdo' para ser suscriptor de esta lista de todas formas."
   },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"No actuar en páginas de este dominio"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Recarga la página con el anuncio."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Instalar Firefox $chrome$ si no lo tienes.",
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Suscríbete a ese filtro, y vuelve a intentarlo: $list_title$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"No tenemos un filtro determinado para ese idioma.<br/>Por favor, busca un link con este idioma $link$ o bloquea este anuncio por ti mismo en la pestaña de 'Personalizar'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -721,242 +197,381 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Haz clic en el anuncio, y te echaré una mano para bloquearlo."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"definición de estilo"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Actualizaciones de AdBlock"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"No"
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Lo siento, AdBlock está desactivado en esta página por una de tus listas de filtros."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"¿Deseas que AdBlock te notifique cuando detecte malware?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"Actualizado hace un día"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"¡No se ha especificado un filtro!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Alemán"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Suscribirse a listas de filtros"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Griego"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"Actualizado hace $seconds$ segundos",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>¿No estás seguro?</b> Tan solo pulsa '¡Bloquéalo!' debajo."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"En ese navegador, carga la página con el anuncio."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"¡Háznoslo saber en nuestro <a>sitio de soporte</a>!"
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Comprobación de malware"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Bloquear anuncios solo en estos sitios:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Personalizar"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Para informar de un anuncio, debes estar conectado a internet."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"¡Ok!"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"No se bloquean anuncios en el canal $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Ocultar una sección de la página"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Mostrar número de anuncios bloqueados en el menú de AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Informar de un anuncio"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Búlgaro"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"No actuar en páginas de este dominio"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Lista de filtros elegidos"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Bloquear más anuncios:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ucraniano"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"Actualizado hace $minutes$ minutos",
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tipo"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"El dominio o URL en el cual AdBlock no debería bloquear nada"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"No utilizar AdBlock en..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Bloquear las URLs que contengan este texto"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Excluir"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Compruébalo en Firefox $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Francés"
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>O</b>, simplemente haz clic en este botón para que hagamos nosotros todo indicado arriba: <a>Desactivar todas las demás extensiones</a>"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"Actualizado ahora mismo"
   },
   "savebutton":{
     "description":"Save button",
     "message":"Guardar"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Aviso: ¡en todos los demás sitios web verás anuncios!<br>Esto se salta las normas de todos los otros filtros para estos sitios."
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
   },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Desactivar estas notificaciones"
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Subscribiéndose a la lista de filtros..."
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Se ve bien"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Personalizar AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"No se ha encontrado malware conocido."
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permitir que AdBlock recoja anónimamente datos sobre el uso de las listas de filtros"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Solución para los vídeos de Hulu.com que no se reproducen (requiere reiniciar el navegador)"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finlandés"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Ocultar este botón"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Lista de filtros de bloqueo de publicidad"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"Actualizado hace $days$ días",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"marco"
+    "message":"objeto interactivo"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (protección de la privacidad)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"¿Qué crees que es correcto sobre este anuncio cada vez que visitas la página?"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Aprender más sobre el malware"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Checo y Eslovaco"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Estás usando una versión antigua de AdBlock. Por favor ve <a href='#'> al administrador de extensiones</a>, activa el modo para desarrolladores y haz click en \"Actualizar extensiones ahora\""
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Opciones de AdBlock"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Comprobación de malware"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Limpiar esta lista"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Lista de filtros Antisocial (elimina los botones de las redes sociales)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Mostrar datos debug en la consola (lo que ralentiza AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Has excedido el límite de espacio de Dropbox. Elimina algunas entradas de tus filtros personalizados o desactivados y vuélvelo a intentar."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Reactivar AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Alemán"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Ten cuidado: ¡Esto bloqueará todos los elementos de tipo $elementtype$ de la página!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"aquí"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Sí"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Solución para los vídeos de Hulu.com que no se reproducen (requiere reiniciar el navegador)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Excluir"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"¿En que idioma está escrita esa página?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"¿Estás seguro de que quieres eliminar los $count$ bloqueos que has creado para $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"imagen"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Los créditos por la traducción son para:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"CARGANDO..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Haz clic derecho en un anuncio de la página para bloquearlo -- o bloquéalo aquí manualmente."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Para ocultar el botón haz click derecho y elige \"Ocultar botón\". Puedes volverlo a mostrar en chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumano"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Editar filtros desactivados:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Anuncios Aceptables (recomendado)"
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Algo ha fallado durante la comprobación de actualizaciones."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Para ocultar el botón, haz clic derecho en la barra de herramientas de Safari y selecciona 'Personalizar barra de herramientas', a continuación arrastra el botón de AdBlock fuera de la barra. Puedes volverlo a mostrar arrastrándolo de vuelta a la barra de herramientas."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"Actualizado hace un minuto"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Anuncios bloqueados:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"página"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Coreano"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Deshacer mis bloqueos en este dominio"
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Editar manualmente tus filtros:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Mostrar enlaces a las listas de filtros"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (recomendado)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Paso 1: Averigua qué bloquear"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"¡También tenemos una <a>página</a> en la que puedes echar un vistazo a toda la gente que hace posible AdBlock!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Sitio:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"aquí"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"ventana emergente"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Si ves un anuncio, no hagas un informe de errores, ¡haz un <a>informe de anuncios</a>!"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"¡AdBlock está actualizado!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Recargar la página."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Sólo en inglés"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Estás usando una versión antigua de AdBlock. Por favor ve <a href='#'> al administrador de extensiones</a>, activa el modo para desarrolladores y haz click en \"Actualizar extensiones ahora\""
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock está pausado."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>O</b>, simplemente haz clic en este botón para que hagamos nosotros todo indicado arriba: <a>Desactivar todas las demás extensiones</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"¿Qué novedades hay en la última versión? ¡Compruébalo en la <a>lista de cambios</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Lista de filtros Antisocial (elimina los botones de las redes sociales)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Encontrando anuncios...<br/><br/><i>Esto solo tardará un momento.</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Soy un usuario avanzado, muéstrame opciones avanzadas"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"En ese navegador, suscríbete a las mismas listas que tengas en éste."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Bloquear un anuncio"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Aviso: ¡en todos los demás sitios web verás anuncios!<br>Esto se salta las normas de todos los otros filtros para estos sitios."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Las extensiones que habían sido deshabilitadas han sido activadas de nuevo."
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"¿Quieres ver los engranajes que mueven AdBlock?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Filtros personalizados de AdBlock (recomendado)"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"¿Qué es esto?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -968,289 +583,83 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"O introduce una URL:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"o AdBlock para Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Estás utilizando una versión antigua de Safari. Consigue la última versión para utilizar el botón de AdBlock de la barra para pausar AdBlock, añadir páginas a la lista blanca, e informar de anuncios. <a>Actualizar ahora</a>."
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Seleccionar idioma -- "
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Los créditos por la traducción son para:"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formato: ~sitio1.com|~sitio2.com|~noticias.sitio3.org"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Haz clic en el menú de Safari &rarr; Preferencias &rarr; Extensiones."
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Para de bloquear anuncios:"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Vídeos y Flash"
   },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"¡La extensión más popular de Chrome, con más de 40 millones de usuarios! Bloquea anuncios de todo internet."
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Las listas de filtros bloquean la mayoría de los anuncios de la red. También puedes:"
   },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"¿Sigue apareciendo el anuncio?"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Para ocultar el botón, haz clic derecho en la barra de herramientas de Safari y selecciona 'Personalizar barra de herramientas', a continuación arrastra el botón de AdBlock fuera de la barra. Puedes volverlo a mostrar arrastrándolo de vuelta a la barra de herramientas."
   },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Soporte"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Has excedido el límite de espacio de Dropbox. Elimina algunas entradas de tus filtros personalizados o desactivados y vuélvelo a intentar."
   },
-  "filtereasylist_plus_bulgarian":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Búlgaro"
+    "message":"Húngaro"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"¿Quieres ver los engranajes que mueven AdBlock?"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"o Chrome"
   },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"No se ha encontrado malware conocido."
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Suscribirse"
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"¡Falló!"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"¡Paga lo que quieras!"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"El filtro, que puede cambiarse en la página de opciones:"
-  },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"Editar manualmente tus filtros:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"El siguiente filtro: <br/> $filter$ <br/> tiene un error: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"ventana emergente"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Mueve la barra hasta que el anuncio esté correctamente bloqueado, y se vea bien."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tipo"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Eslovaco"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Suscribirse a listas de filtros"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"¿Aparece el anuncio también en ese navegador?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"No actuar en esta página"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Bloquear anuncios solo en estos sitios:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"¡Háznoslo saber en nuestro <a>sitio de soporte</a>!"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Último paso: ¿Qué hace esto un anuncio?"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Has excedido el límite de almacenamiento que AdBlock puede usar. ¡Por favor, elimina tu suscripción a algunas listas de filtros!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"No podemos bloquear por el momento anuncios dentro de aplicaciones Flash u otros plugins. Estamos esperando que sea soportado por el navegador y WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"¡Ok!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"Vale, puedes seguir bloqueando el anuncio tú mismo en la página de opciones. ¡Gracias!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"General"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"otro"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Enviar"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"¡No se ha especificado un filtro!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"desconocido"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finlandés"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock está desactivado en esta página."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/vídeo"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japonés"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Permitir alguna publicidad no molesta"
+    "message":"Editar filtros desactivados:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Hay un problema de la lista de filtros. Informa de él aquí: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Desmarca la casilla de \"Activado\" de cada extensión <b>excepto</b> la de AbBlock. <b>Deja AdBlock activado</b>."
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Elemento bloqueado:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Mostrar enlaces a las listas de filtros"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Nota: su informe puede hacerse público. Téngalo en cuenta antes de incluir algo privado."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Sólo en inglés"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Cancelar"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"¡Ayuda a correr la voz!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Desliza el regulador para determinar en qué páginas del dominio AdBlock no se ejecutará."
-  },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock ha bloqueado una descarga de un sitio conocido por alojar software malicioso."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Compruébalo en Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Activar modo de compatibilidad con ClickToFlash"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Suscríbete a ese filtro, y vuelve a intentarlo: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Para informar de un anuncio, debes estar conectado a internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (recomendado)"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"¡Fallo al recibir esta lista!"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italiano"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Español"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Se ve bien"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Si ves un anuncio, no hagas un informe de errores, ¡haz un <a>informe de anuncios</a>!"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"¿Tienes alguna pregunta o idea nueva?"
+  "typepage":{
+    "description":"A resource type",
+    "message":"página"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1260,5 +669,636 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"¿Sigue apareciendo el anuncio?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"otro"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Haz clic aquí: <a>¡Actualizar mis filtros!</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Italiano"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Para ocultar el botón, vaya a opera://externsions y marque la opción 'Ocultar de la barra de herramientas'. Puedes mostrarlo de nuevo desmarcando esta opción."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Algo ha fallado durante la comprobación de actualizaciones."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Haz clic en el menú de Safari &rarr; Preferencias &rarr; Extensiones."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Enviar"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Página:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Recarga la página con el anuncio."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Subscripción desactivada."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/vídeo"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Letón"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Bloquear un anuncio en esta página"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"¡Bloquéalo!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Para de bloquear anuncios:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permitir no bloquear anuncios en canales específicos de Youtube"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"¿En que idioma está escrita esa página?"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Desmarca la casilla de \"Activado\" de cada extensión <b>excepto</b> la de AbBlock. <b>Deja AdBlock activado</b>."
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Borrar de la lista"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"No podemos bloquear por el momento anuncios dentro de aplicaciones Flash u otros plugins. Estamos esperando que sea soportado por el navegador y WebKit."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Desliza el regulador para determinar en qué páginas del dominio AdBlock no se ejecutará."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"ocultando"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock está desactivado en esta página."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"¿El anuncio aparece antes del vídeo o plugin (como un juego en Flash), o aparece en él?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Ruso y ucraniano"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Español"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Bloquear este anuncio"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Ten cuidado: ¡Esto bloqueará todos los elementos de tipo $elementtype$ de la página!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Activar modo de compatibilidad con ClickToFlash"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"No"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Habilitar AdBlock en esta página"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"El filtro, que puede cambiarse en la página de opciones:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Mostrar número de anuncios bloqueados en el botón de AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"¡Falló!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pausar AdBlock"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"El siguiente filtro: <br/> $filter$ <br/> tiene un error: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Inglés"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Añadir elementos al menú de clic derecho"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"Vale, puedes seguir bloqueando el anuncio tú mismo en la página de opciones. ¡Gracias!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Ruso"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"¿Estás seguro de que quieres eliminar los $count$ bloqueos que has creado para $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Estás utilizando una versión antigua de Safari. Consigue la última versión para utilizar el botón de AdBlock de la barra para pausar AdBlock, añadir páginas a la lista blanca, e informar de anuncios. <a>Actualizar ahora</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (protección de la privacidad)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ será $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"O introduce una URL:"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"¡Completado!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Reactivar AdBlock"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Añadir filtros para otro idioma: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"CARGANDO..."
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Haz clic derecho en un anuncio de la página para bloquearlo -- o bloquéalo aquí manualmente."
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Protección contra software malicioso"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Informar de un anuncio en esta página"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Mostrar datos debug en la consola (lo que ralentiza AdBlock)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Instalar Firefox $chrome$ si no lo tienes.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Mueve la barra hasta que el anuncio esté correctamente bloqueado, y se vea bien."
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Has excedido el límite de almacenamiento que AdBlock puede usar. ¡Por favor, elimina tu suscripción a algunas listas de filtros!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"¡La extensión más popular de Chrome, con más de 40 millones de usuarios! Bloquea anuncios de todo internet."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"¿Has encontrado un error?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Aprender más sobre el malware"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Listas de filtros"
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Desactivar estas notificaciones"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Chino"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"El filtro es inválido: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Subscribiéndose a la lista de filtros..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Abre la página de extensiones para activar las extensiones que fueron desactivadas anteriormente."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Eso incluye $matchcount$ elementos en la página.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"Actualizado hace una hora"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Seleccionar idioma -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francés"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesio"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"imagen"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Editar"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"¡Fallo al recibir esta lista!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ en total",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Soporte"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Bloquear un anuncio por su URL"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Cancelar"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"¡No te olvides de guardar!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Anuncios Aceptables (recomendado)"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versión $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"El propósito de esta pregunta es determinar quién debe recibir su informe. Si contestas de forma equivocada, el informe se enviará a las personas equivocadas, y podría ser ignorado."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"¿Estás seguro de que deseas suscribirte a la lista de filtros $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"¡El código fuente está <a>disponible para todos</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holandés"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Por favor escribe el filtro correcto debajo y pulsa Aceptar"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"¡Hay una actualización disponible para AdBlock! Dirígete $here$ para actualizar. <br> Atención: Si quieres recibir actualizaciones automáticamente, haz clic en Safari > Preferencias > Extensiones > Actualizaciones <br> y marca la opción 'Instalar actualizaciones automáticamente'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Eso incluye <b>1</b> elemento en la página."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japonés"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Limpiar esta lista"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"Actualizado hace $hours$ horas",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Atrás"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Opciones de AdBlock"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock ha bloqueado una descarga de un sitio conocido por alojar software malicioso."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"No te sucribas a más de los que necesitas, ¡cada uno ralentiza un poquito tu navegación! Los créditos y otras listas las puedes encontrar <a>aquí</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Comprobando la existencia de actualizaciones (sólo debe tardar unos pocos segundos)..."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Otro"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Dominio de la página que bloquear"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"Actualizado ahora mismo"
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"¿Nuestro equipo te ha solicitado información de depuración? ¡Haz clic <a href='#' id='debug'>aquí</a> para enviárnosla!"
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"Actualizado hace $minutes$ minutos",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Checho"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Permitir alguna publicidad no molesta"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Sueco"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Soporte de AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tipo"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"marco"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"Actualizado hace un minuto"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"marco"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - Haz click para más detalles"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Aviso: ¡No se ha especificado un filtro!"
   }
 }

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -1,1351 +1,1169 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Liitä ruutukaappaus:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Tunnettuja haittaohjelmia ei löytynyt."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Tilaa samat suodatinlistat kyseisessä selaimessa kuin sinulla on tässä."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Lataa sivu, jolla on mainos, sillä selaimella."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Ruotsi"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Estä lisää mainoksia:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"venäjä"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Poistettu käytöstä."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"kiina"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Jos olet luonut toimivan suodattimen \"estä mainos\" -toiminnon avulla, liitä se alla olevaan ruutuun:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Epäsosiaalinen suodatinluottelo (poistaa some-painikkeet)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Löysitkö mainoksen netistä? Autamme sinua ilmoittamaan siitä!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Näytä estettyjen mainosten määrän AdBlock-painikkeessa"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Lähdekoodi on <a>vapaasti saatavilla</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"päivitetty minuutti sitten"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Suodattimen haku epäonnistui!"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Tietokoneesi voi olla haittaohjelman saastuttama. Klikkaa <a>tästä</a> saadaksesi lisää tietoja."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Estä mainos sen osoitteen avulla"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Piilota tämä painike"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Automaattiset päivitykset ovat käytössä; voit myös <a>päivittää nyt</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Muoto: ~sivu1.com|~sivu2.com|~uutiset.sivu3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"viro"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tyyppi"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"AdBlock-päivitys on saatavilla! Napsauta $here$ päivittääksesi.<br>Huomaa: Jos haluat saada päivitykset automaattisesti, napsauta Safari > Asetukset > Lisäosat > Päivitykset<br>ja merkitse kohta 'Asenna päivitykset automaattisesti'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Mikä tämä on?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Älä ota käyttöön liian monta suodatinta -- jokainen hidastaa vähän lisää! Tekijöiden tiedot ja lisälistoja löytyy <a>täältä</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Tämä AdBlock-ominaisuus ei toimi tällä sivustolla, koska sitä käytetään vanhentuneella tekniikalla. Voit lisätä kohteita mustalle tai valkoisille listalle manuaalisesti \"Mukauta\"-välilehdessä."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"puola"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Lisätietoja hyväksyttävistä mainoksista."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"päivitetty $seconds$ sekuntia sitten",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"unkari"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Huomautus: ilmoituksesi saatetaan julkaista. Pidä se mielessä ennen kuin sisällytät mitään yksityistä."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Poista joitakin suodatinlistoja käytöstä. Lisätietoja AdBlockin asetuksissa."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Suodattimen alkuperä:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"AdBlock on poistettu käytöstä tällä sivulla (suodatinlistojen perusteella)."
-  },
-  "filtericelandic":{
-    "description":"language",
-    "message":"islanti"
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Varoitus: suodatinta ei määritetty!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock on pois käytöstä tällä sivulla."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Näytä mainokset <i>kaikkialla</i> paitsi näissä verkkotunnuksissa..."
+    "message":"Onko sinulla kysymys tai ehdotus?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Asetukset"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Estetyt mainokset:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Lisää suodattimia toiselle kielelle: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Napsauta mainosta estääksesi sen."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>TAI</b>, klikkaa tätä painiketta, niin teemme kaiken puolestasi: <a>Poista kaikki muut laajennukset käytöstä</a>"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Upeaa! Olet valmis."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Muu"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock-tuki"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Mukauta AdBlockia"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Vaadittuja tietoja puuttuu tai ne ovat virheellisiä. Tarkista kysymykset, jotka on reunustettu punaisella."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Virhe tallennettaessa ladattua tiedostoa."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Kirjoita oikea suodatin alle ja napsauta OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Vaihe 1: määritä, mitä estetään"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"tanska"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (suositeltu)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ tällä sivulla",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Alikehys"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"päivitetty tunti sitten"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"korea"
+    "message":"puola"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"tai Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Mikä on nimesi?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Chromen suosituin lisäosa. Yli 40 miljoonaa käyttäjää! Estää kaikki mainokset."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Näytä kaikki pyynnöt"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"En halua tarkistaa tätä"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Kyllä"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Kumoa estoni tässä verkkotunnuksessa"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Mukauta"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pysäytä AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Oletko varma, että haluat tilata suodatinlistan $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Missä kohtaa sivua mainos tarkalleen ottaen on? Miltä mainos näyttää?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"tai AdBlock Chromelle"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"tyylimääritelmä"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Sisällöneston sääntöjen raja ylitetty"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Etsitään mainoksia...<br/><br/><i>Tämä kestää hetken.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Osoite tai verkkotunnus, jossa AdBlockin ei pitäisi estää mitään"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"komentosarja"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ yhteensä",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Valmista! Olemme yhteydessä pian, todennäköisesti päivän tai loma-aikoina parin päivän kuluessa. Odotellessa voit lukea AdBlockilta saamasi sähköpostin. Löydät linkin lähettämääsi pyyntöön ohjesivustollemme. Jos haluat seurata edistymistä sähköpostistasi, se hoituu myös siellä!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Ei"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Joku meni vikaan. Resursseja ei kuitenkaan ole lähetetty. Tämä sivu sulkeutuu nyt. Yritä päivittää verkkosivu."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"ukraina"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"päivitetty $minutes$ minuuttia sitten",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Et enää tilaa hyväksyttävät mainokset -suodatinlistaa."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Haittaohjelmien suodatus"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Tallenna"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Varoitus: näet kaikissa muissa sivustoissa mainoksia!<br>Tämä ohittaa kaikki filtterit muissa sivustoissa."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Poista nämä ilmoitukset käytöstä"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Otetaan suodatinlistaa käyttöön..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Käytät vanhaa versiota AdBlockista. Siirry <a href='#'>lisäosasivulle</a>, ota 'Kehittäjätila' käyttöön ja napsauta 'Päivitä lisäosat nyt'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlockin asetukset"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Mainoksia lisäävien haittaohjelmien tarkistus:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Näytä virheilmoitukset Virhekonsolissa (hidastaa AdBlockin toimintaa)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Olet ylittänyt Dropboxin kokorajoituksen. Poista kohteita mukautetuista tai käytöstä poistetuista suodattimista ja yritä uudelleen."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Jatka AdBlockin käyttöä"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Korjaa ongelma, jossa Hulu.com-videot eivät toimi (vaatii selaimen uudelleenkäynnistyksen)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"Vastaava CSS"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Poista käytöstä"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Poista kaikki laajennukset käytöstä, paitsi AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Kiitokset käännöksestä seuraaville:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"LADATAAN..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Klikkaa hiiren oikealla painikkeella mainosta sivulla -- tai estä se tässä manuaalisesti."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Huomaa: mainosten salliminen tietyillä sivuilla ei ole mahdollista, kun Safarin sisällönesto on käytössä."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Käytämme sähköpostiosoitettasi vain silloin, jos tarvitsemme lisätietoja sinulta."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Muokkaa suodattimia, jotka poistettu käytöstä:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Ota Safarin sisällönesto käyttöön"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Mikä on sähköpostiosoitteesi?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Piilottaaksesi painikkeen, klikkaa hiiren oikealla Safarin työkaluriviä ja valitse Mukauta työkaluriviä, sitten vedä AdBlock-painike pois työkaluriviltä. Voit näyttää sen uudelleen vetämällä sen takaisin työkaluriviin."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Virhe käsiteltäessä pyyntöä."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"sivu"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Valmista! Mainoksen sisältänyt sivu on nyt päivitetty. Tarkista, onko mainos edelleen sivulla. Tule sitten takaisin tälle sivulle ja vastaa alla olevaan kysymykseen."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Tai syötä osoite:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Käytät Safarin vanhaa versiota. Lataa uusin versio käyttääksesi AdBlockin työkalurivin painiketta AdBlockin toiminnan keskeyttämiseen, verkkosivujen mainosteneston käytöstä poistoon, ja mainoksista ilmoittamiseen. <a>Päivitä nyt</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Napsauta Safari-valikkoa &rarr; Asetukset &rarr; Lisäosat."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Lopeta mainosten estäminen:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Estä!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Näkyykö mainos edelleen?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"bulgaria"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Hienoa! Selvitetäänpä nyt, mistä laajennuksesta ongelma johtuu. Ota laajennukset yksi kerrallaan käyttöön. Laajennus, jonka käyttöönoton myötä mainos palaa, on sellainen, joka sinun tulee poistaa päästäksesi eroon mainoksesta."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Virhe!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Muokkaa suodattimia manuaalisesti:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"italia"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"ponnahdusikkuna"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tyyppi"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovakki"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Ota suodatinlistoja käyttöön"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Voit kytkeä tämän takaisin päälle ja tukea sivustoja, joista pidät, valitsemalla \"Salli osa ei-häiritsevästä mainonnasta\" alla."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Näkyykö mainos myös siinä selaimessa?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Älä käytä tällä sivulla"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"liettua"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Kerro meille <a>tukisivustolla</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock on pysäytetty."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Mainosten estäminen Flash- ja muiden lisäosien sisällä ei vielä ole mahdollista. Odotamme tukea selaimelta ja WebKitiltä."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Mitä uutta uusimmassa versiossa? Katso <a style='cursor:pointer;'>muutosloki</a>!"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Jos et myöskään halua nähdä tällaisia mainoksia, voit jättää hyväksyttävien mainosten suodatinlistan pois päältä."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"muu"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Suodatinta ei määritetty!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"tuntematon"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"ääni tai video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"japani"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Salli osa ei-häiritsevästä mainonnasta"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Peruuta"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Voit raahata alla olevaa palkkia määrittääksesi sivut, joilla AdBlock ei ole käytössä."
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Viimeinen vaihe: kerro meille ongelmasta."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Tarkista Firefoxissa $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Ilmoittaaksesi mainoksesta sinun täytyy olla yhteydessä internetiin."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (suositeltu)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Mainoksen ilmoittaminen"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Mainostenestolistat"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Kuinka?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Salli tiettyjen YouTube-kanavien mainosten näyttäminen"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Kolmas osapuoli"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (poistaa ärsyttävät kohteet verkosta)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - napsauta saadaksesi tietoja"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"päivitetty $hours$ tuntia sitten",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Venäjä ja ukraina"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Salli AdBlockin kerätä nimettömiä tietoja suodatinlistojen käytöstä ja datasta"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Laajennukset, jotka oli aiemmin poistettu käytöstä, on nyt otettu takaisin käyttöön."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"kreikka"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Piilota verkkosivun kohta"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videot ja Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Mitkä ehdot pitää mielestäsi täyttyä joka kerta tällä sivustolla käytäessä?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Salli AdBlock tällä sivulla"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Edellinen"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Suodatinlistat estävät suurimman osan mainoksista.  Voit myös:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Tarkista hyväksyttävien mainosten suodatinlistat:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Näytä mainokset verkko-osoitteessa tai verkkotunnuksessa"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Suodatin vastaa <b>1</b> kohdetta tällä sivulla."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"En halua tarkistaa tätä"
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Ole varovainen: jos teet virheen tässä, myös viralliset suodattimet voivat lakata toimimasta!<br/>Lue <a>suodattimen syntaksiopas</a> saadaksesi lisätietoja suodattimien muokkauksesta."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Salli kanava $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Näkyykö mainos myös siinä selaimessa?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Yleiset asetukset"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Jos et myöskään halua nähdä tällaisia mainoksia, voit jättää hyväksyttävien mainosten suodatinlistan pois päältä."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock ei ole käytössä sivuilla, jotka vastaavat näitä ehtoja:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Tälle kielelle ei ole oletussuodatinlistaa.<br/>Yritä löytää sopiva lista tälle kielelle  $link$ tai estä tämä mainos itse 'Mukauta' -välilehdellä.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Ota käyttöön"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Olen edistynyt käyttäjä, näytä edistyneet asetukset"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"espanja"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Ladattiin sivu verkkotunnuksessa:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Napsauta tästä: <a>Päivitä suodattimeni!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Mitä enemmän suodatinlistoja sinulla on käytössä, sitä hitaammin AdBlock toimii. Jos käytät liian paljon listoja, selaimesi saattaa jopa kaatua joillakin verkkosivuilla. Paina OK liittyäksesi listalle varoituksesta huolimatta."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Viimeinen vaihe: mikä tekee tästä mainoksen?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Suodatin vastaa $matchcount$ kohdetta tällä sivulla.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Lisäksi löydät kaikki AdBlockin takana olevat henkilöt <a>täältä</a>!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesia"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turkki"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Estä mainos"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Mukautetut suodatinlistat"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"Kehyksen osoite: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Tämän kysymyksen tarkoitus on se, kuka saa vastaanottaa raporttisi. Jos vastaat tähän kysymykseen väärin, raportti lähetetään väärille henkilöille, ja se saatetaan hylätä."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Lisää kohteet oikean klikkauksen valikkoon"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"valitsin"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Estä tämä mainos"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Onko tiimi pyytänyt vianratkaisutietoja? Napsauta <a href='#' id='debug'>tästä</a> saadaksesi ne!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Älä käytä AdBlockia..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Mainoksista ilmoittaminen on vapaaehtoista. Mainoksista ilmoittamalla autat suodatinlistojen ylläpidossa, jolloin mainos piilotetaan jatkossa myös muilta. Jos et halua ilmoittaa nyt, asia on ok. Sulje tämä sivu ja <a>estä mainos</a> vain itseltäsi."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Piilotettu elementti"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Lataa sivu uudelleen."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"sivu"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"hollanti"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Tiedoston nimi on liian pitkä. Anna tiedostolle lyhyempi nimi."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Muista tallentaa!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Tarkistetaan päivityksiä (kestää vain muutaman sekunnin)..."
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Yleiset"
+    "message":"liettua"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Ota suodatinlista käyttöön, ja yritä sitten uudestaan: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Ilmoita, kun haittaohjelma havaitaan"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Tietokoneesi voi olla haittaohjelman saastuttama. Klikkaa <a>tästä</a> saadaksesi lisää tietoja."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Näytä estettyjen mainosten määrän AdBlock-valikossa"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Näytä mainokset verkko-osoitteessa tai verkkotunnuksessa"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Sivusto:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlockin mukautetut listat (suositeltu)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Latvia"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Varmista, että käytät oikean kielen suodatinlistaa/-listoja:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"Vastaava CSS"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Jos haluat piilottaa painikkeen, siirry osoitteeseen opera://extensions ja valitse ruutu 'Piilota työkaluriviltä'. Voit ottaa painikkeen käyttöön uudestaan poistamalla valinnan ruudusta."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Etkö ole varma?</b> Paina vain 'Estä!'-painiketta."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Vastaava suodatin"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Haetaan... odota hetki."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Kaikki resurssit"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock on ajan tasalla!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Älä käytä tämän verkkotunnuksen sivuilla"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Heprea"
+    "message":"Slovakki"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Raahaa säädintä oikealle niin kauan, että mainos häviää näkyvistä ja sivu näyttää hyvältä."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Estä osoitteet, jotka sisältävät tämän tekstin"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Suodatinlistojen kohteiden määrä ylittää rajan 50 000, ja kohteita on poistettu automaattisesti. Poista joidenkin suodatinlistojen tilaus tai poista Safarin sisällönesto käytöstä!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"päivitetty päivä sitten"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Hyväksyttävät mainokset (suositus)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Klikkaa tästä: <a>poista hyväksyttävät mainokset käytöstä</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versio $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Asenna AdBlock Plus Firefoxille $chrome$ jos sinulla ei ole sitä.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Poista listalta"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Tälle kielelle ei ole oletussuodatinlistaa.<br/>Yritä löytää sopiva lista tälle kielelle  $link$ tai estä tämä mainos itse 'Mukauta' -välilehdellä.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Et ladannut kuvatiedostoa. Lataa .png-, .gif- tai .jpg-tiedosto."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Mikset lähettäisi meille <a>virheilmoitusta</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"piilottaminen"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Suodatinlistat"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Kehysverkkotunnus: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Napsauta mainosta estääksesi sen."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Pääkehys"
   },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Valmis!"
-  },
-  "headerresource":{
-    "description":"Resource list page: title of a column",
-    "message":"Resurssi"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Estä mainos tällä sivulla"
-  },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Varmista, että suodatinlistasi ovat ajan tasalla:"
-  },
-  "lang_english":{
-    "description":"language",
-    "message":"englanti"
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Avaa laajennukset-sivu ottaaksesi käyttöön laajennukset, jotka oli poistettu aiemmin käytöstä."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Sivun verkkotunnus, jossa käytetään"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Sivu:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Oletko löytänyt ohjelmavirheen?"
-  },
-  "filtereasylist_plus_arabic":{
-    "description":"language",
-    "message":"arabia"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"tšekki"
-  },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Maksa mitä haluat!"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Haluatko nähdä, kuinka AdBlock toimii?"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Listan osoite ei kelpaa. Se poistetaan."
-  },
-  "typesub_frame":{
+  "typestylesheet":{
     "description":"A resource type",
-    "message":"kehys"
+    "message":"tyylimääritelmä"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Muokkaa"
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"tuntematon"
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Onko sinulla kysymys tai ehdotus?"
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"AdBlock on poistettu käytöstä tällä sivulla (suodatinlistojen perusteella)."
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Unohdit liittää kuvakaappauksen! Emme voi auttaa sinua, jos emme näe mainosta tai mainoksia, jota/joita olet ilmoittamassa."
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Kolmas osapuoli"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Suodatinta ei määritetty!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"kreikka"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Käytät vanhaa versiota AdBlockista. Siirry <a href='#'>lisäosasivulle</a>, ota 'Kehittäjätila' käyttöön ja napsauta 'Päivitä lisäosat nyt'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Mikä on nimesi?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Korjaa ongelma, jossa Hulu.com-videot eivät toimi (vaatii selaimen uudelleenkäynnistyksen)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Varoitus: suodatinta ei määritetty!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Mukauta"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Löysitkö mainoksen netistä? Autamme sinua ilmoittamaan siitä!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"viro"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"bulgaria"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Sallittu resurssi"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Sisällöneston sääntöjen raja ylitetty"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Älä käytä AdBlockia..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Estä osoitteet, jotka sisältävät tämän tekstin"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Sulje"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Tarkista Firefoxissa $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Viimeinen vaihe: mikä tekee tästä mainoksen?"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Mukauta AdBlockia"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"korea"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Mikset lähettäisi meille <a>virheilmoitusta</a>?"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"suomi"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"komentosarja"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"ukraina"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Tunnettuja haittaohjelmia ei löytynyt."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Poista joitakin suodatinlistoja käytöstä. Lisätietoja AdBlockin asetuksissa."
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Lisäksi löydät kaikki AdBlockin takana olevat henkilöt <a>täältä</a>!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"tästä"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"ponnahdusikkuna"
   },
   "ad_report_please":{
     "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
     "message":"Jos näet mainoksen, ethän tee virheilmoitusta, vaan tee <a>ilmoitus mainoksesta</a>!"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Lisätietoja haittaohjelmista"
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Lataa sivu uudelleen."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Millä kielellä sivu on kirjoitettu?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock on pysäytetty."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Jatka AdBlockin käyttöä"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Etsitään mainoksia...<br/><br/><i>Tämä kestää hetken.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock on pois käytöstä tällä sivulla."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Tilaa samat suodatinlistat kyseisessä selaimessa kuin sinulla on tässä."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Estä mainos"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Varoitus: näet kaikissa muissa sivustoissa mainoksia!<br>Tämä ohittaa kaikki filtterit muissa sivustoissa."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"AdBlock-päivitys on saatavilla! Napsauta $here$ päivittääksesi.<br>Huomaa: Jos haluat saada päivitykset automaattisesti, napsauta Safari > Asetukset > Lisäosat > Päivitykset<br>ja merkitse kohta 'Asenna päivitykset automaattisesti'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Valmis!"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlockin mukautetut listat (suositeltu)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tyyppi"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Mikä tämä on?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"japani"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Suodattimen alkuperä:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Ota suodatinlistoja käyttöön"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Sivusto:"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Lisää suodattimia toiselle kielelle: "
+  },
+  "headerfilter":{
+    "description":"Resource list page: title of a column",
+    "message":"Vastaava suodatin"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Suodatinlistat estävät suurimman osan mainoksista.  Voit myös:"
+  },
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Piilottaaksesi painikkeen, klikkaa hiiren oikealla Safarin työkaluriviä ja valitse Mukauta työkaluriviä, sitten vedä AdBlock-painike pois työkaluriviltä. Voit näyttää sen uudelleen vetämällä sen takaisin työkaluriviin."
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Olet ylittänyt Dropboxin kokorajoituksen. Poista kohteita mukautetuista tai käytöstä poistetuista suodattimista ja yritä uudelleen."
+  },
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Ota käyttöön"
+  },
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Huomaa: mainosten salliminen tietyillä sivuilla ei ole mahdollista, kun Safarin sisällönesto on käytössä."
+  },
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Estetty kohde:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"sivu"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"muu"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Napsauta tästä: <a>Päivitä suodattimeni!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Piilotettu elementti"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Jos haluat piilottaa painikkeen, siirry osoitteeseen opera://extensions ja valitse ruutu 'Piilota työkaluriviltä'. Voit ottaa painikkeen käyttöön uudestaan poistamalla valinnan ruudusta."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Sivu:"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Estä!"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Salli tiettyjen YouTube-kanavien mainosten näyttäminen"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Mainosten estäminen Flash- ja muiden lisäosien sisällä ei vielä ole mahdollista. Odotamme tukea selaimelta ja WebKitiltä."
+  },
+  "filterhungarian":{
+    "description":"language",
+    "message":"unkari"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Estä tämä mainos"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Salli AdBlock tällä sivulla"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Näytä estettyjen mainosten määrän AdBlock-painikkeessa"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Virhe!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pysäytä AdBlock"
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"englanti"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Lisää kohteet oikean klikkauksen valikkoon"
+  },
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Siirry <a>tukisivustollemme</a>."
+  },
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Mainostenestovaroitusten poisto (poistaa varoitukset mainostenestäjistä)"
+  },
+  "typemain_frame":{
+    "description":"A resource type",
+    "message":"sivu"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Oletko varma, että haluat poistaa $count$ estoa, jotka olet estänyt verkkotunnuksessa $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Selite: "
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"päivitetty $minutes$ minuuttia sitten",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Liitä ruutukaappaus:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"romania"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Muokkaa suodattimia, jotka poistettu käytöstä:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Alikehys"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Päivitä sivu, joka sisältää mainoksen."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Ota Safarin sisällönesto käyttöön"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Asenna Firefox $chrome$ jos sinulla ei ole sitä.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Suodatinlistat"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Jos olet luonut toimivan suodattimen \"estä mainos\" -toiminnon avulla, liitä se alla olevaan ruutuun:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Tiedosto on liian iso. Varmista, että tiedosto on alle 10 Mt."
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Olen edistynyt käyttäjä, näytä edistyneet asetukset"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"kiina"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Suodatin ei kelpaa: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Otetaan suodatinlistaa käyttöön..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Avaa laajennukset-sivu ottaaksesi käyttöön laajennukset, jotka oli poistettu aiemmin käytöstä."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Poista nämä ilmoitukset käytöstä"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turkki"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Älä ota käyttöön liian monta suodatinta -- jokainen hidastaa vähän lisää! Tekijöiden tiedot ja lisälistoja löytyy <a>täältä</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"kehys"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesia"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"kuva"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ yhteensä",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Peruuta"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Muista tallentaa!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"valitsin"
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"islanti"
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Oletko varma, että haluat tilata suodatinlistan $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Estä mainokset vain näillä sivuilla:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Ladattiin sivu verkkotunnuksessa:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Laajennukset, jotka oli aiemmin poistettu käytöstä, on nyt otettu takaisin käyttöön."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Puhdista lista"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Auta välittämään sanaa!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock-päivitykset"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Mainostenestovaroitusten poisto (poistaa varoitukset mainostenestäjistä)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlockin asetukset"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Virhe käsiteltäessä pyyntöä."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"päivitetty tunti sitten"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Tarkistetaan päivityksiä (kestää vain muutaman sekunnin)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"päivitetty juuri nyt"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Klikkaa hiiren oikealla painikkeella mainosta sivulla -- tai estä se tässä manuaalisesti."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Mainoksia lisäävien haittaohjelmien tarkistus:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock-tuki"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tyyppi"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Raahaa säädintä oikealle niin kauan, että mainos häviää näkyvistä ja sivu näyttää hyvältä."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"päivitetty minuutti sitten"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"kehys"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Estetty resurssi"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Myös seuraavat tiedot sisältyvät virheilmoitukseen."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"tanska"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Tarkista hyväksyttävien mainosten suodatinlistat:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Voit kytkeä tämän takaisin päälle ja tukea sivustoja, joista pidät, valitsemalla \"Salli osa ei-häiritsevästä mainonnasta\" alla."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Haetaan... odota hetki."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Listan osoite ei kelpaa. Se poistetaan."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Yleiset asetukset"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Poista rasti ruudusta 'Käytössä' jokaiselta lisäosalta <b>paitsi</b> AdBlockilta. <b>Jätä AdBlock käyttöön</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Lataa sivu, jolla on mainos, sillä selaimella."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Näytä mainokset <i>kaikkialla</i> paitsi näissä verkkotunnuksissa..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Unohdit liittää kuvakaappauksen! Emme voi auttaa sinua, jos emme näe mainosta tai mainoksia, jota/joita olet ilmoittamassa."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Ja luo pyyntö manuaalisesti. Kopioi ja liitä alla olevat tiedot \"Fill in any details you think will help us understand your issue\" -kohtaan."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Piilottaaksesi painikkeen, napsauta sitä hiiren oikealla ja napsauta Piilota painike. Voit ottaa sen takaisin käyttöön kohdassa chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Heprea"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Tämä AdBlock-ominaisuus ei toimi tällä sivustolla, koska sitä käytetään vanhentuneella tekniikalla. Voit lisätä kohteita mustalle tai valkoisille listalle manuaalisesti \"Mukauta\"-välilehdessä."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Tshekki ja slovakia"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Kaikki muut laajennukset on nyt poistettu käytöstä. Sivu, jolla mainos on, päivitetään nyt. Hetki vain."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Muut suodatinlistat"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"ranska"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Automaattiset päivitykset ovat käytössä; voit myös <a>päivittää nyt</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Estetty kohde:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Näytä kaikki pyynnöt"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktiivinen objekti"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Mitä enemmän suodatinlistoja sinulla on käytössä, sitä hitaammin AdBlock toimii. Jos käytät liian paljon listoja, selaimesi saattaa jopa kaatua joillakin verkkosivuilla. Paina OK liittyäksesi listalle varoituksesta huolimatta."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Upeaa! Olet valmis."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Avaa <a href='#'>laajennukset-sivu</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Valmista! Olemme yhteydessä pian, todennäköisesti päivän tai loma-aikoina parin päivän kuluessa. Odotellessa voit lukea AdBlockilta saamasi sähköpostin. Löydät linkin lähettämääsi pyyntöön ohjesivustollemme. Jos haluat seurata edistymistä sähköpostistasi, se hoituu myös siellä!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Lisätietoja hyväksyttävistä mainoksista."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Ilmoita, kun haittaohjelma havaitaan"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"päivitetty juuri nyt"
+    "message":"päivitetty päivä sitten"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"Kehyksen osoite: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"saksa"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Tiedoston nimi on liian pitkä. Anna tiedostolle lyhyempi nimi."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"päivitetty $seconds$ sekuntia sitten",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Älä käytä tällä sivulla"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Kerro meille <a>tukisivustolla</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Valmista! Mainoksen sisältänyt sivu on nyt päivitetty. Tarkista, onko mainos edelleen sivulla. Tule sitten takaisin tälle sivulle ja vastaa alla olevaan kysymykseen."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Kaikki resurssit"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Salli kanava $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Resurssi"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Näytä estettyjen mainosten määrän AdBlock-valikossa"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Mainoksen ilmoittaminen"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Kuinka?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Älä käytä tämän verkkotunnuksen sivuilla"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Mukautetut suodatinlistat"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Estä lisää mainoksia:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Vaadittuja tietoja puuttuu tai ne ovat virheellisiä. Tarkista kysymykset, jotka on reunustettu punaisella."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Osoite tai verkkotunnus, jossa AdBlockin ei pitäisi estää mitään"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Et enää tilaa hyväksyttävät mainokset -suodatinlistaa."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (poistaa ärsyttävät kohteet verkosta)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock esti latauksen sivustolta, joka on levittänyt haittaohjelmia."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Tallenna"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Etkö ole varma?</b> Paina vain 'Estä!'-painiketta."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Viimeinen vaihe: kerro meille ongelmasta."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Tämän kysymyksen tarkoitus on se, kuka saa vastaanottaa raporttisi. Jos vastaat tähän kysymykseen väärin, raportti lähetetään väärille henkilöille, ja se saatetaan hylätä."
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Näyttää hyvältä"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Salli AdBlockin kerätä nimettömiä tietoja suodatinlistojen käytöstä ja datasta"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Ilmoittaaksesi mainoksesta sinun täytyy olla yhteydessä internetiin."
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Mainostenestolistat"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"päivitetty $days$ päivää sitten",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"kehys"
+    "message":"interaktiivinen objekti"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Mitkä ehdot pitää mielestäsi täyttyä joka kerta tällä sivustolla käytäessä?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Estetyt mainokset:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"arabia"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Kumoa estoni tässä verkkotunnuksessa"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Muokkaa suodattimia manuaalisesti:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Vaihe 1: määritä, mitä estetään"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Kirjoita oikea suodatin alle ja napsauta OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Kiitokset käännöksestä seuraaville:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock on ajan tasalla!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Vain englanniksi"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>TAI</b>, klikkaa tätä painiketta, niin teemme kaiken puolestasi: <a>Poista kaikki muut laajennukset käytöstä</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Mitä uutta uusimmassa versiossa? Katso <a style='cursor:pointer;'>muutosloki</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (yksityisyydensuoja)"
+    "message":"Epäsosiaalinen suodatinluottelo (poistaa some-painikkeet)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Raportoi mainoksesta tällä sivulla"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Haittaohjelmien suodatus"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Puhdista lista"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock ei ole käytössä sivuilla, jotka vastaavat näitä ehtoja:"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"saksa"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"AdBlock käyttää tällä hetkellä liikaa tilaa, koska suodattimia on käytössä liian paljon. Poista osa suodattimista käytöstä!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Varoitus: tämä suodatin estää kaikki tyypin $elementtype$ kohteet tällä sivulla!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"tästä"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Mikä on sähköpostiosoitteesi?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Millä kielellä sivu on kirjoitettu?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Haluatko nähdä, kuinka AdBlock toimii?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Oletko varma, että haluat poistaa $count$ estoa, jotka olet estänyt verkkotunnuksessa $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"kuva"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Piilota verkkosivun kohta"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Ja luo pyyntö manuaalisesti. Kopioi ja liitä alla olevat tiedot \"Fill in any details you think will help us understand your issue\" -kohtaan."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Yleiset"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Piilottaaksesi painikkeen, napsauta sitä hiiren oikealla ja napsauta Piilota painike. Voit ottaa sen takaisin käyttöön kohdassa chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"tai AdBlock Chromelle"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"romania"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videot ja Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Jokin meni vikaan tarkistettaessa päivityksiä."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Kaikki muut laajennukset on nyt poistettu käytöstä. Sivu, jolla mainos on, päivitetään nyt. Hetki vain."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Sallittu resurssi"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Hienoa! Selvitetäänpä nyt, mistä laajennuksesta ongelma johtuu. Ota laajennukset yksi kerrallaan käyttöön. Laajennus, jonka käyttöönoton myötä mainos palaa, on sellainen, joka sinun tulee poistaa päästäksesi eroon mainoksesta."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1357,190 +1175,412 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Tshekki ja slovakia"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"tai Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Kehystyyppi: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Muoto: ~sivu1.com|~sivu2.com|~uutiset.sivu3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Valitse kieli -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Asenna AdBlock Plus Firefoxille $chrome$ jos sinulla ei ole sitä.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Estetty resurssi"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Näkyykö mains videossa tai jossakin muussa vastaavassa, kuten Flash-pelissä tai ennen sitä?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ arvossa $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Suodatin, jota voidaan muuttaa asetussivulla:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Seuraava suodatin:<br/>$filter$<br/> sisältää virheen:<br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Sulje"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Estä mainokset vain näillä sivuilla:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"AdBlock käyttää tällä hetkellä liikaa tilaa, koska suodattimia on käytössä liian paljon. Poista osa suodattimista käytöstä!"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Suodatin ei kelpaa: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, voit edelleen estää mainoksen vain itsellesi Asetukset-sivulla. Kiitos!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Lähetä"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"suomi"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Tiedosto on liian iso. Varmista, että tiedosto on alle 10 Mt."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Myös seuraavat tiedot sisältyvät virheilmoitukseen."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Maksa mitä haluat!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Tämä on suodatinlistan ongelma. Ilmoita se tästä: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Poista rasti ruudusta 'Käytössä' jokaiselta lisäosalta <b>paitsi</b> AdBlockilta. <b>Jätä AdBlock käyttöön</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Huomautus: ilmoituksesi saatetaan julkaista. Pidä se mielessä ennen kuin sisällytät mitään yksityistä."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Näytä linkit suodatinlistoille"
+  "filteritalian":{
+    "description":"language",
+    "message":"italia"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Vain englanniksi"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Auta välittämään sanaa!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Näkyykö mainos edelleen?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock esti latauksen sivustolta, joka on levittänyt haittaohjelmia."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Varmista, että käytät oikean kielen suodatinlistaa/-listoja:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Selite: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Varmista, että suodatinlistasi ovat ajan tasalla:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Jokin meni vikaan tarkistettaessa päivityksiä."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Napsauta Safari-valikkoa &rarr; Asetukset &rarr; Lisäosat."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Lähetä"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Poistettu käytöstä."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"ääni tai video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Latvia"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Estä mainos tällä sivulla"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Lopeta mainosten estäminen:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Virhe tallennettaessa ladattua tiedostoa."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Suodatin vastaa $matchcount$ kohdetta tällä sivulla.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Suodattimen haku epäonnistui!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Voit raahata alla olevaa palkkia määrittääksesi sivut, joilla AdBlock ei ole käytössä."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"piilottaminen"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Näkyykö mains videossa tai jossakin muussa vastaavassa, kuten Flash-pelissä tai ennen sitä?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Venäjä ja ukraina"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"espanja"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Varoitus: tämä suodatin estää kaikki tyypin $elementtype$ kohteet tällä sivulla!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"ClickToFlash-yhteensopivuustila"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Ei"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Suodatin, jota voidaan muuttaa asetussivulla:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Piilota tämä painike"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Muu"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, voit edelleen estää mainoksen vain itsellesi Asetukset-sivulla. Kiitos!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"venäjä"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Käytät Safarin vanhaa versiota. Lataa uusin versio käyttääksesi AdBlockin työkalurivin painiketta AdBlockin toiminnan keskeyttämiseen, verkkosivujen mainosteneston käytöstä poistoon, ja mainoksista ilmoittamiseen. <a>Päivitä nyt</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (yksityisyydensuoja)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ arvossa $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Tai syötä osoite:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Seuraava suodatin:<br/>$filter$<br/> sisältää virheen:<br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Kehystyyppi: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"LADATAAN..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Onko tiimi pyytänyt vianratkaisutietoja? Napsauta <a href='#' id='debug'>tästä</a> saadaksesi ne!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Suodatinlistojen kohteiden määrä ylittää rajan 50 000, ja kohteita on poistettu automaattisesti. Poista joidenkin suodatinlistojen tilaus tai poista Safarin sisällönesto käytöstä!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Raportoi mainoksesta tällä sivulla"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Näytä virheilmoitukset Virhekonsolissa (hidastaa AdBlockin toimintaa)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Kehysverkkotunnus: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Chromen suosituin lisäosa. Yli 40 miljoonaa käyttäjää! Estää kaikki mainokset."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Oletko löytänyt ohjelmavirheen?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"tšekki"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Et ladannut kuvatiedostoa. Lataa .png-, .gif- tai .jpg-tiedosto."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Näytä linkit suodatinlistoille"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Salli osa ei-häiritsevästä mainonnasta"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Ruotsi"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Poista listalta"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Valitse kieli -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"ranska"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Muokkaa"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Tuki"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Siirry <a>tukisivustollemme</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Estä mainos sen osoitteen avulla"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versio $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Missä kohtaa sivua mainos tarkalleen ottaen on? Miltä mainos näyttää?"
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Mainoksista ilmoittaminen on vapaaehtoista. Mainoksista ilmoittamalla autat suodatinlistojen ylläpidossa, jolloin mainos piilotetaan jatkossa myös muilta. Jos et halua ilmoittaa nyt, asia on ok. Sulje tämä sivu ja <a>estä mainos</a> vain itseltäsi."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Kyllä"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Lähdekoodi on <a>vapaasti saatavilla</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"hollanti"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Käytämme sähköpostiosoitettasi vain silloin, jos tarvitsemme lisätietoja sinulta."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Suodatin vastaa <b>1</b> kohdetta tällä sivulla."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"päivitetty $hours$ tuntia sitten",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Edellinen"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Klikkaa tästä: <a>poista hyväksyttävät mainokset käytöstä</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Sivun verkkotunnus, jossa käytetään"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock-päivitykset"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Joku meni vikaan. Resursseja ei kuitenkaan ole lähetetty. Tämä sivu sulkeutuu nyt. Yritä päivittää verkkosivu."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Lisätietoja haittaohjelmista"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Hyväksyttävät mainokset (suositus)"
   },
   "safaricontentblockingpausemessage":{
     "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
     "message":"Jos haluat keskeyttää AdBlockin toiminnan, kun sisällönesto on käytössä, valitse Safari (valikkopalkista) > Asetukset > Laajennukset > AdBlock ja poista rasti ruudusta 'Ota AdBlock käyttöön'."
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - napsauta saadaksesi tietoja"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Näyttää hyvältä"
-  },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Avaa <a href='#'>laajennukset-sivu</a>."
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Poista kaikki laajennukset käytöstä, paitsi AdBlock:"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Joignez une capture d'écran :"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Aucun logiciel malveillant connu n'a été trouvé."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Dans ce navigateur, abonnez-vous aux mêmes listes de filtres que vous avez ici."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Dans cet autre navigateur, ouvrez la page avec la publicité."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Suédois"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Bloquer plus de publicités :"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Russe"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Désabonné."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Chinois"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Si vous avez créé un filtre fonctionnel à l'aide de l'assistant \"bloquer une pub\", collez-le dans le champ ci-dessous :"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Liste de filtres Antisocial (supprime les boutons de réseaux sociaux)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Vous avez trouvé une pub sur une page web ? Nous allons vous aider à trouver le bon endroit pour la signaler !"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Afficher le nombre de pubs bloquées sur le bouton AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Le code source est <a>disponible librement</a> !"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"Mis à jour il y a 1 minute."
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Impossible de récupérer ce filtre !"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Merci de relancer Safari pour terminer la désactivation du Blocage de Contenu."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Bloquer une publicité par son URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Masquer ce bouton"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Les listes seront mises à jour automatiquement. Vous pouvez aussi les <a>mettre à jour maintenant</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format : ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estonien"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Type"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Il y a une mise à jour pour AdBlock ! Cliquez $here$ pour mettre à jour. <br>Note: si vous souhaitez recevoir des mises à jour automatiquement, il suffit de cliquer sur Safari > Préférences > Extensions > Mises à jour <br>et cocher l'option \"Installer automatiquement\".",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Qu'est-ce que c'est ?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Trop de filtres activés ralentissent la navigation, choisissez donc uniquement ceux qui vous sont utiles !<br/>Les crédits et autres listes se trouvent <a>ici</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Cette fonctionnalité d'AdBlock ne fonctionne pas sur ce site car celui-ci utilise des technologies obsolètes. Vous pouvez bloquer ou autoriser des ressources manuellement dans l'onglet \"Personnaliser\" des options AdBlock."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polonais"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"En savoir plus sur le programme Publicités Acceptables."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"Mis à jour il y a $seconds$ secondes.",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Hongrois"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Note : votre rapport peut être rendu public. Gardez cela à l'esprit avant d'inclure quoi que ce soit de privé."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Désactivez quelques listes de filtres. Plus d'infos dans les Options AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Origine du filtre :\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Désolé, AdBlock est désactivé sur cette page par un ou plusieurs de vos filtres."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filtre invalide : $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Attention : aucun filtre spécifié !"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock est désactivé sur cette page."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Afficher les publicités <i>partout</i> sauf sur ces domaines..."
+    "message":"Une question ou une nouvelle idée ?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Options"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Pubs bloquées :"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Ajouter des filtres pour une autre langue : "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Cliquez sur la pub à bloquer."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"une recherche de photos (ex : <i>course de voilier</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Si vous voyez une publicité sur un site, n'envoyez pas un rapport de bogue, mais <a>signalez-nous la publicité</a> !"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Génial ! Il n'y a rien d'autre à faire."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Autre"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Support AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Personnaliser AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Les informations requises sont invalides ou manquantes. Veuillez remplir les questions marquées en rouge."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Erreur lors de l'enregistrement du fichier téléversé."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Merci d'entrer le filtre correct ci-dessous et appuyer sur OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Étape 1 : Indiquer quoi bloquer"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Danois"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (recommandé)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ sur cette page",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Sous-cadre"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"Mis à jour il y a 1 heure."
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Coréen"
+    "message":"Polonais"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"ou Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Quel est votre nom ?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"La plus populaire des extensions Chrome, avec plus de 40 millions d'utilisateurs ! Bloque la publicité sur le web."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Afficher toutes les requêtes"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Je ne veux pas vérifier cela"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"Options CatBlock"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Oui"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Annuler mes blocages sur ce domaine"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Personnaliser"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Désactiver AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Êtes-vous certain de vouloir vous abonner à la liste de filtres $title$ ?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Où exactement se trouve la pub sur cette page ? À quoi ressemble-t-elle ?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"ou AdBlock pour Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"définition de style"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"(expérimental)"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Limite de Blocage de Contenu dépassée"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Recherche des pubs...<br/><br/><i>Cela peut prendre un moment.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"URL Flickr photoset (ex : $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Le domaine ou l'URL où AdBlock ne doit rien bloquer :"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ au total",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Tout est bon ! Nous entrerons bientôt en contact avec vous, probablement dans un jour, deux si c'est un jour férié. En attendant, vous allez recevoir un email d'AdBlock avec un lien vers votre discussion sur notre site de support. Si vous préférez continuer par e-mail, c'est aussi possible !"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Non"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Quelque chose s'est mal passé. Aucune ressource n'a été envoyée. Cette page va maintenant se fermer. Essayez de recharger le site web."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ukrainien"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"Mis à jour il y a $minutes$ minutes.",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Vous avez été désabonné de la liste de filtres Publicités Acceptables parce que vous avez activé le Blocage de Contenu Safari. Vous ne pouvez pas activer les deux à la fois. (<a>Pourquoi ?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Vous n'êtes plus abonné à la liste de filtres Publicités Acceptables."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Protection contre les logiciels malveillants"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Enregistrer"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Attention : vous verrez les pubs sur tous les autres sites !<br>Ceci annule tous les autres filtres pour ces sites."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Désactiver ces notifications"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Abonnement à la liste de filtres..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Vous utilisez une version obsolète d'AdBlock. Merci d'aller sur <a href='#'>la page des extensions</a>, activer le 'Mode développeur' et cliquer sur 'Mettre à jour les extensions maintenant'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Options AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Recherche de logiciels malveillants qui pourraient injecter de la pub :"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Afficher les messages de débogage dans la Console (ralentit AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Vous avez dépassé la limite de stockage de Dropbox. Effacez quelques entrées de vos filtres personnalisés ou désactivés, et essayez à nouveau."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Réactiver AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Contourner le problème des vidéos Hulu.com qui ne se lisent pas (nécessite un redémarrage de votre navigateur)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS correspondant :"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Exclure"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Désactivez toutes les extensions à part AdBlock :"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Traduction par :"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"Chargement..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Faites un clic droit sur une pub pour la bloquer, ou bloquez-la ici manuellement."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Note : Autoriser la pub sur une page ou un site n'est pas supporté lorsque le Blocage de Contenu Safari est activé."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Nous ne l'utiliserons que pour vous contacter si nous avons besoin de plus de détails."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Modifier les filtres désactivés :"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Activer le Blocage de Contenu Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Quelle est votre adresse e-mail ?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Pour masquer ce bouton, faites un clic droit dessus et choisissez \"Personnaliser la barre d'outils\". Vous pouvez ensuite le faire glisser hors de la barre d'outils. Pour l'afficher à nouveau, glissez-le dans la barre d'outils."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Une erreur est survenue pendant le traitement de votre requête."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"page"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Ajouter des Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Terminé ! La page avec la pub a été rechargée. Veuillez vérifier si la pub a disparu, puis revenez sur cette page et répondez à la question suivante."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Ou entrez une URL :"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Vous utilisez une ancienne version de Safari. Merci de mettre à jour vers la dernière version afin de pouvoir utiliser le bouton de la barre d'outils pour désactiver AdBlock, autoriser des sites web, ou rapporter des pubs. <a>Mettre à jour maintenant</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Allez dans le menu Safari &rarr; Préférences &rarr; Extensions."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Ne pas bloquer les publicités :"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Bloquer"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Est-ce que la publicité est toujours là ?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bulgare"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Formidable ! Maintenant, il faut trouver quelle extension en est la cause. Activez à nouveau vos extensions une par une. L'extension qui ramène la publicité est celle que vous devez désinstaller pour vous débarrasser de cette pub."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Erreur !"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Modifier vos filtres manuellement :"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italien"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Type"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovaque"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Abonnement aux listes de filtres"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Vous pouvez vous y réabonner et soutenir les sites que vous aimez en sélectionnant \"Autoriser certaines publicités non-intrusives\" ci-dessous."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Est-ce que la publicité apparaît aussi dans cet autre navigateur ?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Désactiver sur cette page"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Lituanien"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Faites-le nous savoir sur notre <a>site de support</a> !"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock est désactivé."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Il est pour le moment impossible de bloquer les publicités dans Flash et les autres plugins."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Général"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Si vous préférez ne pas voir des pubs telles que celle-ci, vous pouvez laisser la liste de filtres \"Publicités Acceptables\" désactivée."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Votre ordinateur semble être infecté par des logiciels malveillants. Cliquez <a>ici</a> pour davantage d'informations."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"autre"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Pas de filtre spécifié !"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"inconnu"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/vidéo"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japonais"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Autoriser certaines publicités non-intrusives"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Annuler"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Faites glisser les curseurs ci-dessous pour choisir les pages sur lesquelles AdBlock ne devra rien faire."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Le Blocage de Contenu Safari a été désactivé car vous avez choisi d'autoriser les publicités non-intrusives. Vous ne pouvez pas activer les deux à la fois. (<a>Pourquoi ?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Dernière étape : signalez-nous le problème."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Vérifier dans Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Pour signaler une publicité, vous devez être connecté à Internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (recommandé)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"ID Flickr photoset (ex : $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Signaler une publicité"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Listes de filtres pour le blocage de publicités"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Comment ?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Autoriser la pub sur certaines chaînes YouTube uniquement"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Tierce-partie"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (supprime les éléments agaçants sur le Web)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - cliquez pour plus de détails"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"Mis à jour il y a $hours$ heures.",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Russe et ukrainien"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Quoi de neuf dans la dernière version ? Découvrez-le dans <a style='cursor:pointer;'>les notes de version</a> !"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Les extensions précédemment désactivées ont été réactivées."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grec"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Masquer une section d'une page web"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Vidéos et Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Quelles caractéristiques vont systématiquement correspondre à cette pub, à chaque fois que vous visiterez cette page ?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Activer AdBlock sur cette page"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Retour"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Les listes de filtres bloquent la plupart des publicités, mais vous pouvez également :"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Vérifiez les filtres Publicités Acceptables :"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Afficher les publicités sur une page ou un domaine"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Ceci s'applique à <b>1</b> élément sur cette page."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Je ne veux pas vérifier cela"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Merci de relancer Safari pour terminer la désactivation du Blocage de Contenu."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Attention : faire une erreur ici peut entraîner un mauvais fonctionnement des filtres officiels.<br/>Consultez le <a>tutoriel de syntaxe</a> pour apprendre à ajouter des filtres avancés."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Autoriser la pub sur la chaîne $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Est-ce que la publicité apparaît aussi dans cet autre navigateur ?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Options générales"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Si vous préférez ne pas voir des pubs telles que celle-ci, vous pouvez laisser la liste de filtres \"Publicités Acceptables\" désactivée."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock ne s'exécutera pas sur les pages correspondantes à :"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Nous n'avons pas de liste de filtres pour cette langue.<br/>Essayez de trouver une liste appropriée qui supporte cette langue $link$ ou bloquez cette publicité pour vous-même dans l'onglet \"Personnaliser\".",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"S'abonner"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Je suis un utilisateur avancé, afficher les options avancées"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Espagnol"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Chargé sur la page avec le domaine :\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Cliquez ici : <a>Mettre à jour mes filtres !</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Plus vous utilisez de listes, plus AdBlock sera lent. Utiliser trop de listes peut même faire planter votre navigateur. Appuyez sur OK si vous êtes certain de vouloir vous abonner à cette liste."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Étape 2 : Options de blocage"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Ceci s'applique à $matchcount$ éléments sur cette page.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Nous avons également une <a>page</a> sur laquelle vous pouvez trouver les contributeurs AdBlock !"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonésien"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turc"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Bloquer une pub"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Listes de filtres personnalisées"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL du cadre : "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Le but de cette question est de déterminer qui doit recevoir votre rapport. Si vous répondez incorrectement à cette question, le rapport ne sera pas envoyé aux bonnes personnes, et il pourrait être ignoré."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Afficher les éléments AdBlock dans le menu du clic droit"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"sélecteur"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Bloquer cette pub"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Notre équipe vous a demandé des infos de débogage ? Cliquez <a href='#' id='debug'>ici</a> pour cela !"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Ne pas exécuter AdBlock sur..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Signaler des publicités est purement volontaire. En le faisant, vous aidez les autres utilisateurs en permettant aux listes de filtres de bloquer cette pub pour tout le monde. Si toutefois vous ne vous sentez pas particulièrement altruiste en ce moment, ce n'est pas grave. Vous pouvez fermer cette page et uniquement <a>bloquer cette pub</a> pour vous-même."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Élément masqué"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Recharger la page."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"page"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Néerlandais"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Le nom du fichier est trop long. Merci de donner un nom plus court au fichier."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"N'oubliez pas d'enregistrer !"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Recherche de mises à jour (ne devrait pas prendre plus de quelques secondes)…"
+    "message":"Lituanien"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Abonnez-vous à cette liste de filtres, et réessayez : $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Est-ce qu'AdBlock doit vous prévenir si un logiciel malveillant est détecté ?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Votre ordinateur semble être infecté par des logiciels malveillants. Cliquez <a>ici</a> pour davantage d'informations."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Afficher le nombre de pubs bloquées dans le menu AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Afficher les publicités sur une page ou un domaine"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Site :"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Filtres personnalisés AdBlock (recommandé)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Letton"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Assurez-vous d'utiliser les bons filtres pour votre langue :"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS correspondant :"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Pour masquer ce bouton, allez sur opera://extensions et cochez \"Cacher de la barre d'outils\". Vous pouvez l'afficher à nouveau en décochant cette option."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Vous ne savez pas ?</b> Appuyez simplement sur \"Bloquer\" ci-dessous."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Filtre correspondant"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Récupération en cours..."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Toutes les resources"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock est à jour !"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Ne rien bloquer sur les pages de ce domaine"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Hébreu"
+    "message":"Slovaque"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Faites glisser le curseur jusqu'à ce que la pub disparaisse, et que l'élément bloqué semble correct."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Bloquer les URL contenant ce texte :"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Ajoutez des photos</b> depuis Flickr ! Vous pouvez entrer :"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"La quantité de règles dans vos listes de filtres excède 50 000 et a été automatiquement réduite. Merci de vous désabonner de quelques listes ou de désactiver le Blocage de Contenu Safari !"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"Mis à jour il y a 1 jour."
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Publicités Acceptables (recommandé)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Cliquez ici : <a>Désactiver les Publicités Acceptables</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Version $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Installez Adblock Plus pour Firefox $chrome$ si vous ne l'avez pas.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Retirer de la liste"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Nous n'avons pas de liste de filtres pour cette langue.<br/>Essayez de trouver une liste appropriée qui supporte cette langue $link$ ou bloquez cette publicité pour vous-même dans l'onglet \"Personnaliser\".",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Ceci n'est pas une image. Merci de joindre un fichier .png, .gif, ou .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Pourquoi ne pas nous envoyer un <a>rapport de bogue</a> ?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"masqué"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Listes de filtres"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Domaine du cadre : "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Cliquez sur la pub à bloquer."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Premier cadre"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"définition de style"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"inconnu"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Désolé, AdBlock est désactivé sur cette page par un ou plusieurs de vos filtres."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Tierce-partie"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Pas de filtre spécifié !"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Grec"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Vous utilisez une version obsolète d'AdBlock. Merci d'aller sur <a href='#'>la page des extensions</a>, activer le 'Mode développeur' et cliquer sur 'Mettre à jour les extensions maintenant'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Quel est votre nom ?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Contourner le problème des vidéos Hulu.com qui ne se lisent pas (nécessite un redémarrage de votre navigateur)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Attention : aucun filtre spécifié !"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Personnaliser"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Vous avez trouvé une pub sur une page web ? Nous allons vous aider à trouver le bon endroit pour la signaler !"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estonien"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Personnaliser AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgare"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Resource autorisée"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Limite de Blocage de Contenu dépassée"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Cochez la case à côté des séries de photos que vous désirez utiliser."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Ne pas exécuter AdBlock sur..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Bloquer les URL contenant ce texte :"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Fermer"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Vérifier dans Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Étape 2 : Options de blocage"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Si vous voyez une publicité sur un site, n'envoyez pas un rapport de bogue, mais <a>signalez-nous la publicité</a> !"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Coréen"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Vous utilisez une ancienne version de Safari. Merci de mettre à jour vers la dernière version afin de pouvoir utiliser le bouton de la barre d'outils pour désactiver AdBlock, autoriser des sites web, ou rapporter des pubs. <a>Mettre à jour maintenant</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finlandais"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ukrainien"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Aucun logiciel malveillant connu n'a été trouvé."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Désactivez quelques listes de filtres. Plus d'infos dans les Options AdBlock."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Vous avez été désabonné de la liste de filtres Publicités Acceptables parce que vous avez activé le Blocage de Contenu Safari. Vous ne pouvez pas activer les deux à la fois. (<a>Pourquoi ?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Nous avons également une <a>page</a> sur laquelle vous pouvez trouver les contributeurs AdBlock !"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"ici"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Recharger la page."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Dans quelle langue cette page est-elle écrite ?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock est désactivé."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"Options CatBlock"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Réactiver AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Recherche des pubs...<br/><br/><i>Cela peut prendre un moment.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock est désactivé sur cette page."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Dans ce navigateur, abonnez-vous aux mêmes listes de filtres que vous avez ici."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Bloquer une pub"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Attention : vous verrez les pubs sur tous les autres sites !<br>Ceci annule tous les autres filtres pour ces sites."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Il y a une mise à jour pour AdBlock ! Cliquez $here$ pour mettre à jour. <br>Note: si vous souhaitez recevoir des mises à jour automatiquement, il suffit de cliquer sur Safari > Préférences > Extensions > Mises à jour <br>et cocher l'option \"Installer automatiquement\".",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Terminé !"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Filtres personnalisés AdBlock (recommandé)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Type"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Qu'est-ce que c'est ?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japonais"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Origine du filtre :\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Abonnement aux listes de filtres"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Type de cadre : "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Ajouter des filtres pour une autre langue : "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Resource"
+    "message":"Filtre correspondant"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Bloquer une pub sur cette page"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Les listes de filtres bloquent la plupart des publicités, mais vous pouvez également :"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Vérifiez que vos filtres sont à jour :"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Pour masquer ce bouton, faites un clic droit dessus et choisissez \"Personnaliser la barre d'outils\". Vous pouvez ensuite le faire glisser hors de la barre d'outils. Pour l'afficher à nouveau, glissez-le dans la barre d'outils."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Anglais"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Vous avez dépassé la limite de stockage de Dropbox. Effacez quelques entrées de vos filtres personnalisés ou désactivés, et essayez à nouveau."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Islandais"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"S'abonner"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Ouvrez la page des extensions pour activer les extensions précédemment désactivées."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Note : Autoriser la pub sur une page ou un site n'est pas supporté lorsque le Blocage de Contenu Safari est activé."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domaine de la page :"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Élément bloqué :"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"page"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"autre"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Cliquez ici : <a>Mettre à jour mes filtres !</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Élément masqué"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Pour masquer ce bouton, allez sur opera://extensions et cochez \"Cacher de la barre d'outils\". Vous pouvez l'afficher à nouveau en décochant cette option."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Page :"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Avez-vous trouvé un bogue ?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Bloquer"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Autoriser la pub sur certaines chaînes YouTube uniquement"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"une recherche de photos (ex : <i>course de voilier</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Il est pour le moment impossible de bloquer les publicités dans Flash et les autres plugins."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Arabe"
+    "message":"Hongrois"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Bloquer cette pub"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Activer AdBlock sur cette page"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Afficher le nombre de pubs bloquées sur le bouton AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Erreur !"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Désactiver AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Tchèque"
+    "message":"Anglais"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Payez ce que vous voulez !"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Afficher les éléments AdBlock dans le menu du clic droit"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Aimeriez-vous voir comment AdBlock fonctionne ?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Merci d'aller sur <a>notre site de support</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Avertissements Adblock (supprime les messages au sujet de l'utilisation de bloqueurs de publicité)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"URL de liste invalide. Elle sera supprimée."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"cadre"
+    "message":"page"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Éditer"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Êtes-vous sûr de vouloir supprimer les $count$ blocages que vous avez créé sur $host$ ?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Une question ou une nouvelle idée ?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Légende : "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Vous avez oublié de joindre une capture d'écran ! Nous ne pouvons pas vous aider sans voir la pub que vous signalez."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>SOIT</b>, cliquez simplement sur ce bouton pour faire toutes les étapes ci-dessus: <a>Désactiver toutes les autres extensions</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"Mis à jour il y a $minutes$ minutes.",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Plus d'infos sur les logiciels malveillants"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Joignez une capture d'écran :"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Roumain"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Modifier les filtres désactivés :"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Sous-cadre"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Actualisez la page qui contient la publicité."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Activer le Blocage de Contenu Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Installez Firefox $chrome$ si vous ne l'avez pas.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Listes de filtres"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Si vous avez créé un filtre fonctionnel à l'aide de l'assistant \"bloquer une pub\", collez-le dans le champ ci-dessous :"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Ce fichier est trop gros. Merci de joindre un fichier inférieur à 10 Mo."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock ne s'exécutera pas sur les pages correspondantes à :"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Chinois"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filtre invalide : $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Abonnement à la liste de filtres..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Ouvrez la page des extensions pour activer les extensions précédemment désactivées."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Désactiver ces notifications"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turc"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Trop de filtres activés ralentissent la navigation, choisissez donc uniquement ceux qui vous sont utiles !<br/>Les crédits et autres listes se trouvent <a>ici</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"cadre"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonésien"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"image"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ au total",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Annuler"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"N'oubliez pas d'enregistrer !"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"sélecteur"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Le Blocage de Contenu Safari a été désactivé car vous avez choisi d'autoriser les publicités non-intrusives. Vous ne pouvez pas activer les deux à la fois. (<a>Pourquoi ?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Islandais"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Listes de filtres pour le blocage de publicités"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Bloquer les pubs uniquement sur ces sites :"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Chargé sur la page avec le domaine :\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Les extensions précédemment désactivées ont été réactivées."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Nettoyer cette liste"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Faites passer le mot !"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Mises à jour AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Avertissements Adblock (supprime les messages au sujet de l'utilisation de bloqueurs de publicité)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Options AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Une erreur est survenue pendant le traitement de votre requête."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"Mis à jour il y a 1 heure."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Recherche de mises à jour (ne devrait pas prendre plus de quelques secondes)…"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"Mis à jour à l'instant."
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Faites un clic droit sur une pub pour la bloquer, ou bloquez-la ici manuellement."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Recherche de logiciels malveillants qui pourraient injecter de la pub :"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Support AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Type"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Faites glisser le curseur jusqu'à ce que la pub disparaisse, et que l'élément bloqué semble correct."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"Mis à jour il y a 1 minute."
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"cadre"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Resource bloquée"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Les informations suivantes figureront également dans votre rapport."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Danois"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Vérifiez les filtres Publicités Acceptables :"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Vous pouvez vous y réabonner et soutenir les sites que vous aimez en sélectionnant \"Autoriser certaines publicités non-intrusives\" ci-dessous."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Récupération en cours..."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"URL de liste invalide. Elle sera supprimée."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Options générales"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Décochez la case 'Activée' à côté de chaque extension <b>à part</b> AdBlock. <b>Gardez AdBlock activé</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Dans cet autre navigateur, ouvrez la page avec la publicité."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Afficher les publicités <i>partout</i> sauf sur ces domaines..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Vous avez oublié de joindre une capture d'écran ! Nous ne pouvons pas vous aider sans voir la pub que vous signalez."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Créez-y une discussion manuellement, et copiez/collez les informations ci-dessous dans le champ \"Fill in any details you think will help us understand your issue\"."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Pour masquer ce bouton, faites un clic droit dessus et choisissez \"Masquer le bouton\".  Pour l'afficher à nouveau, allez dans chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hébreu"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Cette fonctionnalité d'AdBlock ne fonctionne pas sur ce site car celui-ci utilise des technologies obsolètes. Vous pouvez bloquer ou autoriser des ressources manuellement dans l'onglet \"Personnaliser\" des options AdBlock."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Tchèque et slovaque"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Nous avons désactivé toutes les autres extensions. Nous allons maintenant recharger la page avec la pub. Un moment, s'il vous plaît."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Autres listes de filtres"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Français"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Les listes seront mises à jour automatiquement. Vous pouvez aussi les <a>mettre à jour maintenant</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Élément bloqué :"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Afficher toutes les requêtes"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"objet interactif"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Plus vous utilisez de listes, plus AdBlock sera lent. Utiliser trop de listes peut même faire planter votre navigateur. Appuyez sur OK si vous êtes certain de vouloir vous abonner à cette liste."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Génial ! Il n'y a rien d'autre à faire."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"(expérimental)"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Ouvrez <a href='#'>la page des extensions</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Tout est bon ! Nous entrerons bientôt en contact avec vous, probablement dans un jour, deux si c'est un jour férié. En attendant, vous allez recevoir un email d'AdBlock avec un lien vers votre discussion sur notre site de support. Si vous préférez continuer par e-mail, c'est aussi possible !"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"En savoir plus sur le programme Publicités Acceptables."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Est-ce qu'AdBlock doit vous prévenir si un logiciel malveillant est détecté ?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"Mis à jour à l'instant."
+    "message":"Mis à jour il y a 1 jour."
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL du cadre : "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Allemand"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Le nom du fichier est trop long. Merci de donner un nom plus court au fichier."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"Mis à jour il y a $seconds$ secondes.",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Désactiver sur cette page"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Faites-le nous savoir sur notre <a>site de support</a> !"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Terminé ! La page avec la pub a été rechargée. Veuillez vérifier si la pub a disparu, puis revenez sur cette page et répondez à la question suivante."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Toutes les resources"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Autoriser la pub sur la chaîne $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Resource"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Afficher le nombre de pubs bloquées dans le menu AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Signaler une publicité"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Comment ?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Ne rien bloquer sur les pages de ce domaine"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Listes de filtres personnalisées"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Bloquer plus de publicités :"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Les informations requises sont invalides ou manquantes. Veuillez remplir les questions marquées en rouge."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Le domaine ou l'URL où AdBlock ne doit rien bloquer :"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Vous n'êtes plus abonné à la liste de filtres Publicités Acceptables."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (supprime les éléments agaçants sur le Web)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock a bloqué un téléchargement d'un site connu pour servir des logiciels malveillants."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Enregistrer"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Vous ne savez pas ?</b> Appuyez simplement sur \"Bloquer\" ci-dessous."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Dernière étape : signalez-nous le problème."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Où exactement se trouve la pub sur cette page ? À quoi ressemble-t-elle ?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"OK"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Autoriser AdBlock à recueillir des données anonymes sur l'utilisation des listes de filtres"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Pour signaler une publicité, vous devez être connecté à Internet."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Êtes-vous certain de vouloir vous abonner à la liste de filtres $title$ ?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"Mis à jour il y a $days$ jours.",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"cadre"
+    "message":"objet interactif"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Quelles caractéristiques vont systématiquement correspondre à cette pub, à chaque fois que vous visiterez cette page ?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Pubs bloquées :"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arabe"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Annuler mes blocages sur ce domaine"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Modifier vos filtres manuellement :"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Étape 1 : Indiquer quoi bloquer"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Merci d'entrer le filtre correct ci-dessous et appuyer sur OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Traduction par :"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock est à jour !"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Anglais uniquement"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>SOIT</b>, cliquez simplement sur ce bouton pour faire toutes les étapes ci-dessus: <a>Désactiver toutes les autres extensions</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Quoi de neuf dans la dernière version ? Découvrez-le dans <a style='cursor:pointer;'>les notes de version</a> !"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (protection de la vie privée)"
+    "message":"Liste de filtres Antisocial (supprime les boutons de réseaux sociaux)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Signaler une publicité sur cette page"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Protection contre les logiciels malveillants"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Nettoyer cette liste"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Je suis un utilisateur avancé, afficher les options avancées"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Allemand"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Vous avez dépassé la quantité de stockage que peut utiliser AdBlock. Désabonnez-vous de quelques listes de filtres !"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Attention : ce filtre bloque tous les éléments de type $elementtype$ sur cette page !",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"ici"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Quelle est votre adresse e-mail ?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Dans quelle langue cette page est-elle écrite ?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Aimeriez-vous voir comment AdBlock fonctionne ?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Êtes-vous sûr de vouloir supprimer les $count$ blocages que vous avez créé sur $host$ ?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"image"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Masquer une section d'une page web"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Créez-y une discussion manuellement, et copiez/collez les informations ci-dessous dans le champ \"Fill in any details you think will help us understand your issue\"."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Général"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Pour masquer ce bouton, faites un clic droit dessus et choisissez \"Masquer le bouton\".  Pour l'afficher à nouveau, allez dans chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"ou AdBlock pour Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Roumain"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Vidéos et Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Quelque chose s'est mal passé lors de la vérification des mises à jour."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Nous avons désactivé toutes les autres extensions. Nous allons maintenant recharger la page avec la pub. Un moment, s'il vous plaît."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Resource autorisée"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Formidable ! Maintenant, il faut trouver quelle extension en est la cause. Activez à nouveau vos extensions une par une. L'extension qui ramène la publicité est celle que vous devez désinstaller pour vous débarrasser de cette pub."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Tchèque et slovaque"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"ou Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Type de cadre : "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format : ~site1.com|~site2.com|~news.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Sélectionnez une langue -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Installez Adblock Plus pour Firefox $chrome$ si vous ne l'avez pas.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Resource bloquée"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Est-ce que la publicité s'affiche dans ou avant une vidéo, ou dans un plugin comme par exemple un jeu Flash ?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ sera $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Le filtre, qui peut être changé dans les options :"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Le filtre suivant :<br/> $filter$ <br/> est erroné : <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Cochez la case à côté des séries de photos que vous désirez utiliser."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Fermer"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Bloquer les pubs uniquement sur ces sites :"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Vous avez dépassé la quantité de stockage que peut utiliser AdBlock. Désabonnez-vous de quelques listes de filtres !"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Autoriser AdBlock à recueillir des données anonymes sur l'utilisation des listes de filtres"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"D'accord, vous pouvez tout de même bloquer cette publicité pour vous-même dans les options."
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Envoyer"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finlandais"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Ce fichier est trop gros. Merci de joindre un fichier inférieur à 10 Mo."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Les informations suivantes figureront également dans votre rapport."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Payez ce que vous voulez !"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Il y a un problème avec la liste de filtres. Rapportez-le ici : $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Décochez la case 'Activée' à côté de chaque extension <b>à part</b> AdBlock. <b>Gardez AdBlock activé</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Note : votre rapport peut être rendu public. Gardez cela à l'esprit avant d'inclure quoi que ce soit de privé."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Afficher les liens des listes de filtres"
+  "filteritalian":{
+    "description":"language",
+    "message":"Italien"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Anglais uniquement"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"ID Flickr photoset (ex : $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Faites passer le mot !"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Est-ce que la publicité est toujours là ?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock a bloqué un téléchargement d'un site connu pour servir des logiciels malveillants."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Assurez-vous d'utiliser les bons filtres pour votre langue :"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Légende : "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Vérifiez que vos filtres sont à jour :"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Quelque chose s'est mal passé lors de la vérification des mises à jour."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Allez dans le menu Safari &rarr; Préférences &rarr; Extensions."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Envoyer"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"URL Flickr photoset (ex : $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Désabonné."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/vidéo"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Letton"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Bloquer une pub sur cette page"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Ne pas bloquer les publicités :"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Erreur lors de l'enregistrement du fichier téléversé."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Ceci s'applique à $matchcount$ éléments sur cette page.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Impossible de récupérer ce filtre !"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Faites glisser les curseurs ci-dessous pour choisir les pages sur lesquelles AdBlock ne devra rien faire."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"masqué"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Est-ce que la publicité s'affiche dans ou avant une vidéo, ou dans un plugin comme par exemple un jeu Flash ?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Russe et ukrainien"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Espagnol"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Attention : ce filtre bloque tous les éléments de type $elementtype$ sur cette page !",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Activer le mode de compatibilité ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Non"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Le filtre, qui peut être changé dans les options :"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Masquer ce bouton"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Autre"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"D'accord, vous pouvez tout de même bloquer cette publicité pour vous-même dans les options."
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Russe"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Pourquoi ne pas nous envoyer un <a>rapport de bogue</a> ?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (protection de la vie privée)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ sera $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Ou entrez une URL :"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Le filtre suivant :<br/> $filter$ <br/> est erroné : <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"Chargement..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Notre équipe vous a demandé des infos de débogage ? Cliquez <a href='#' id='debug'>ici</a> pour cela !"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"La quantité de règles dans vos listes de filtres excède 50 000 et a été automatiquement réduite. Merci de vous désabonner de quelques listes ou de désactiver le Blocage de Contenu Safari !"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Signaler une publicité sur cette page"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Afficher les messages de débogage dans la Console (ralentit AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Domaine du cadre : "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"La plus populaire des extensions Chrome, avec plus de 40 millions d'utilisateurs ! Bloque la publicité sur le web."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Avez-vous trouvé un bogue ?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Tchèque"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Ceci n'est pas une image. Merci de joindre un fichier .png, .gif, ou .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Ajoutez des photos</b> depuis Flickr ! Vous pouvez entrer :"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Afficher les liens des listes de filtres"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Autoriser certaines publicités non-intrusives"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Suédois"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Retirer de la liste"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Ajouter des Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Sélectionnez une langue -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Français"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Éditer"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Support"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Merci d'aller sur <a>notre site de support</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Bloquer une publicité par son URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Pour désactiver AdBlock lorsque le Blocage de Contenu est activé, cliquez sur Safari (dans la barre des menus) > Préférences > Extensions > AdBlock, et désélectionnez \"Activer AdBlock\"."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Version $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Le but de cette question est de déterminer qui doit recevoir votre rapport. Si vous répondez incorrectement à cette question, le rapport ne sera pas envoyé aux bonnes personnes, et il pourrait être ignoré."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Signaler des publicités est purement volontaire. En le faisant, vous aidez les autres utilisateurs en permettant aux listes de filtres de bloquer cette pub pour tout le monde. Si toutefois vous ne vous sentez pas particulièrement altruiste en ce moment, ce n'est pas grave. Vous pouvez fermer cette page et uniquement <a>bloquer cette pub</a> pour vous-même."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Oui"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Le code source est <a>disponible librement</a> !"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Néerlandais"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Nous ne l'utiliserons que pour vous contacter si nous avons besoin de plus de détails."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Ceci s'applique à <b>1</b> élément sur cette page."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"Mis à jour il y a $hours$ heures.",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Retour"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Cliquez ici : <a>Désactiver les Publicités Acceptables</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domaine de la page :"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Mises à jour AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Quelque chose s'est mal passé. Aucune ressource n'a été envoyée. Cette page va maintenant se fermer. Essayez de recharger le site web."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Plus d'infos sur les logiciels malveillants"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Site :"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Publicités Acceptables (recommandé)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"OK"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Pour désactiver AdBlock lorsque le Blocage de Contenu est activé, cliquez sur Safari (dans la barre des menus) > Préférences > Extensions > AdBlock, et désélectionnez \"Activer AdBlock\"."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Ouvrez <a href='#'>la page des extensions</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - cliquez pour plus de détails"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Désactivez toutes les extensions à part AdBlock :"
   }
 }

--- a/_locales/gu/messages.json
+++ b/_locales/gu/messages.json
@@ -1,711 +1,193 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - જાહેરાત જાણ કરો"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"આપે બ્લોકીંગ કરેલી જાહેરાત ની યાદી ફિલ્ટર દ્વારા"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"સાઇટ:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"ચોક્કસ YouTube ની ચેનલો વ્હાઇટલિસ્ટિંગ પરવાનગી આપો"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"કોઈ જાણીતા malware મળ્યા નથી."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - વિગતો માટે ક્લિક કરો"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"આ બ્રાઉઝર માં, જાહેરાત સાથે પેજ​ ને લોડ કરો."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"સ્વિડીશ"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"પ્રકાર"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"વધુ જાહેરાતો અવરોધિત કરો:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"રશિયન"
+    "message":"ડેનિશ"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"તમે શું કરવા માંગો છો તેના માટે ની ચૂકવણી કરો!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"તેનો પ્રસાર માટે મદદ કરો!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"ઉમેદવારી દૂર."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"તેના URL દ્વારા જાહેરાત અવરોધિત કરો"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"ગ્રીક"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"ચિની"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"વિડિઓઝ અને Flash"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Malware સુરક્ષા"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"શું તમે વિચારો છો કે જો તમે આ જાહેરાત તમને આ પૃષ્ઠની મુલાકાત લો દર વખતે ઓપન​ થાય છે તે વિશે સાચું આ છે?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"આ પાનાં પર AdBlock ની સક્રિય કરો"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"પાછા"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"AdBlock ના બટન પર જાહેરાતોના નંબર બતાવો"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"એક પ્રશ્ન અથવા નવા વિચારો છે?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"લાતવિયન"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"વેબ પર સૌથી વધુ જાહેરાતો આ એડબ્લોક ગાળક યાદીઓ મા છે. તમે પણ કરી શકો છો:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"સ્ત્રોત કોડ <a>મુક્ત રીતે ઉપલબ્ધ</a> છે!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"વેબ પેજ અથવા ડોમેન પર બતાવો જાહેરાતો"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"આ પાનાં પર <b>1</b> આઇટમ સાથે બંધબેસે છે."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"વેબ પૃષ્ઠ વિભાગ ના છુપાવવા માટે"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"વ્હાઇટલિસ્ટ $name$ ચેનલ",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"સામાન્ય વિકલ્પો"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"તમારા કમ્પ્યુટર ને મૉલવેર દ્વારા ચેપ લાગ્યો છે.વધુ માહિતી માટે. વધુ માહિતી માટે.<a>અહીં</a> ક્લિક કરો."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock કોઈપણ પાનાં બંધબેસતી પર ચાલશે નહીં:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"અમે તે ભાષા માટે મૂળભૂત ગાળક યાદી નથી.<br/>આ ભાષામાં $link$ આધાર આપે છે કે યોગ્ય યાદી શોધવા પ્રયત્ન કરો અથવા પર તમારા માટે આ જાહેરાત અવરોધિત કૃપા કરીને 'Customize tab' પર જાઓ.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"સબ્સ્ક્રાઇબ કરો"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"હું ઉન્નત વપરાશકર્તા છું મને ઉચ્ચ વિકલ્પો બતાવવા"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"ઝેક"
-  },
   "hide_this_button":{
     "description":"Toolbar button menu entry to hide the AdBlock button",
     "message":"આ બટન છુપાવો"
   },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"હું આપમેળે અપડેટ્સ મેળવીશ; તમે <a>હમાણાજ અપડેટ</a> કરી શકો છો"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"આ ક્લિક કરો:<a>મારા ગાળકો અપડેટ કરો</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"ફોર્મેટ: ~ site1.com | ~ site2.com | ~ news.site3.org"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"છેલ્લું પગલું: શું આ જાહેરાત કરે છે?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"કે આ પાનાં પર $matchcount$ વસ્તુઓ મેળ ખાય છે.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"અમે એક <a>પાનું રાખ્યું</a> છે સાથે સાથે જે આપડા જેવા લોકો ની મદદ કરવા માટે AdBlock ઉપયોગી છે!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"ઇન્ડોનેશિયન"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"પ્રકાર"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"AdBlock ની માટે એક અપડેટ જ નથી! અપડેટ કરવા માટે $here$ જાઓ. <br> નોંધ: જો તમે આપોઆપ સુધારાઓ મેળવવા માંગો છો, તેના માટે Safari પર ક્લિક કરો > પસંદગીઓ > એક્સ્ટેન્શન્સ > સુધારાઓ <br> અને 'આપમેળે અપડેટ્સ સ્થાપિત' વિકલ્પ પર તપાસો.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"ટર્કિશ"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"આ શું છે?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"કસ્ટમ ફિલ્ટર યાદી"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"તમને જરૂર કરતાં વધુ સબ્સ્ક્રાઇબ નથી -- દરેક એક એક નાના બીટ તમને શાંત કરે છે! ક્રેડિટ અને વધુ યાદીઓ મળી શકે <a>અહીં</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"શૈલી વ્યાખ્યા"
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"યાદીમાંથી દૂર કરો"
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"આ પ્રશ્ન હેતુ તમારી રિપોર્ટની પ્રાપ્ત કરીશું જે નક્કી કરવા માટે છે.તમે આ પ્રશ્નનો જવાબ ખોટા આપ શો તો,આ અહેવાલ ખોટા લોકો મોકલવામાં આવશે,તેથી તે અવગણવામાં આવી શકે છે."
-  },
-  "filtereasylist_plus_polish":{
+  "filterjapanese":{
     "description":"language",
-    "message":"પોલિશ"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"જમણી ક્લિક ના મેનૂ પર આઇટમ્સ ઉમેરો"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"આ જાહેરાત અવરોધિત કરો"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"સુધારાયેલ $hours$ કલાક પહેલા",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"સુધારાશે $seconds$ સેકન્ડ પહેલા",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"અમારી ટીમ કેટલાક ડિબગ માહિતી માટે વિનંતી કરી છે? તે માટે! <a href='#' id='debug'>અહીં</a> જાઓ!"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"ઑબ્જેક્ટ_પેટાવિનંતી"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"હંગેરિયન"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"અમાન્ય સૂચી URL. તે કાઢી નાખવામાં આવશે."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"નોંધ: તમારી રિપોર્ટની જાહેરમાં ઉપલબ્ધ બની જાય છે. ખાનગી કંઈપણ સહિત પહેલાં ધ્યાનમાં રાખવા."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"પૃષ્ઠને ફરીથી લોડ કરો."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"પાનું"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"ડચ"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"સેવ કરવાનું ભૂલો નહિં!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ હશે $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"બંધ કરો"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"અવરોધિત તત્વ:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"ગાળક અયોગ્ય છે:$exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"ચેતવણી: કોઈ ફિલ્ટર સ્પષ્ટ!"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"AdBlock મૉલવેર શોધે છે ત્યારે તમને જાણ કરી એ?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"આ ડોમેન્સ સિવાય <i>બધે જાહેરાતો</i> બતાવવા ..."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"તે ટેકનોલોજી તારીખ બહાર વાપરે છે કારણ કે આ AdBlock ની સુવિધાને આ સાઇટ પર કામ કરતું નથી. તમે જાતે વ્હાઇટલિસ્ટ સંસાધનો બ્લેકલીસ્ટ કરી શકો છો અથવા 'Customize' Tab માં options page પર જાઓ."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"AdBlock ના મેનુ માં જાહેરાતો બતાવો સંખ્યા બતાવો"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"વિકલ્પો"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"AdBlock ચલાવવા નથી ..."
-  },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"XMLHttp માગણી"
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"અવરોધિત જાહેરાતો:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock વૈવિધ્યપૂર્ણ ગાળકો (ભલામણ)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"અન્ય ભાષા માટે ફિલ્ટર્સ ઉમેરો: "
+    "message":"Japanese"
   },
   "filterannoyances":{
     "description":"A filter list",
     "message":"Fanboy's Annoyances (વેબ પર ત્રાસ દૂર કરે છે)"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS સાથે મેળ"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"આ બટન છુપાવવા માટે, આ લિંક પર જાઓ opera://extensions અને તપાસો 'ટૂલબાર છુપાવ્યા' વિકલ્પ પસંદ કરો. તમે તે વિકલ્પ ચકાસ્યા વગર તેને ફરીથી બતાવી શકો છો."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"આ જાહેરાત પર ક્લિક કરો, અને હું તેને અવરોધિત કરી આપીશ."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"આ પેજ પર ની જાહેરાતો ની જાણ કરો"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"રશિયન અને યુક્રેનિયન"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"સ્ક્રિપ્ટ"
-  },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"કાળજી રાખો: તમે ખૂબ ભાંગી મળી શકે છે, અહીં એક ભૂલ સત્તાવાર ગાળકો સહિત અન્ય ગાળકો, ઘણો બનાવવા માટે જો!<br/>આ વાંચો<a>ફિલ્ટર વાક્યરચના ટ્યુટોરીયલ</a>અદ્યતન બ્લેકલિસ્ટ અને વ્હાઇટલિસ્ટ ગાળકો માં કેવી રીતે ઉમેરવુ તે શીખવા માટે."
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock નો આધાર"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"કસ્ટમાઇઝ AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock ની અપ ટુ ડેટ છે!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"કુલ $count$",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"હિબ્રુ"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"માફ કરશો, AdBlock ની તમારી ફિલ્ટર યાદીઓની એક પછી આ પૃષ્ઠ પર નિષ્ક્રિય થયેલ છે."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"આ લખાણ સમાવતી બ્લોક URL ને"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"આ ડોમેન પર મારી બ્લોકો પૂર્વવત્ કરો"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"નીચે બરાબર ફિલ્ટર લખો અને કૃપા કરીને પ્રેસ કરો"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"સુધારાશે 1 દિવસ પહેલાં"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"બીટા"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ આ પાનાં પર",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>ચોક્કસ નહિં?</b>માત્ર  નીચે 'Block it!' દબાવો."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"અમાન્ય સૂચી URL. તે કાઢી નાખવામાં આવશે."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"1 કલાક પહેલા સુધારાશે"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"પોલિશ"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"આવૃત્તિ $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"સામાન્ય વિકલ્પો"
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"યાદીઓ ફિલ્ટર કરવા માટે સબ્સ્ક્રાઇબ કરો"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"અન્ય"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS સાથે મેળ"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"છૂપાઇ"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"ફિલ્ટર યાદીઓ"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"આ જાહેરાતમાં અથવા ફિલ્મ કે એક Flash રમત જેવી અન્ય કોઇ પ્લગઇન પહેલાં દેખાય છે?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"અન્ય ફિલ્ટર યાદી"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"અથવા Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"અવરોધિત કરો!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"સમાપ્ત થયું!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"આ પાનાં પર જાહેરાત અવરોધિત કરો"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"ના"
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"'Enabled checkbox' ને અનચેક કરો AdBlock ની સિવાય દરેક વિસ્તરણ માટે <b>આગામી</b> થશે.\n<b>AdBlock ને સક્રિય કરો</b>."
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"હું આ ચકાસવા માટે નથી માંગતો"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock કોઈપણ પાનાં બંધબેસતી પર ચાલશે નહીં:"
   },
-  "lang_english":{
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"આ ડોમેન્સ સિવાય <i>બધે જાહેરાતો</i> બતાવવા ..."
+  },
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"કાળજી રાખો: તમે ખૂબ ભાંગી મળી શકે છે, અહીં એક ભૂલ સત્તાવાર ગાળકો સહિત અન્ય ગાળકો, ઘણો બનાવવા માટે જો!<br/>આ વાંચો<a>ફિલ્ટર વાક્યરચના ટ્યુટોરીયલ</a>અદ્યતન બ્લેકલિસ્ટ અને વ્હાઇટલિસ્ટ ગાળકો માં કેવી રીતે ઉમેરવુ તે શીખવા માટે."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"ઇંગલિશ"
+    "message":"સ્લોવેક"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"કસ્ટમાઇઝ"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"AdBlock થોભાવો"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"શું તમે ખરેખર સૂચિ ફિલ્ટર ઉમેદવારી નોંધાવવા માટે માગો છો $title$ ?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"ડોમેન ના પેજ પર લાગુ કરવા"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"કોરિયન"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"પાનું:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"શું તમને ભૂલ મળી?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"પગલું 1: અવરોધિત કરવા ની આકૃતિ અથવા રસ્તો"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"તમે વધુ ફિલ્ટર યાદીઓ નો ઉપયોગ કરી શકો છો, જો AdBlock ધીમી ઝડપે ચાલતુ હોય તો. ઘણી બધી યાદીઓ ઉપયોગ કરીને પણ કેટલીક વેબસાઇટ્સ પર તમારા બ્રાઉઝર ક્રેશ કરી શકે છે. ઓકે દબાવો તેમ છતાં આ યાદી ઉમેદવારી નોંધાવવા માટે."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"અથવા Chrome માટે AdBlock"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"જાહેરાત અવરોધિત કરો"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"હા"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"આ જાહેરાત બ્રાઉઝરમાં બહુ દેખાય છે?"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"બાકાત"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"સેવ કરો"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"આ પાનાં પર ચાલુ નથી"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"ડેનિશ"
+    "message":"રોમાનિયન"
   },
-  "typesub_frame":{
-    "description":"A resource type",
-    "message":"ફ્રેમ"
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"આ બટન છુપાવવા માટે, તેને અધિકાર ક્લિક કરો અને છુપાવો બટન પસંદ કરો. તમે હેઠળ તે ફરીથી બતાવી શકે છે chrome://chrome/extensions."
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"ફેરફાર કરો"
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"જાહેરાતો શોધવા ...<br/><br/><i>આ માત્ર ત્યારે જ એક ક્ષણ લેવા પડશે.</i>"
+  "filterisraeli":{
+    "description":"language",
+    "message":"હિબ્રુ"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"આ ડોમેઇન અથવા url AdBlock અવરોધિત ન જોઈએ"
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"તે ટેકનોલોજી તારીખ બહાર વાપરે છે કારણ કે આ AdBlock ની સુવિધાને આ સાઇટ પર કામ કરતું નથી. તમે જાતે વ્હાઇટલિસ્ટ સંસાધનો બ્લેકલીસ્ટ કરી શકો છો અથવા 'Customize' Tab માં options page પર જાઓ."
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"અપડેટ્સ માટે તપાસી રહ્યું છે (માત્ર થોડી સેકન્ડોમાં માં થઇ જશે)..."
+  "other":{
+    "description":"Multiple choice option",
+    "message":"અન્ય"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"આ જાહેરાત આ પૃષ્ઠ પર યોગ્ય રીતે અવરોધિત છે, ત્યાં સુધી આ બદલવા માટે સ્લાઇડર સ્લાઇડ કરો,અને અવરોધિત તત્વ ઉપયોગી લાગે શકે તેવ હોય તો."
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"ઝેક અને સ્લોવેક"
   },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"આ ડોમેન પર પૃષ્ઠો પર ચલાવવા નથી"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"આ જાહેરાત સાથે પૃષ્ઠને ફરીથી લોડ કરો."
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"અન્ય ફિલ્ટર યાદી"
   },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Firefox $chrome$ જો તમરી પાસે ન હોય તો.",
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"વિકલ્પો"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"તમારા કમ્પ્યુટર ને મૉલવેર દ્વારા ચેપ લાગ્યો છે.વધુ માહિતી માટે. વધુ માહિતી માટે.<a>અહીં</a> ક્લિક કરો."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"હું આપમેળે અપડેટ્સ મેળવીશ; તમે <a>હમાણાજ અપડેટ</a> કરી શકો છો"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"લાવતી ... કૃપા કરીને રાહ જુઓ."
+  },
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"વેબ પેજ અથવા ડોમેન પર બતાવો જાહેરાતો"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"ટર્કિશ"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"તમે વધુ ફિલ્ટર યાદીઓ નો ઉપયોગ કરી શકો છો, જો AdBlock ધીમી ઝડપે ચાલતુ હોય તો. ઘણી બધી યાદીઓ ઉપયોગ કરીને પણ કેટલીક વેબસાઇટ્સ પર તમારા બ્રાઉઝર ક્રેશ કરી શકે છે. ઓકે દબાવો તેમ છતાં આ યાદી ઉમેદવારી નોંધાવવા માટે."
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"અમે તે ભાષા માટે મૂળભૂત ગાળક યાદી નથી.<br/>આ ભાષામાં $link$ આધાર આપે છે કે યોગ્ય યાદી શોધવા પ્રયત્ન કરો અથવા પર તમારા માટે આ જાહેરાત અવરોધિત કૃપા કરીને 'Customize tab' પર જાઓ.",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -713,234 +195,421 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"આ જાહેરાત પર ક્લિક કરો, અને હું તેને અવરોધિત કરી આપીશ."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"શૈલી વ્યાખ્યા"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock ની નવી સુધારાઓ"
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"'Enabled checkbox' ને અનચેક કરો AdBlock ની સિવાય દરેક વિસ્તરણ માટે <b>આગામી</b> થશે.\n<b>AdBlock ને સક્રિય કરો</b>."
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"માફ કરશો, AdBlock ની તમારી ફિલ્ટર યાદીઓની એક પછી આ પૃષ્ઠ પર નિષ્ક્રિય થયેલ છે."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"AdBlock મૉલવેર શોધે છે ત્યારે તમને જાણ કરી એ?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"સુધારાશે 1 દિવસ પહેલાં"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"કોઈ ફિલ્ટર સ્પષ્ટ કરેલા નથી!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"જર્મન"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"ગ્રીક"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"સુધારાશે $seconds$ સેકન્ડ પહેલા",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>ચોક્કસ નહિં?</b>માત્ર  નીચે 'Block it!' દબાવો."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"આ બ્રાઉઝર માં, જાહેરાત સાથે પેજ​ ને લોડ કરો."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"અમને અમારી <a>સપોર્ટ સાઇટ</a> પર જણાવો!"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"ફક્ત આ સાઇટ્સ પર જાહેરાતો અવરોધિત કરો:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"કસ્ટમાઇઝ"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"જાહેરાત જાણ માટે, તમે ઇન્ટરનેટ સાથે જોડાયેલ હોવું જ જોઈએ."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"ઓકે!"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"વ્હાઇટલિસ્ટ $name$ ચેનલ",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"વેબ પૃષ્ઠ વિભાગ ના છુપાવવા માટે"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"ફ્રેમ"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"AdBlock ના મેનુ માં જાહેરાતો બતાવો સંખ્યા બતાવો"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - જાહેરાત જાણ કરો"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"બલ્ગેરિયન"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"તાજેતરની પ્રકાશનમાં નવી શું છે? <a style='cursor:pointer;'>ચેન્જલોગ</a> જોવો!"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"આ ડોમેન પર પૃષ્ઠો પર ચલાવવા નથી"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"કસ્ટમ ફિલ્ટર યાદી"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"વધુ જાહેરાતો અવરોધિત કરો:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"યુક્રેનિયન"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"સુધારાયેલ $minutes$ મિનિટ પહેલા",
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"આ ડોમેઇન અથવા url AdBlock અવરોધિત ન જોઈએ"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"ચેતવણી: કોઈ ફિલ્ટર સ્પષ્ટ!"
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"આ લખાણ સમાવતી બ્લોક URL ને"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"બંધ કરો"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Firefox માટે ચેક કરો $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "filtereasylist_plus_french":{
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"છેલ્લું પગલું: શું આ જાહેરાત કરે છે?"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"શું તમે ખરેખર દૂર કરવા માંગો છો $count$ તમે બ્લોકો માં $host$ પર રચના કરી છે?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"સારી દેખાય છે"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"કસ્ટમાઇઝ AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"કોઈ જાણીતા malware મળ્યા નથી."
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Hulu.com ની દરેક બાજુએ વિડિઓઝ પ્લે ના થાય તો (તમારા બ્રાઉઝર પુનઃશરૂ જરૂરી છે)"
+  },
+  "filtereasylist_plus_finnish":{
     "description":"language",
-    "message":"ફ્રેન્ચ"
+    "message":"ફિનિશ"
   },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"તમને એક જાહેરાત જોઈ રહ્યાં છો, તો ક્ષતિ અહેવાલ બનાવા ની જરૂર નથી<a>જાહેરાત રિપોર્ટ</a>!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"ઇન્ટરેક્ટિવ પદાર્થ"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"હમણાં અપડેટ કરો"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"સેવ કરો"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"ચેતવણી: અન્ય તમામ સાઇટ્સ પર જાહેરાતો દેખાળવા માં આવશે!<br>તે સાઇટ્સ માટે અન્ય તમામ ગાળક નામંજૂર કરે છે."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"આ સૂચનાઓ અક્ષમ કરો"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"ઉમેદવારી સૂચિ  ફિલ્ટર કરો ..."
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"આપે બ્લોકીંગ કરેલી જાહેરાત ની યાદી ફિલ્ટર દ્વારા"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"સુધારાયેલ $days$ દિવસોપહેલા",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"ફ્રેમ"
+    "message":"ઇન્ટરેક્ટિવ પદાર્થ"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (ગોપનીયતા રક્ષણ)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"શું તમે વિચારો છો કે જો તમે આ જાહેરાત તમને આ પૃષ્ઠની મુલાકાત લો દર વખતે ઓપન​ થાય છે તે વિશે સાચું આ છે?"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"malware વિશે વધુ જાણો"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"ઝેક અને સ્લોવેક"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"તમને AdBlock ની ના જૂના આવૃત્તિ વાપરી રહ્યા છો.કૃપા કરીને <a href='#'>એકસટેન્શન પૃષ્ઠ પર જાઓ</a>, અને 'વિકાસકર્તા મોડ' સક્રિય કરો અને 'હવે અપડેટ કરો એક્સ્ટેન્શન' ક્લિક કરો"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock ના વિકલ્પો"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"આ યાદી સાફ કરો"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Anticocial ફિલ્ટર યાદી(સામાજિક મીડિયા બટનો દૂર કરે)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"ડિબગ સ્ટેટમેન્ટ કન્સોલ લોગ માં બતાવો (AdBlock ડાઉન પડી જાય છે)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"તમે ડ્રૉપબૉક્સ માપ મર્યાદા વટાવી દીધી છે. તમારી વૈવિધ્યપૂર્ણ અથવા અક્ષમ ફિલ્ટર કેટલાક પ્રવેશોને દૂર કરો અને ફરી પ્રયત્ન કરો."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"ફરીથી AdBlock ચાલુ કરો"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"જર્મન"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"કાળજી રાખો: પૃષ્ઠ પર આ ગાળક બધા $elementtype$ તત્વો સાથે બ્લોકો છે!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"અહીં"
-  },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- ભાષા પસંદ કરો -- "
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Hulu.com ની દરેક બાજુએ વિડિઓઝ પ્લે ના થાય તો (તમારા બ્રાઉઝર પુનઃશરૂ જરૂરી છે)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"બાકાત"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"કઈ ભાષામાં તે પૃષ્ઠ લખાયેલ છે?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"શું તમે ખરેખર દૂર કરવા માંગો છો $count$ તમે બ્લોકો માં $host$ પર રચના કરી છે?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"છબી"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"અનુવાદ માટે ક્રેડિટ જાય:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"લોળીગ..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"જાહેરાત અવરોધિત કરવા માટે જમણી ક્લિક કરો -- અથવા જાતે તેને અહીં અવરોધિત કરો."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"આ બટન છુપાવવા માટે, તેને અધિકાર ક્લિક કરો અને છુપાવો બટન પસંદ કરો. તમે હેઠળ તે ફરીથી બતાવી શકે છે chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"રોમાનિયન"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"નિષ્ક્રિય ગાળકો માં ફેરફાર કરો:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"અપડેટ્સ તપાસ કરતી વખતે કંઈક ખોટું થયું હતું."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"આ બટન છુપાવવા માટે,Safari ની ટૂલબાર પર જમણી ક્લિક કરો અને કસ્ટમાઇઝ ટૂલબાર પસંદ કરો,પછી AdBlock ના બટનને ટૂલબાર બહાર  ખેંચો.તમે ટૂલબાર પાછું ખેંચીને તેને ફરીથી બતાવી શકો છો."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"સુધારાયેલ 1 મિનિટ પહેલા"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"અવરોધિત જાહેરાતો:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"પાનું"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"કોરિયન"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"આ ડોમેન પર મારી બ્લોકો પૂર્વવત્ કરો"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"જાતે જ તમારી ગાળકો ફેરફાર કરો:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"ગાળક યાદીઓ લિંક્સ બતાવો"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (ભલામણ)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"પગલું 1: અવરોધિત કરવા ની આકૃતિ અથવા રસ્તો"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"અમે એક <a>પાનું રાખ્યું</a> છે સાથે સાથે જે આપડા જેવા લોકો ની મદદ કરવા માટે AdBlock ઉપયોગી છે!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"સાઇટ:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"અહીં"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"પોપઅપ"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock ની અપ ટુ ડેટ છે!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"પૃષ્ઠને ફરીથી લોડ કરો."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"માત્ર ઇંગલિશ"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"તમને AdBlock ની ના જૂના આવૃત્તિ વાપરી રહ્યા છો.કૃપા કરીને <a href='#'>એકસટેન્શન પૃષ્ઠ પર જાઓ</a>, અને 'વિકાસકર્તા મોડ' સક્રિય કરો અને 'હવે અપડેટ કરો એક્સ્ટેન્શન' ક્લિક કરો"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock થોભાવવામાં અવાયું છે."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"ફરીથી AdBlock ચાલુ કરો"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Anticocial ફિલ્ટર યાદી(સામાજિક મીડિયા બટનો દૂર કરે)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"જાહેરાતો શોધવા ...<br/><br/><i>આ માત્ર ત્યારે જ એક ક્ષણ લેવા પડશે.</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"હું ઉન્નત વપરાશકર્તા છું મને ઉચ્ચ વિકલ્પો બતાવવા"
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"જાહેરાત અવરોધિત કરો"
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"અથવા એક URL દાખલ કરો:"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"ચેતવણી: અન્ય તમામ સાઇટ્સ પર જાહેરાતો દેખાળવા માં આવશે!<br>તે સાઇટ્સ માટે અન્ય તમામ ગાળક નામંજૂર કરે છે."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"AdBlock ની માટે એક અપડેટ જ નથી! અપડેટ કરવા માટે $here$ જાઓ. <br> નોંધ: જો તમે આપોઆપ સુધારાઓ મેળવવા માંગો છો, તેના માટે Safari પર ક્લિક કરો > પસંદગીઓ > એક્સ્ટેન્શન્સ > સુધારાઓ <br> અને 'આપમેળે અપડેટ્સ સ્થાપિત' વિકલ્પ પર તપાસો.",
     "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock ની નિશાની બનાવે છે તે જોવા માંગો છો?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock વૈવિધ્યપૂર્ણ ગાળકો (ભલામણ)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"પ્રકાર"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"આ શું છે?"
+  },
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"જનરલ"
+  },
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"અથવા Chrome માટે AdBlock"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"યાદીઓ ફિલ્ટર કરવા માટે સબ્સ્ક્રાઇબ કરો"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"અનુવાદ માટે ક્રેડિટ જાય:"
+  },
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"ફોર્મેટ: ~ site1.com | ~ site2.com | ~ news.site3.org"
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"વિડિઓઝ અને Flash"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"વેબ પર સૌથી વધુ જાહેરાતો આ એડબ્લોક ગાળક યાદીઓ મા છે. તમે પણ કરી શકો છો:"
+  },
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"આ બટન છુપાવવા માટે,Safari ની ટૂલબાર પર જમણી ક્લિક કરો અને કસ્ટમાઇઝ ટૂલબાર પસંદ કરો,પછી AdBlock ના બટનને ટૂલબાર બહાર  ખેંચો.તમે ટૂલબાર પાછું ખેંચીને તેને ફરીથી બતાવી શકો છો."
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"તમે ડ્રૉપબૉક્સ માપ મર્યાદા વટાવી દીધી છે. તમારી વૈવિધ્યપૂર્ણ અથવા અક્ષમ ફિલ્ટર કેટલાક પ્રવેશોને દૂર કરો અને ફરી પ્રયત્ન કરો."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -952,251 +621,43 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"અથવા એક URL દાખલ કરો:"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"અથવા Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"તમને Safari ની જૂના આવૃત્તિ વાપરી રહ્યા છો. તાજેતરની આવૃત્તિ મેળવો અથવા AdBlock ની વિરામ માટે AdBlock ની ટૂલબાર પર જઈ ને વિરામ બટન પર ક્લિક કરો, વ્હાઇટલિસ્ટ વેબસાઇટ્સ,અને જાહેરાતો જાણ કરો.<a>હમણાં જ સુધારો</a>."
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"સબ્સ્ક્રાઇબ કરો"
   },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"લાવતી ... કૃપા કરીને રાહ જુઓ."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"તમે શું કરવા માંગો છો તેના માટે ની ચૂકવણી કરો!"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"આ સફારી મેનુ પર​ ક્લિક કરો &rarr; પસંદગીઓ &rarr; એક્સ્ટેન્શન્સ."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"જાહેરાતો અવરોધિત કરવાનું બંધ કરો:"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"40 મિલિયન વપરાશકર્તાઓ સાથે સૌથી લોકપ્રિય, Chrome એક્સ્ટેન્શન! બધી વેબ સાઇટ​ પર જાહેરાતો બ્લોકો કરો."
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"શું આ જાહેરાત હજુ દેખાય છે?"
-  },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"સહાયતા"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"બલ્ગેરિયન"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock ની નિશાની બનાવે છે તે જોવા માંગો છો?"
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"સમાપ્ત થયું!"
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"ફિલ્ટર દ્વારા, આ વિકલ્પો પાનાં પર બદલી શકાય છે:"
-  },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"જાતે જ તમારી ગાળકો ફેરફાર કરો:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"ઇટાલિયન"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"પોપઅપ"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"તાજેતરની પ્રકાશનમાં નવી શું છે? <a style='cursor:pointer;'>ચેન્જલોગ</a> જોવો!"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"સ્લોવેક"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"આ જાહેરાત બ્રાઉઝરમાં બહુ દેખાય છે?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"આ પાનાં પર ચાલુ નથી"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"ફક્ત આ સાઇટ્સ પર જાહેરાતો અવરોધિત કરો:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"અમને અમારી <a>સપોર્ટ સાઇટ</a> પર જણાવો!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock થોભાવવામાં અવાયું છે."
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"તમને તમારો સ્ટોરેજ જથ્થો વટાવી ઉપયોગ AdBlock કરી શકો છો. કેટલાક ફિલ્ટર યાદીઓ ઉમેદવારી દૂર કરો!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"અમે હજુ સુધી Flash અંદર જાહેરાતો અને અન્ય પ્લગઈનો અવરોધિત કરી શકતા નથી. પણ આપણે બ્રાઉઝર અને WebKit ટેકા ની રાહ જોઈ રહ્યા છીએ."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"ઓકે!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"ઠીક, તમે હજુ પણ પર તમારા માટે આ જાહેરાત અવરોધિત કરી શકો છો Options page પરથી. આભાર!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"જનરલ"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"અન્ય"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"કોઈ ફિલ્ટર સ્પષ્ટ કરેલા નથી!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"અજ્ઞાત"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"ફિનિશ"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock  આ પાનાં પર નિષ્ક્રિય થયેલ છે."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"ઓડિયો/વિડિયો"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japanese"
+    "message":"નિષ્ક્રિય ગાળકો માં ફેરફાર કરો:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"આ એક ફિલ્ટર યાદી સમસ્યા છે. તેને અહીં જાણ અહી કરો: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"આ ગાળક મેળવે કરવામાં નિષ્ફળ!"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"અવરોધિત તત્વ:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"ગાળક યાદીઓ લિંક્સ બતાવો"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"નોંધ: તમારી રિપોર્ટની જાહેરમાં ઉપલબ્ધ બની જાય છે. ખાનગી કંઈપણ સહિત પહેલાં ધ્યાનમાં રાખવા."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"માત્ર ઇંગલિશ"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"રદ કરો"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"તેનો પ્રસાર માટે મદદ કરો!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"તમને પૃષ્ઠો AdBlock પર ચાલશે નહીં અને કાઈ બદલવા માટે નીચે સ્લાઇડ કરી શકો છો."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Firefox માટે ચેક કરો $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"ClickToFlash સુસંગતતા સ્થિતિ સક્રિય કરો"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"આ ગાળક યાદી પર સબ્સ્ક્રાઇબ કરો,પછી ફરીથી પ્રયત્ન કરો: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"જાહેરાત જાણ માટે, તમે ઇન્ટરનેટ સાથે જોડાયેલ હોવું જ જોઈએ."
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"એક પ્રશ્ન અથવા નવા વિચારો છે?"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"હા"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"સ્પેનિશ"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"સારી દેખાય છે"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (ભલામણ)"
+  "typepage":{
+    "description":"A resource type",
+    "message":"પાનું"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1206,5 +667,584 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"શું આ જાહેરાત હજુ દેખાય છે?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"અન્ય"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"આ ક્લિક કરો:<a>મારા ગાળકો અપડેટ કરો</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"ઇટાલિયન"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"આ બટન છુપાવવા માટે, આ લિંક પર જાઓ opera://extensions અને તપાસો 'ટૂલબાર છુપાવ્યા' વિકલ્પ પસંદ કરો. તમે તે વિકલ્પ ચકાસ્યા વગર તેને ફરીથી બતાવી શકો છો."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"અપડેટ્સ તપાસ કરતી વખતે કંઈક ખોટું થયું હતું."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"આ સફારી મેનુ પર​ ક્લિક કરો &rarr; પસંદગીઓ &rarr; એક્સ્ટેન્શન્સ."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"ઑબ્જેક્ટ_પેટાવિનંતી"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"પાનું:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"આ જાહેરાત સાથે પૃષ્ઠને ફરીથી લોડ કરો."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"ઉમેદવારી દૂર."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"ઓડિયો/વિડિયો"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"લાતવિયન"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"આ પાનાં પર જાહેરાત અવરોધિત કરો"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"અવરોધિત કરો!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"જાહેરાતો અવરોધિત કરવાનું બંધ કરો:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"ચોક્કસ YouTube ની ચેનલો વ્હાઇટલિસ્ટિંગ પરવાનગી આપો"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"કઈ ભાષામાં તે પૃષ્ઠ લખાયેલ છે?"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"યાદીમાંથી દૂર કરો"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"અમે હજુ સુધી Flash અંદર જાહેરાતો અને અન્ય પ્લગઈનો અવરોધિત કરી શકતા નથી. પણ આપણે બ્રાઉઝર અને WebKit ટેકા ની રાહ જોઈ રહ્યા છીએ."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"તમને પૃષ્ઠો AdBlock પર ચાલશે નહીં અને કાઈ બદલવા માટે નીચે સ્લાઇડ કરી શકો છો."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"છૂપાઇ"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock  આ પાનાં પર નિષ્ક્રિય થયેલ છે."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"આ જાહેરાતમાં અથવા ફિલ્મ કે એક Flash રમત જેવી અન્ય કોઇ પ્લગઇન પહેલાં દેખાય છે?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"રશિયન અને યુક્રેનિયન"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"સ્પેનિશ"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"આ જાહેરાત અવરોધિત કરો"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"કાળજી રાખો: પૃષ્ઠ પર આ ગાળક બધા $elementtype$ તત્વો સાથે બ્લોકો છે!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"ClickToFlash સુસંગતતા સ્થિતિ સક્રિય કરો"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"ના"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"આ પાનાં પર AdBlock ની સક્રિય કરો"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"ફિલ્ટર દ્વારા, આ વિકલ્પો પાનાં પર બદલી શકાય છે:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"AdBlock ના બટન પર જાહેરાતોના નંબર બતાવો"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"સમાપ્ત થયું!"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"અજ્ઞાત"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"AdBlock થોભાવો"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"આ ગાળક યાદી પર સબ્સ્ક્રાઇબ કરો,પછી ફરીથી પ્રયત્ન કરો: $list_title$",
+    "placeholders":{
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"ઇંગલિશ"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"જમણી ક્લિક ના મેનૂ પર આઇટમ્સ ઉમેરો"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"ઠીક, તમે હજુ પણ પર તમારા માટે આ જાહેરાત અવરોધિત કરી શકો છો Options page પરથી. આભાર!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"રશિયન"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"તમને એક જાહેરાત જોઈ રહ્યાં છો, તો ક્ષતિ અહેવાલ બનાવા ની જરૂર નથી<a>જાહેરાત રિપોર્ટ</a>!"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"તમને Safari ની જૂના આવૃત્તિ વાપરી રહ્યા છો. તાજેતરની આવૃત્તિ મેળવો અથવા AdBlock ની વિરામ માટે AdBlock ની ટૂલબાર પર જઈ ને વિરામ બટન પર ક્લિક કરો, વ્હાઇટલિસ્ટ વેબસાઇટ્સ,અને જાહેરાતો જાણ કરો.<a>હમણાં જ સુધારો</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (ગોપનીયતા રક્ષણ)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"XMLHttp માગણી"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ હશે $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"સમાપ્ત થયું!"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"અન્ય ભાષા માટે ફિલ્ટર્સ ઉમેરો: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"લોળીગ..."
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"જાહેરાત અવરોધિત કરવા માટે જમણી ક્લિક કરો -- અથવા જાતે તેને અહીં અવરોધિત કરો."
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Malware સુરક્ષા"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"આ પેજ પર ની જાહેરાતો ની જાણ કરો"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"ડિબગ સ્ટેટમેન્ટ કન્સોલ લોગ માં બતાવો (AdBlock ડાઉન પડી જાય છે)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Firefox $chrome$ જો તમરી પાસે ન હોય તો.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"તમને તમારો સ્ટોરેજ જથ્થો વટાવી ઉપયોગ AdBlock કરી શકો છો. કેટલાક ફિલ્ટર યાદીઓ ઉમેદવારી દૂર કરો!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"40 મિલિયન વપરાશકર્તાઓ સાથે સૌથી લોકપ્રિય, Chrome એક્સ્ટેન્શન! બધી વેબ સાઇટ​ પર જાહેરાતો બ્લોકો કરો."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"શું તમને ભૂલ મળી?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"malware વિશે વધુ જાણો"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"સ્ક્રિપ્ટ"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"ફિલ્ટર યાદીઓ"
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"આ સૂચનાઓ અક્ષમ કરો"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"ચિની"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"ગાળક અયોગ્ય છે:$exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"ઉમેદવારી સૂચિ  ફિલ્ટર કરો ..."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"કે આ પાનાં પર $matchcount$ વસ્તુઓ મેળ ખાય છે.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"1 કલાક પહેલા સુધારાશે"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- ભાષા પસંદ કરો -- "
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"આ જાહેરાત આ પૃષ્ઠ પર યોગ્ય રીતે અવરોધિત છે, ત્યાં સુધી આ બદલવા માટે સ્લાઇડર સ્લાઇડ કરો,અને અવરોધિત તત્વ ઉપયોગી લાગે શકે તેવ હોય તો."
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"ઇન્ડોનેશિયન"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"છબી"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"ફેરફાર કરો"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"આ ગાળક મેળવે કરવામાં નિષ્ફળ!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"કુલ $count$",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"સહાયતા"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"તેના URL દ્વારા જાહેરાત અવરોધિત કરો"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"રદ કરો"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"સેવ કરવાનું ભૂલો નહિં!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"આવૃત્તિ $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"આ પ્રશ્ન હેતુ તમારી રિપોર્ટની પ્રાપ્ત કરીશું જે નક્કી કરવા માટે છે.તમે આ પ્રશ્નનો જવાબ ખોટા આપ શો તો,આ અહેવાલ ખોટા લોકો મોકલવામાં આવશે,તેથી તે અવગણવામાં આવી શકે છે."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"શું તમે ખરેખર સૂચિ ફિલ્ટર ઉમેદવારી નોંધાવવા માટે માગો છો $title$ ?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"સ્ત્રોત કોડ <a>મુક્ત રીતે ઉપલબ્ધ</a> છે!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"ડચ"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"નીચે બરાબર ફિલ્ટર લખો અને કૃપા કરીને પ્રેસ કરો"
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"આ પાનાં પર <b>1</b> આઇટમ સાથે બંધબેસે છે."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"આ યાદી સાફ કરો"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"સુધારાયેલ $hours$ કલાક પહેલા",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"પાછા"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock ના વિકલ્પો"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"બીટા"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"તમને જરૂર કરતાં વધુ સબ્સ્ક્રાઇબ નથી -- દરેક એક એક નાના બીટ તમને શાંત કરે છે! ક્રેડિટ અને વધુ યાદીઓ મળી શકે <a>અહીં</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"અપડેટ્સ માટે તપાસી રહ્યું છે (માત્ર થોડી સેકન્ડોમાં માં થઇ જશે)..."
+  },
+  "filterhungarian":{
+    "description":"language",
+    "message":"હંગેરિયન"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"ડોમેન ના પેજ પર લાગુ કરવા"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"હમણાં અપડેટ કરો"
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"અમારી ટીમ કેટલાક ડિબગ માહિતી માટે વિનંતી કરી છે? તે માટે! <a href='#' id='debug'>અહીં</a> જાઓ!"
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"સુધારાયેલ $minutes$ મિનિટ પહેલા",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"ઝેક"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"સ્વિડીશ"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock નો આધાર"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"પ્રકાર"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"ફ્રેન્ચ"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"સુધારાયેલ 1 મિનિટ પહેલા"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"ફ્રેમ"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - વિગતો માટે ક્લિક કરો"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"AdBlock ચલાવવા નથી ..."
   }
 }

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Dodajte snimak ekrana:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Nije pronađen poznati zlonamjerni softver."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"U tom pregledniku, pretplatite se na iste liste filtera koje imate ovdje."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"U tom pregledniku pokrenite stranicu sa reklamom."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Švedski"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blokirati još reklama:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Ruski"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Odjavljeno."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Kineski"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Ako ste stvorili filter koji radi koristeći čarobnjaka \"Blokiraj oglas\", zalijepite ga u prostor ispod:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocijalna lista filtera (uklanja gumbe društevnih mreža)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Pronašli ste oglas na web-stranici? Pomoći ćemo Vam da pronađete pravo mjesto za prijaviti!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Pokaži broj blokiranih reklama na AdBlock gumbu"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Izvorni kod je <a>slobodno dostupan</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"ažurirano prije 1 minutu"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Neuspjelo dobavljanje ovog filtera!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Ponovno pokrenite Safari kako bi završili isključivanje blokiranje sadržaja."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blokirati reklamu po njezinom URL-u"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Sakrij dugme"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Ažuriranja će se preuzimati automatski; također možete <a>ažurirati sada</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~site1.com|~site2.com|~vijesti.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estonski"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tip"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Postoji nova verzija za AdBlock! Idite $here$ kako biste ažurirali. <br> Bilješka: Ako želite primati ažuriranja automatski, samo kliknite u Safari > Postavke > Proširenja > Ažuriranja <br> i provjerite opciju 'Instaliraj ažuriranja automatski'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Što je ovo?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Nemojte se prijavljivati na više nego Vam je potrebno -- svaka stavka dodatno usporava AdBlock! Impresum i ostale liste možete pronaći <a>ovdje</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Ta AdBlock mogućnost ne radi na ovoj stranici jer koristi zastarjelu tehnologiju. Možete staviti na listu zabranjujućih i dopuštajućih filtera ručno u kartici 'Prilagodi' u postavkama."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Poljski"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Naučite više o programu Prihvatljivih oglasa."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"ažurirano prije $seconds$ sekundi",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"objektni podzahtjev"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Mađarski"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Napomena: Vaše izvješće može biti javno dostupno. Imajte to na umu prije nego ćete staviti nešto privatno."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Molimo onemogućite neke liste filtera. Više informacija u AdBlock postavkama."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Podrijetlo filtera:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Isprika, AdBlock je onemogućen na ovoj stranici zbog neke od vaših lista filtera."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filter je neispravan: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Upozorenje: filter nije unesen!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock je onemogućen na ovoj stranici."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Prikaži reklame <i>bilo gdje</i> osim na slijedećim domenama..."
+    "message":"Imate pitanje ili novu ideju?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Postavke"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttp zahtjev"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Blokirane reklame:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Reklamni filteri za drugi jezik: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Kliknite reklamu i ja ću Vas voditi kroz blokiranje."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Ako vidite reklamu, nemojte napraviti prijavu greške, napravite prijavu <a>reklame</a>!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Savršeno! Sve je kompletno namješteno."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Drugi"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock podrška"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Prilagodi AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Tražene informacije nedostaju ili nisu valjane. Molimo ispunite pitanja koja su označena crveno."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Greška pri spremanju poslane datoteke."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Molim Vas da ispravite filter ispod i kliknete OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Korak 1: Što blokirati?"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Danski"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (preporučeno)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"Blokirano na ovoj stranici: $count$",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Podokvir"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"ažurirano prije 1 sat"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Korejski"
+    "message":"Poljski"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"ili Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Kako se zovete?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Najpopularnije Chrome proširenje, sa preko 40 milijuna korisnika! Blokira reklame na cijelom internetu."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Pokaži sve zahtjeve"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Ne želim ovo provjeravati"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Da"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Vrati moja blokiranja na ovoj domeni"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Prilagodi"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pauziraj AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Jeste li sigurni da se želite pretplatiti na popis filtera $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Gdje točno na stranici se nalazi reklama? Kako izgleda?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"ili AdBlock za Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definicija stila"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Granica pravila blokiranog sadržaja je premašena"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Traženje reklama...<br/><br/><i>Ovo će potrajati trenutak.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domena ili URL gdje AdBlock ne bi trebao blokirati ništa"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skripta"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"Ukupno blokirano: $count$",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Sve gotovo! Uskoro ćemo se opet čuti, već kroz jedan dan vjerojatno, dva ako je praznik. U međuvremenu, potražite email od AdBlock-a. Naći ćete poveznicu za vašu prijavnicu na našoj stranici za pomoć. Ako preferirate koristiti email, možete i tako nastaviti!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Ne"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Nešto je pošlo krivo. Resursi nisu poslani. Stranica će se sada zatvoriti. Pokušajte ponovno pokrenuti stranicu."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ukrajinski"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"ažurirano prije $minutes$ minuta",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Isključili smo vas iz Prihvatljivih oglasa zato što ste uključili Safari blokiranje sadržaja. Možete odabrati samo jedno po jedno. (<a>Zašto?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Više niste pretplaćeni na liste prihvatljivih oglasa."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Zaštita od zločudnog softvera"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Spremi"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Upozoranje: na svim drugim stranicama ćete vidjeti reklame!<br>Ovo nadilazi sve druge filtere za te stranice."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Onemogući ove obavijesti"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Pretplata na listu filtera..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Koristite staru verziju AdBlock-a. Molim Vas posjetite <a href='#'>stranicu proširenja</a>, omogućite 'Način za razvojne programere' i kliknite 'Ažuriraj proširenja sada'."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock postavke"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Provjeri za zloćudni softver koji možda umeće oglase:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Prikaži izjave uklanjanja pogreške u zapisu konzole (usporava AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Premašili ste Dropbox ograničenje veličine. Molimo uklonite neke unose iz vaših prilagođenih ili onemogućenih filtera pa pokušajte ponovno."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Ponovo aktivirati AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Zaobilazno rješenje problema sa Hulu.com kad video ne radi (zahtijeva da se preglednik ponovno pokrene)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"Da odgovara CSS-u"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Isključiti"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Onemogućite sva proširenja osim AdBlock-a:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Zasluga za prijevod:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"POKRETANJE..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Desni klik na stranici na reklami za blokiranje -- ili ovdje blokiraj ručno."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Napomena: Dodavanjem na listu dopuštenog (dopuštanje oglasa) stranice nije podržano sa blokiranjem sadržaja za Safari."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Koristiti ćemo ovo samo ako budemo trebali još informacija."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Uredi onemogućene filtere:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Omogući blokiranje sadržaja za Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Vaša email adresa?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Za skrivanje gumba, desnim klikom na alatnu traku Safari-ja odaberite Prilagodba alatne trake, a zatim povucite gumb AdBlock iz alatne trake. Možete ga ponovo prikazati povlačenjem natrag u alatnoj traci."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Greška pri analiziranju vašeg zahtjeva."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"stranica"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Gotovo! Ponovo smo pokrenuli stranicu sa reklamom. Molimo provjerite tu stranicu i je li oglas nestao. Onda se vratite na ovu stranicu i odgovorite na pitanje ispod."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Ili unesite URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Koristite staru verziju preglednika Safari. Nabavite zadnju verziju da biste mogi koristiti AdBlock dugme alatne trake za pauziranje AdBlock-a, da onemogućite AdBlock-a na nekim web stranicama ili prijavite reklame. <a>Ažurirajte sad</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Kliknite Safari menu &rarr; Postavke &rarr; Proširenja."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Zaustavi blokiranje reklama:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokiraj!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Da li se reklama još pojavljuje?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bugarski"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Odlično! Pronađimo sada koje proširenje je uzrok. Prođite kroz listu i omogućite svako proširenje posebno. Proširenje koje donosi oglase nazad je ono koje bi trebali maknuti da se riješite reklama."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Neuspjelo!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Ručno urediti svoje filtere:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Talijanski"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"skočni prozorčić"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tip"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"slovački"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Prijava na listu filtera"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Možete ovo omogućite i podržati stranice koje volite odabiranjem \"Dopusti neke nenametljive reklame\" ispod."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Da li se reklama pojavljuje i u tom pregledniku?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Nemoj pokretati na ovoj stranici"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Litvanski"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Recite nam na našoj <a>stranici podrške</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock je pauziran."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Još ne možemo blokirati reklame unutar Flash ili drugih dodataka. Čekamo da to podrže preglednik ili WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"U redu!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Općenito"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Ako ne želite vidjeti oglase poput ovog, možete napustiti filter listu Prihvatljivih oglasa."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Vaše računalo je možda zaraženo sa zlonamjernim softverom. Kliknite <a>ovdje</a> za više informacija."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"ostalo"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Filter nije unesen!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"nepoznato"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japanski"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Dopusti neke nenametljive reklame"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Odustani"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Možete pomaknuti klizač ispod kako biste promjenili točno gdje želite da se AdBlock ne pokreće."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Isključili smo Safari blokiranje sadržaja jer ste odlučili dopustiti prihvatljive oglase. Možete odabrati samo jedno po jedno. (<a>Zašto?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Zadnji korak: prijavite grešku nama."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Provjerite u Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Da biste prijavili reklamu, morate biti spojeni na internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (preporučeno)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Prijavljivanje reklame"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Liste filtera blokiranih reklama"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Kako?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dopusti postavljanje YouTube kanala na listu dopuštenih"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Treće-strane"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (uklanja dosadne smetnje sa Weba)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - kliknite za detalje"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"ažurirano prije $hours$ sati",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Ruski i ukrajinski"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Što je novo u posljednjem izdanju? Pogledajte <a style='cursor:pointer;'>popis promjena</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Proširenja koja su prije bila onemogućena sada su omogućena."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grčki"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Sakriti dio stranice"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video i Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Što mislite da će biti istinito oko ove reklame svaki puta kad posjetite ovu stranicu?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Omogući AdBlock na ovoj stranici"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Nazad"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Liste filtera blokiraju večinu reklama na internetu. Možete također:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Provjeri filtere Prihvatljivih oglasa:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Prikazati reklame na stranici ili domeni"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Ovo odgovara <b>1</b> stavci na ovoj stranici."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Ne želim ovo provjeravati"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Ponovno pokrenite Safari kako bi završili isključivanje blokiranje sadržaja."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Budite oprezni: ako ovdje napravite pogrešku mnogo drugih filtera, uključujući službene, se može pokvariti!<br/>Pročitajte <a>sintaksni vodič za filtere</a> kako bi naučili dodavati napredne filtere zabranjujućih i dopuštajućih lista."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Dopusti $name$ kanal",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Da li se reklama pojavljuje i u tom pregledniku?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opće postavke"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Ako ne želite vidjeti oglase poput ovog, možete napustiti filter listu Prihvatljivih oglasa."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock neće raditi na nijednoj stranici koja odgovara slijedećem:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Nemamo zadanu listu filtera za taj jezik.<br/>Molim pronađite odgovarajuću listu koja podržava ovaj jezik $link$ ili blokirajte reklamu samo za sebe na kartici 'Prilagodi'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Prijavi"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Ja sam napredni korisnik, prikaži mi napredne postavke"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Španjolski"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Pokrenuto na stranici s domenom:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Klikni ovo: <a>Ažuriraj moje filtere!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Što više lista fitera koristite, sporiji će biti AdBlock. Korištenje previše lista može čak srušiti Vaš preglednik na nekim stranicama. Pritisnite U redu da se ipak prijavite na ovu listu."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Posljednji korak: Što ovo čini reklamom"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Ovo odgovara $matchcount$ stavki na ovoj stranici.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Također, imamo i <a>stranicu</a> na kojoj možete pronaći ljude koji su napravili AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonezijski"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turski"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokiraj reklamu"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Lista prilagođenih filtera"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL okvira: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Svrha ovog pitanja je da se utvrdi tko bi trebao primiti vaš izvještaj. Ako odgovorite netočno, izvještaj će biti poslan krivim ljudima pa tako možda i zanemaren."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dodaj stavke na izbornik desnog klika"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"za odabir"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokiraj ovu reklamu"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Da li je naš tim zatražio informacije o grešci? Kliknite <a href='#' id='debug'>ovdje</a> za to!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Nemoj pokretati AdBlock na..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Prijavljivanje oglasa je dobrovoljno. Pomaže drugima da također ne vide reklame tako što održavatelji lista filtera blokiraju oglas za sve. Ako se ne osjećate altruistički, to je isto u redu. Zatvorite ovu stranicu i <a>blokirajte oglas</a> samo sebi."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Skriveni element"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Ponovo učitajte stranicu."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"stranica"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Nizozemski"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Naziv datoteke je prevelik. Molimo skratite naziv datoteke."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Ne zaboravite spremiti!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Provjeravanje ažuriranja (trebalo bi trajati samo nekoliko sekundi)..."
+    "message":"Litvanski"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Prijavite se na ovu listu filtera, pa ponovno pokušajte: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Treba li vas AdBlock obavijestiti kada pronađe zloćudni softver?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Vaše računalo je možda zaraženo sa zlonamjernim softverom. Kliknite <a>ovdje</a> za više informacija."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Pokaži broj blokiranih reklama na AdBlock izborniku"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Prikazati reklame na stranici ili domeni"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Lokacija:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock prilagodljivi filteri (preporučeno)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Latvijski"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Provjerite je li koristite ispravni filter za jezik:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"Da odgovara CSS-u"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Da maknete gumb, idite na opera://extensions i obilježite 'Makni sa alatne trake' opciju. Možete ga vratiti kasnije tako da poništite tu opciju."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Niste sigurni?</b> samo kliknite 'Blokiraj!' ispod."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Odgovarajući filter"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Dobavljam... molim pričekajte."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Svi resursi"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock je ažuriran!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Onemogući pokretanje na stranicima ove domene"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Hebrejski"
+    "message":"slovački"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Pomaknite klizač dok reklama nije blokirana ispravno na stranici te blokirani element ne izgleda upotrebljivo."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokirati URL-ove koji sadržavaju ovaj tekst"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Broj pravila filter listi prešao je granicu od 50.000 i automatski je smanjen. Molimo odjavite se sa nekih listi ili onemogućite blokiranje sadržaja za Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"ažurirano prije 1 dan"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Prihvatljivi oglasi (preporučeno)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Kliknite ovo: <a>Onemogući Prihvatljive oglase</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Verzija $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Instalirajte AdBlock Plus za Firefox $chrome$ ako ga nemate.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Uklanjanje iz liste"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Nemamo zadanu listu filtera za taj jezik.<br/>Molim pronađite odgovarajuću listu koja podržava ovaj jezik $link$ ili blokirajte reklamu samo za sebe na kartici 'Prilagodi'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"To nije slikovna datoteka. Molimo pošaljite .png, .gif, ili .jpg datoteku."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Zašto nam ne pošaljete <a>izvještaj greške</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"skrivanje"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Liste filtera"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Domena okvira: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Kliknite reklamu i ja ću Vas voditi kroz blokiranje."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Gornji okvir"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"definicija stila"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"nepoznato"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Isprika, AdBlock je onemogućen na ovoj stranici zbog neke od vaših lista filtera."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Treće-strane"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Filter nije unesen!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Grčki"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Koristite staru verziju AdBlock-a. Molim Vas posjetite <a href='#'>stranicu proširenja</a>, omogućite 'Način za razvojne programere' i kliknite 'Ažuriraj proširenja sada'."
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Kako se zovete?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Zaobilazno rješenje problema sa Hulu.com kad video ne radi (zahtijeva da se preglednik ponovno pokrene)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Upozorenje: filter nije unesen!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Prilagodi"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Pronašli ste oglas na web-stranici? Pomoći ćemo Vam da pronađete pravo mjesto za prijaviti!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estonski"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Prilagodi AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bugarski"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Dopušteni resurs"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Granica pravila blokiranog sadržaja je premašena"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Nemoj pokretati AdBlock na..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokirati URL-ove koji sadržavaju ovaj tekst"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Zatvori"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Provjerite u Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Posljednji korak: Što ovo čini reklamom"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Ako vidite reklamu, nemojte napraviti prijavu greške, napravite prijavu <a>reklame</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Korejski"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Koristite staru verziju preglednika Safari. Nabavite zadnju verziju da biste mogi koristiti AdBlock dugme alatne trake za pauziranje AdBlock-a, da onemogućite AdBlock-a na nekim web stranicama ili prijavite reklame. <a>Ažurirajte sad</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finski"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skripta"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ukrajinski"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Nije pronađen poznati zlonamjerni softver."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Molimo onemogućite neke liste filtera. Više informacija u AdBlock postavkama."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Isključili smo vas iz Prihvatljivih oglasa zato što ste uključili Safari blokiranje sadržaja. Možete odabrati samo jedno po jedno. (<a>Zašto?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Također, imamo i <a>stranicu</a> na kojoj možete pronaći ljude koji su napravili AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"ovdje"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"skočni prozorčić"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttp zahtjev"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Ponovo učitajte stranicu."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Na kojem je jeziku stranica napisana?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock je pauziran."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Ponovo aktivirati AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Traženje reklama...<br/><br/><i>Ovo će potrajati trenutak.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock je onemogućen na ovoj stranici."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"U tom pregledniku, pretplatite se na iste liste filtera koje imate ovdje."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokiraj reklamu"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Upozoranje: na svim drugim stranicama ćete vidjeti reklame!<br>Ovo nadilazi sve druge filtere za te stranice."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Postoji nova verzija za AdBlock! Idite $here$ kako biste ažurirali. <br> Bilješka: Ako želite primati ažuriranja automatski, samo kliknite u Safari > Postavke > Proširenja > Ažuriranja <br> i provjerite opciju 'Instaliraj ažuriranja automatski'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Završeno!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock prilagodljivi filteri (preporučeno)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tip"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Što je ovo?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japanski"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Podrijetlo filtera:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Prijava na listu filtera"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Vrsta okvira: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Reklamni filteri za drugi jezik: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Resurs"
+    "message":"Odgovarajući filter"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blokiraj reklamu na ovoj stranici"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Liste filtera blokiraju večinu reklama na internetu. Možete također:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Provjerite stanje ažuriranja vaših filter lista:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Za skrivanje gumba, desnim klikom na alatnu traku Safari-ja odaberite Prilagodba alatne trake, a zatim povucite gumb AdBlock iz alatne trake. Možete ga ponovo prikazati povlačenjem natrag u alatnoj traci."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Engleski"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Premašili ste Dropbox ograničenje veličine. Molimo uklonite neke unose iz vaših prilagođenih ili onemogućenih filtera pa pokušajte ponovno."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Islandski"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Prijavi"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Otvori stranicu proširenja kako bi omogućili proširenja koja su bila onemogućena."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Napomena: Dodavanjem na listu dopuštenog (dopuštanje oglasa) stranice nije podržano sa blokiranjem sadržaja za Safari."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domena stranice na koju želite primijeniti"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blokirani element:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"stranica"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"ostalo"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Klikni ovo: <a>Ažuriraj moje filtere!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Skriveni element"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Da maknete gumb, idite na opera://extensions i obilježite 'Makni sa alatne trake' opciju. Možete ga vratiti kasnije tako da poništite tu opciju."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"objektni podzahtjev"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Stranica:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Pronašli ste grešku?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokiraj!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dopusti postavljanje YouTube kanala na listu dopuštenih"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Još ne možemo blokirati reklame unutar Flash ili drugih dodataka. Čekamo da to podrže preglednik ili WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Arapski"
+    "message":"Mađarski"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokiraj ovu reklamu"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Omogući AdBlock na ovoj stranici"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Pokaži broj blokiranih reklama na AdBlock gumbu"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Neuspjelo!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pauziraj AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Češki"
+    "message":"Engleski"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Plati koliko želiš!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dodaj stavke na izbornik desnog klika"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Želite li vidjeti kako radi AdBlock?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Molimo idite na <a>našu stranicu za podršku</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"AdBlock lista uklanjanja upozorenja (uklanja upozorenja o korištenju blokera oglasa)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Nepravilna lista URL. Bit će obrisana."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"okvir"
+    "message":"stranica"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Promjeni"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Jeste li sigurni da želite maknuti $count$ blokiranja koje ste napravili na $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Imate pitanje ili novu ideju?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legenda: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Zaboravili ste prikvačiti snimak zaslona! Ne možemo Vam pomoći ako ne vidimo o kakvom se oglasu radi."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ILI</b>, samo kliknite ovaj gumb kako bi uradili sve ovo iznad: <a>Onemogući sva druga proširenja</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"ažurirano prije $minutes$ minuta",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Naučite više o zloćudnom softveru"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Dodajte snimak ekrana:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Rumunjski"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Uredi onemogućene filtere:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Podokvir"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Ponovno pokreni stranicu sa reklamom."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Omogući blokiranje sadržaja za Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Instalirajte Firefox $chrome$ ako ga nemate.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Liste filtera"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Ako ste stvorili filter koji radi koristeći čarobnjaka \"Blokiraj oglas\", zalijepite ga u prostor ispod:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Ova datoteka je prevelika. Molimo provjerite veličinu, maksimalno je 10 MB."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock neće raditi na nijednoj stranici koja odgovara slijedećem:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Kineski"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filter je neispravan: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Pretplata na listu filtera..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Otvori stranicu proširenja kako bi omogućili proširenja koja su bila onemogućena."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Onemogući ove obavijesti"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turski"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Nemojte se prijavljivati na više nego Vam je potrebno -- svaka stavka dodatno usporava AdBlock! Impresum i ostale liste možete pronaći <a>ovdje</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"okvir"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonezijski"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"slika"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"Ukupno blokirano: $count$",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Odustani"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Ne zaboravite spremiti!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"za odabir"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Isključili smo Safari blokiranje sadržaja jer ste odlučili dopustiti prihvatljive oglase. Možete odabrati samo jedno po jedno. (<a>Zašto?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Islandski"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Liste filtera blokiranih reklama"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokiraj reklame samo na slijedećim stranicama:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Pokrenuto na stranici s domenom:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Proširenja koja su prije bila onemogućena sada su omogućena."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Očisti ovu listu"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Pomozite proširiti ideju!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock ažuriranja"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"AdBlock lista uklanjanja upozorenja (uklanja upozorenja o korištenju blokera oglasa)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock postavke"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Greška pri analiziranju vašeg zahtjeva."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"ažurirano prije 1 sat"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Provjeravanje ažuriranja (trebalo bi trajati samo nekoliko sekundi)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"upravo ažurirano"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Desni klik na stranici na reklami za blokiranje -- ili ovdje blokiraj ručno."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Provjeri za zloćudni softver koji možda umeće oglase:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock podrška"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tip"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Pomaknite klizač dok reklama nije blokirana ispravno na stranici te blokirani element ne izgleda upotrebljivo."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"ažurirano prije 1 minutu"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"okvir"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Blokirani resurs"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Slijedeće informacije biti će također uključene u prijavu oglasa."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Danski"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Provjeri filtere Prihvatljivih oglasa:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Možete ovo omogućite i podržati stranice koje volite odabiranjem \"Dopusti neke nenametljive reklame\" ispod."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Dobavljam... molim pričekajte."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Nepravilna lista URL. Bit će obrisana."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opće postavke"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Poništite 'Omogućeno' kvačicu  pokraj svakog proširenja <b>osim</b> pokraj AdBlock-a. <b>Ostavite AdBlock omogućen</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"U tom pregledniku pokrenite stranicu sa reklamom."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Prikaži reklame <i>bilo gdje</i> osim na slijedećim domenama..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Zaboravili ste prikvačiti snimak zaslona! Ne možemo Vam pomoći ako ne vidimo o kakvom se oglasu radi."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"I ručno napravite prijavnicu, kopirajte i zalijepite informacije ispod u sekciju \"Fill in any details you think will help us understand your issue\"."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Sakrijte gumb tako da ga desnim klikom miša kliknete i odaberte Sakrij gumb. Možete gumb vratiti nazad u opcijama proširenja: chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebrejski"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Ta AdBlock mogućnost ne radi na ovoj stranici jer koristi zastarjelu tehnologiju. Možete staviti na listu zabranjujućih i dopuštajućih filtera ručno u kartici 'Prilagodi' u postavkama."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Češki i slovački"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Onemogućili smo sva proširenja. Sada ćemo ponovno pokrenuti stranicu sa oglasom. Jednu sekundu, molim."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Ostale liste filtera"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Francuski"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Ažuriranja će se preuzimati automatski; također možete <a>ažurirati sada</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blokirani element:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Pokaži sve zahtjeve"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interakivni objekt"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Što više lista fitera koristite, sporiji će biti AdBlock. Korištenje previše lista može čak srušiti Vaš preglednik na nekim stranicama. Pritisnite U redu da se ipak prijavite na ovu listu."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Savršeno! Sve je kompletno namješteno."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Otvori <a href='#'>stranicu proširenja</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Sve gotovo! Uskoro ćemo se opet čuti, već kroz jedan dan vjerojatno, dva ako je praznik. U međuvremenu, potražite email od AdBlock-a. Naći ćete poveznicu za vašu prijavnicu na našoj stranici za pomoć. Ako preferirate koristiti email, možete i tako nastaviti!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Naučite više o programu Prihvatljivih oglasa."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Treba li vas AdBlock obavijestiti kada pronađe zloćudni softver?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"upravo ažurirano"
+    "message":"ažurirano prije 1 dan"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL okvira: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Njemački"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Naziv datoteke je prevelik. Molimo skratite naziv datoteke."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"ažurirano prije $seconds$ sekundi",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Nemoj pokretati na ovoj stranici"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Recite nam na našoj <a>stranici podrške</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"U redu!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Gotovo! Ponovo smo pokrenuli stranicu sa reklamom. Molimo provjerite tu stranicu i je li oglas nestao. Onda se vratite na ovu stranicu i odgovorite na pitanje ispod."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Svi resursi"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Dopusti $name$ kanal",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Resurs"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Pokaži broj blokiranih reklama na AdBlock izborniku"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Prijavljivanje reklame"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Kako?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Onemogući pokretanje na stranicima ove domene"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Lista prilagođenih filtera"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blokirati još reklama:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Tražene informacije nedostaju ili nisu valjane. Molimo ispunite pitanja koja su označena crveno."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domena ili URL gdje AdBlock ne bi trebao blokirati ništa"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Više niste pretplaćeni na liste prihvatljivih oglasa."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (uklanja dosadne smetnje sa Weba)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock je blokirao preuzimanje sa web stranice poznate po držanju zločudnih programa."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Spremi"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Niste sigurni?</b> samo kliknite 'Blokiraj!' ispod."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Zadnji korak: prijavite grešku nama."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Gdje točno na stranici se nalazi reklama? Kako izgleda?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Izgleda u redu"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dopusti AdBlock-u anonimno prikupljanje podatka i korištenja liste filtara"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Da biste prijavili reklamu, morate biti spojeni na internet."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Jeste li sigurni da se želite pretplatiti na popis filtera $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"ažurirano prije $days$ dana",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"okvir"
+    "message":"interakivni objekt"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Što mislite da će biti istinito oko ove reklame svaki puta kad posjetite ovu stranicu?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Blokirane reklame:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arapski"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Vrati moja blokiranja na ovoj domeni"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Ručno urediti svoje filtere:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Korak 1: Što blokirati?"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Molim Vas da ispravite filter ispod i kliknete OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Zasluga za prijevod:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock je ažuriran!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Samo engleski"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ILI</b>, samo kliknite ovaj gumb kako bi uradili sve ovo iznad: <a>Onemogući sva druga proširenja</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Što je novo u posljednjem izdanju? Pogledajte <a style='cursor:pointer;'>popis promjena</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (zaštita privatnosti)"
+    "message":"Antisocijalna lista filtera (uklanja gumbe društevnih mreža)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Prijavi reklamu na ovoj stranici"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Zaštita od zločudnog softvera"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Očisti ovu listu"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Ja sam napredni korisnik, prikaži mi napredne postavke"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Njemački"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Prešli ste preko omogućene memorije koje AdBlock koristi. Molim Vas da se odjavite od nekih listi filtera!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Oprez: Ovaj filter blokira sve $elementtype$ elemente na stranici!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"ovdje"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Vaša email adresa?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Na kojem je jeziku stranica napisana?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Želite li vidjeti kako radi AdBlock?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Jeste li sigurni da želite maknuti $count$ blokiranja koje ste napravili na $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"slika"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Sakriti dio stranice"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"I ručno napravite prijavnicu, kopirajte i zalijepite informacije ispod u sekciju \"Fill in any details you think will help us understand your issue\"."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Općenito"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Sakrijte gumb tako da ga desnim klikom miša kliknete i odaberte Sakrij gumb. Možete gumb vratiti nazad u opcijama proširenja: chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"ili AdBlock za Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumunjski"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video i Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Nešto je pošlo po zlu kod provjere ažuriranja."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Onemogućili smo sva proširenja. Sada ćemo ponovno pokrenuti stranicu sa oglasom. Jednu sekundu, molim."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Dopušteni resurs"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Odlično! Pronađimo sada koje proširenje je uzrok. Prođite kroz listu i omogućite svako proširenje posebno. Proširenje koje donosi oglase nazad je ono koje bi trebali maknuti da se riješite reklama."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Češki i slovački"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"ili Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Vrsta okvira: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~site1.com|~site2.com|~vijesti.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Odaberite jezik --"
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Instalirajte AdBlock Plus za Firefox $chrome$ ako ga nemate.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Blokirani resurs"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Da li se reklama pojvljuje u ili prije filma odnosno drugih dodataka kao Flash igre?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ će biti $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filter, može se promjeniti u Postavkama:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Slijedeći filter:<br/> $filter$ <br/> ima grešku: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Zatvori"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokiraj reklame samo na slijedećim stranicama:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Prešli ste preko omogućene memorije koje AdBlock koristi. Molim Vas da se odjavite od nekih listi filtera!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dopusti AdBlock-u anonimno prikupljanje podatka i korištenja liste filtara"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"U redu, još možete blokirati ovu reklamu samo za sebe u Postavkama. Hvala!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Pošalji"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finski"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Ova datoteka je prevelika. Molimo provjerite veličinu, maksimalno je 10 MB."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Slijedeće informacije biti će također uključene u prijavu oglasa."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Plati koliko želiš!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Ovo je problem sa listom filtera. Prijavi ga ovdje: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Poništite 'Omogućeno' kvačicu  pokraj svakog proširenja <b>osim</b> pokraj AdBlock-a. <b>Ostavite AdBlock omogućen</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Napomena: Vaše izvješće može biti javno dostupno. Imajte to na umu prije nego ćete staviti nešto privatno."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Prikaži linkove na liste filtera"
+  "filteritalian":{
+    "description":"language",
+    "message":"Talijanski"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Samo engleski"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Pomozite proširiti ideju!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Da li se reklama još pojavljuje?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock je blokirao preuzimanje sa web stranice poznate po držanju zločudnih programa."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Provjerite je li koristite ispravni filter za jezik:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legenda: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Provjerite stanje ažuriranja vaših filter lista:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Nešto je pošlo po zlu kod provjere ažuriranja."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Kliknite Safari menu &rarr; Postavke &rarr; Proširenja."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Pošalji"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Odjavljeno."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Latvijski"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blokiraj reklamu na ovoj stranici"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Zaustavi blokiranje reklama:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Greška pri spremanju poslane datoteke."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Ovo odgovara $matchcount$ stavki na ovoj stranici.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Neuspjelo dobavljanje ovog filtera!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Možete pomaknuti klizač ispod kako biste promjenili točno gdje želite da se AdBlock ne pokreće."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"skrivanje"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Da li se reklama pojvljuje u ili prije filma odnosno drugih dodataka kao Flash igre?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Ruski i ukrajinski"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Španjolski"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Oprez: Ovaj filter blokira sve $elementtype$ elemente na stranici!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Omogući način kompatibilnosti ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Ne"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filter, može se promjeniti u Postavkama:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Sakrij dugme"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Drugi"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"U redu, još možete blokirati ovu reklamu samo za sebe u Postavkama. Hvala!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Ruski"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Zašto nam ne pošaljete <a>izvještaj greške</a>?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (zaštita privatnosti)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ će biti $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Ili unesite URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Slijedeći filter:<br/> $filter$ <br/> ima grešku: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"POKRETANJE..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Da li je naš tim zatražio informacije o grešci? Kliknite <a href='#' id='debug'>ovdje</a> za to!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Broj pravila filter listi prešao je granicu od 50.000 i automatski je smanjen. Molimo odjavite se sa nekih listi ili onemogućite blokiranje sadržaja za Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Prijavi reklamu na ovoj stranici"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Prikaži izjave uklanjanja pogreške u zapisu konzole (usporava AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Domena okvira: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Najpopularnije Chrome proširenje, sa preko 40 milijuna korisnika! Blokira reklame na cijelom internetu."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Pronašli ste grešku?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Češki"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"To nije slikovna datoteka. Molimo pošaljite .png, .gif, ili .jpg datoteku."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Prikaži linkove na liste filtera"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Dopusti neke nenametljive reklame"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Švedski"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Uklanjanje iz liste"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Odaberite jezik --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francuski"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Promjeni"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Podrška"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Molimo idite na <a>našu stranicu za podršku</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blokirati reklamu po njezinom URL-u"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Kako bi pauzirali AdBlock sa omogućenim blokiranjem sadržaja, molimo odaberite Safari (u traci izbornika) > Postavke > Proširenja > AdBlock i odbilježite 'Omogući AdBlock'."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Verzija $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Svrha ovog pitanja je da se utvrdi tko bi trebao primiti vaš izvještaj. Ako odgovorite netočno, izvještaj će biti poslan krivim ljudima pa tako možda i zanemaren."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Prijavljivanje oglasa je dobrovoljno. Pomaže drugima da također ne vide reklame tako što održavatelji lista filtera blokiraju oglas za sve. Ako se ne osjećate altruistički, to je isto u redu. Zatvorite ovu stranicu i <a>blokirajte oglas</a> samo sebi."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Da"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Izvorni kod je <a>slobodno dostupan</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Nizozemski"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Koristiti ćemo ovo samo ako budemo trebali još informacija."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Ovo odgovara <b>1</b> stavci na ovoj stranici."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"ažurirano prije $hours$ sati",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Nazad"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Kliknite ovo: <a>Onemogući Prihvatljive oglase</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domena stranice na koju želite primijeniti"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock ažuriranja"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Nešto je pošlo krivo. Resursi nisu poslani. Stranica će se sada zatvoriti. Pokušajte ponovno pokrenuti stranicu."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Naučite više o zloćudnom softveru"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Lokacija:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Prihvatljivi oglasi (preporučeno)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Izgleda u redu"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Kako bi pauzirali AdBlock sa omogućenim blokiranjem sadržaja, molimo odaberite Safari (u traci izbornika) > Postavke > Proširenja > AdBlock i odbilježite 'Omogući AdBlock'."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Otvori <a href='#'>stranicu proširenja</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - kliknite za detalje"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Onemogućite sva proširenja osim AdBlock-a:"
   }
 }

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -1,759 +1,199 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Egy hirdetés bejelentése"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Hirdetés blokkoló szűrőlisták"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Kattintson ide: <a>Elfogadható hirdetések letiltása</a>"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Webhely:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Adott YouTube csatornák fehér listára tételének engedélyezése"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Nem található ismert kártevő."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Abban a böngészőben iratkozzon fel ugyanazon szűrőlistákra, amelyekre itt is fel van."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - kattintson a részletekért"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Töltse be az oldalt a hirdetéssel abban a böngészőben."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Svéd"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Mi új van a legújabb kiadásban? Nézze meg a <a style='cursor:pointer;'>változásnaplót</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"További hirdetéseket blokkolni:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Orosz"
+    "message":"Dán"
   },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Az előzetesen letiltott bővítmények újraengedélyezésre kerültek."
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Az Elfogadható hirdetések szűrőinek ellenőrzése:"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Leiratkozva."
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Segítsen terjeszteni az igét!"
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Izlandi"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Görög"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Kínai"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Spanyol"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Kártevő védelem"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Ön szerint mi lesz igaz erre a reklámra mindig, amikor meglátogatja ezt az oldalt?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"AdBlock engedélyezése ezen az oldalon"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Vissza"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"A blokkolt hirdetések számának megjelenítése az AdBlock gombján"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Utolsó lépés: Ez mitől hirdetés?"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Kérdése vagy új ötlete van?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Lett"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"A szűrőlisták blokkolják a legtöbb reklámot a weben. Továbbá lehet még:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"A forráskód <a>szabadon elérhető</a>!"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Tudjon meg többet az Elfogadható hirdetések programról."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Hirdetések megjelenítése egy weboldalon vagy tartományban"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Ez <b>1</b> elemmel egyezik az oldalon."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Weboldal egy részének elrejtése"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"A(z) $name$ csatorna fehér listára tétele",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Általános opciók"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Lehet, hogy számítógépe kártevővel fertőzött. További információért kattintson <a>ide</a>."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"Az AdBlock nem fut az alábbiakkal megegyező oldalakon:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Nincs alapértelmezett szűrőlistánk ahhoz a nyelvhez.<br/>Kérem próbáljon találni egy megfelelő listát, amely támogatja ezt a nyelvet $link$, vagy blokkolja magának ezt a hirdetést az 'Testreszabás' oldalon.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Feliratkozás"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Haladó felhasználó vagyok, jelenjenek meg a haladó opciók"
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Egy hirdetés blokkolása annak URL-je alapján"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Gomb eljrejtése"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"A frissítések automatikusan le lesznek töltve; vagy inkább <a>frissítés most</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Kattintson erre: <a>Frissítse a szűrőimet!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formátum: ~webhely1.hu|~webhely2.hu|~hírek.webhely3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Észt"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Ez $matchcount$ elemmel egyezik az oldalon.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Van egy <a>oldalunk</a>, amely az AdBlock mögött álló embereket is segít kiismerni!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonéz"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Típus"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Van egy frissítés az AdBlock-hoz! Irány $here$ a frissítéshez. <br> Megjegyzés: Ha automatikusan szeretné kapni a frissítéseket, csak kattintson a Safari > Környezeti beállítások > Bővítmények > Frissítések menüpontra <br> és jelölje be a \"Frissítések automatikus telepítése\" opciót.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Török"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Mi ez?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Egyéni szűrőlisták"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Ne iratkozzon fel a szükségesnél többre -- mindegyik lelassítja egy aprócskát! A stáblista és még több lista <a>itt</a> találhatók."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"stílusmeghatározás"
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Eltávolítás a listáról"
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Ezen kérdésnek célja, hogy meghatározza, ki kapja meg az Ön jelentését. Ha helytelenül válaszolja meg e kérdést, a jelentés rossz embereknek lesz elküldve, így lehet, hogy figyelembe se lesz véve."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Lengyel"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Elemek hozzáadása a jobb klikk menühöz"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videók és Flash"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokkolja ezt a hirdetést"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"$hours$ órája frissítve",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"$seconds$ másodperce frissítve",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Csapatunk netán némi hibakeresési információt kérelmezett? Ehhez kattintson <a href='#' id='debug'>ide</a>!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktív objektum"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Magyar"
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"A hirdetések jelentése önkéntes alapú. Úgy segít másoknak, hogy lehetővé teszi a szűrőlista karbantartóknak a hirdetés blokkolását mindekni rászáre. Ha épp nincs önzetlen hangulatban, semmi gond. Zárja be ezt az oldalt, és <a>blokkolja a hirdetést</a> csak magának."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Megjegyzés: bejelentése nyilvánosan elérhetővé válhat. Ezt tartsa szem előtt, mielőtt bármi bizalmasat foglalna bele."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Az oldal újratöltése."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"oldal"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Holland"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Ne felejtsen el menteni!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"A(z) $attribute$ $value$ lesz",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Bezárás"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blokkolt elem:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"A szűrő érvénytelen: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Figyelmeztetés: nem lett szűrő megadva!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Engedély megadása az AdBlock-nak, hogy névtelen szűrőlista használatot és adatokat gyűjtsön"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Értesítsen az AdBlock, ha kártevőt észlel?"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Ha hirdetést lát, ne hibajelentést tegyen, hanem <a>hirdetés jelentést</a>!"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Hirdetések megjelenítése <i>mindenhol</i>, kivéve ezekben a tartományokban..."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Ez az AdBlock szolgáltatás nem működik ezen az oldalon, mert elavult technológiát használ. Az opciók oldal 'Testreszabás' fülén manuálisan fekete- vagy fehér listára teheti az erőforrásokat."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"A blokkolt hirdetések számának megjelenítése az AdBlock menüjében"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Opciók"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Ne fusson az AdBlockot..."
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Blokkolt hirdetések:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock egyéni szűrők (ajánlott)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Szűrők hozzáadása másik nyelvhez: "
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fiúrajongói zaklatások (eltávolítja a weben található zavaró tényezőket)"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Győződjön meg róla, hogy a megfelelő nyelvi szűrő(ke)t használja:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"Egyeztetendő CSS"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"A gomb elrejtéséhez menjen az opera://extensions oldalra, majd jelölje be az \"Elrejtés az eszköztárról\" opciót. Újból megjelenítheti az opció előtti jelölés törlésével."
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Kattintson a hirdetésre, én pedig végigvezetem Önt a blokkolás menetén."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Hirdetés bejelentése ezen az oldalon"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Remek! Minden kész."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Orosz és ukrán"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Lekérés... kérem várjon."
   },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Legyen óvatos: ha itt hibát vét, sok más szűrő, beleértve a hivatalosakat is, szintén meghibásodhatnak!<br/>Olvassa el a <a>szűrő mondattan oktatóanyagot</a>, hogy megtudja hogyan kell összetett fekete lista és fehér lista szűrőket hozzáadni."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Általános"
   },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock ügyfélszolgálat"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"AdBlock testreszabása"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"Az AdBlock naprakész!"
-  },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Tudjon meg többet a kártevőkröl"
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Héber"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sajnáljuk, az AdBlock le van tiltva ezen az oldalon az egyik szűrőlista által."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Az ezt a szöveget tartalmazó URL-ek blokkolása"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Blokkolásaim visszavonása ebben a tartományban"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Kérem gépelje be lent a helyes szűrőt, majd nyomja meg az OK gombot"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"1 napja frissítve"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Béta"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fiúrajongói zaklatások (eltávolítja a weben található zavaró tényezőket)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"Ezen az oldalon $count$",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Nem biztos benne?</b> Csak nyomja meg lent a 'Blokkold!' gombot."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Érvénytelen lista URL. Törlődni fog."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"1 órája frissítve"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Lengyel"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Verzió: $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Általános opciók"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Feliratkozás szűrőlistákra"
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Egyéb"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"elrejtés"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Szűrőlisták"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"A hirdetés egy filmben vagy az előtt jelenik meg, vagy más beépülő modulban, mint egy Flash játékban?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Egyéb szűrőlisták"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"Egyeztetendő CSS"
   },
   "disableforchromeandsafaristeptwo":{
     "description":"Step 2 for disabling Chrome and Safari extensions",
     "message":"Törölje a jelölést az összes bővítmény melletti \"Engedélyezve\" jelölőnégyzetből az AdBlock <b>kivételével</b>. <b>Hagyja az AdBlock-ot engedélyezve</b>."
   },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokkold!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Befejezve!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Egy hirdetés blokkolása az oldalon"
-  },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Győződjön meg róla, hogy szűrőlistái naprakészek:"
-  },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Nem szeretném ellenőrizni"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Hirdetések megjelenítése <i>mindenhol</i>, kivéve ezekben a tartományokban..."
   },
-  "lang_english":{
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Legyen óvatos: ha itt hibát vét, sok más szűrő, beleértve a hivatalosakat is, szintén meghibásodhatnak!<br/>Olvassa el a <a>szűrő mondattan oktatóanyagot</a>, hogy megtudja hogyan kell összetett fekete lista és fehér lista szűrőket hozzáadni."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Angol"
+    "message":"Szlovák"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Testreszabás"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Az AdBlock felfüggesztése"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Biztos abban, hogy fel akar iratkozni a(z) $title$ szűrőlistára?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Nyissa meg a bővítmények oldalt az előzetesen letiltott bővítmények engedélyezéséhez."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Oldal tartománya, amelyre alkalmazandó"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Koreai"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Oldal:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Programhibát talált?"
-  },
-  "filtereasylist_plus_arabic":{
-    "description":"language",
-    "message":"Arab"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Cseh"
-  },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Fizess, amennyit akarsz!"
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"vagy az AdBlock-ot Chrome-ra"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Egy hirdetés blokkolása"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Igen"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Abban a böngészőben is megjelenik a hirdetés?"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Kizárás"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Mentés"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Dán"
+    "message":"Román"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"A gomb elrejtéséhez jobb klikkeljen rá, majd válassza a Gomb elrejtése menüpontot. Újból megjelenítheti a chrome://chrome/extensions alatt."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Héber"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Ez az AdBlock szolgáltatás nem működik ezen az oldalon, mert elavult technológiát használ. Az opciók oldal 'Testreszabás' fülén manuálisan fekete- vagy fehér listára teheti az erőforrásokat."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Egyéb"
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Cseh és szlovák"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Letiltottunk minden egyéb kiegészítőt. Most újratöltjük a hirdetést tartalmazó oldalt. Egy másodpercet kérünk."
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Egyéb szűrőlisták"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Opciók"
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Lehet, hogy számítógépe kártevővel fertőzött. További információért kattintson <a>ide</a>."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"A frissítések automatikusan le lesznek töltve; vagy inkább <a>frissítés most</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"adatkeret"
+    "message":"ismeretlen"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Szerkesztés"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Hirdetések megjelenítése egy weboldalon vagy tartományban"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Hirdetések keresése...<br/><br/><i>Csak egy pillanat az egész.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Török"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"A tartomány vagy url, ahol az AdBlock ne blokkoljon semmit"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Frissítések keresése (csak pár másodpercig tarthat)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Minél több szűrőlistát használ, annál lassabban fut az AdBlock. Túl sok lista használata akár a böngésző összeomlásához is vezethet egyes weboldalakon. Nyomja meg az OK gombot, ha mindenképp fel akar iratkozni a listára."
   },
-  "typescript":{
-    "description":"A resource type",
-    "message":"parancsfájl"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"Összesen $count$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Telepítse az AdBlock-ot Firefox alá $chrome$, ha még nem lenne meg.",
     "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Töltse újra a hirdetést tartalmazó oldalt."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Telepítse a Firefox-ot $chrome$, ha még nincs meg.",
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Nincs alapértelmezett szűrőlistánk ahhoz a nyelvhez.<br/>Kérem próbáljon találni egy megfelelő listát, amely támogatja ezt a nyelvet $link$, vagy blokkolja magának ezt a hirdetést az 'Testreszabás' oldalon.",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -761,250 +201,447 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Kattintson a hirdetésre, én pedig végigvezetem Önt a blokkolás menetén."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"stílusmeghatározás"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock frissítések"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nem"
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Tudjon meg többet az Elfogadható hirdetések programról."
   },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Minél több szűrőlistát használ, annál lassabban fut az AdBlock. Túl sok lista használata akár a böngésző összeomlásához is vezethet egyes weboldalakon. Nyomja meg az OK gombot, ha mindenképp fel akar iratkozni a listára."
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sajnáljuk, az AdBlock le van tiltva ezen az oldalon az egyik szűrőlista által."
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"1 napja frissítve"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Nem lett szűrő megadva!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Német"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Görög"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"$seconds$ másodperce frissítve",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Nem biztos benne?</b> Csak nyomja meg lent a 'Blokkold!' gombot."
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"A nem lejátszódó Hulu.com videók megkerülése (a böngésző újraindítását igényli)"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arab"
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Lehetséges hirdetéseket beadó malware keresése:"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Hirdetések blokkolása csak ezeken az oldalakon:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Testreszabás"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Hirdetés bejelentéséhez kapcsolódnia kell az internethez."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Kész is! Újratöltöttük a hirdetést tartalmazó oldalt. Kérjük ellenőrizze, hogy a hirdetés eltűnt-e. Utána jöjjön vissza erre az oldalra és válaszoljon az alábbi kérdésre."
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"A(z) $name$ csatorna fehér listára tétele",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OKÉ, az Opciók oldalon még mindig blokkolhatja magának a hirdetést. Köszönjük!"
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Weboldal egy részének elrejtése"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"adatkeret"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Észt"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"A blokkolt hirdetések számának megjelenítése az AdBlock menüjében"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Egy hirdetés bejelentése"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bolgár"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Ne fusson ezen tartománynak az oldalain"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Egyéni szűrőlisták"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"További hirdetéseket blokkolni:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukrán"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"$minutes$ perce frissítve",
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"A tartomány vagy url, ahol az AdBlock ne blokkoljon semmit"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Ne fusson az AdBlockot..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Az ezt a szöveget tartalmazó URL-ek blokkolása"
+  },
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Ha inkább nem szeretne ehhez hasonló hirdetéseket látni, érdemesebb az Elfogadható hirdetések szűrőlistát kikapcsolva hagyni."
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Bezárás"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Ellenőrzés a Firefox-ban $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "filtereasylist_plus_french":{
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Utolsó lépés: Ez mitől hirdetés?"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Biztos benne, hogy szeretné törölni a(z) $count$ blokkolást, amelyet a(z) $host$ tartományhoz hozott létre?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Ezen kérdésnek célja, hogy meghatározza, ki kapja meg az Ön jelentését. Ha helytelenül válaszolja meg e kérdést, a jelentés rossz embereknek lesz elküldve, így lehet, hogy figyelembe se lesz véve."
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Jól fest"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"AdBlock testreszabása"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Nem található ismert kártevő."
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Engedély megadása az AdBlock-nak, hogy névtelen szűrőlista használatot és adatokat gyűjtsön"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Ne fusson ezen az oldalon"
+  },
+  "filtereasylist_plus_finnish":{
     "description":"language",
-    "message":"Francia"
+    "message":"Finn"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>VAGY</b>, csak kattintson erre a gombra, hogy a fent említetteket mi végezzük el: <a>Minden egyéb bővítmény letiltása</a>"
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Gomb eljrejtése"
   },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"éppen most frissítve"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Mentés"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Figyelmeztetés: Az összes többi oldalon reklámokat fog látni!<br>Ez felülbírálja azokhoz az oldalakhoz a többi szűrőt."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Ezen értesítések letiltása"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Feliratkozás szűrőlistára..."
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Hirdetés blokkoló szűrőlisták"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"$days$ napja frissítve",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"adatkeret"
+    "message":"interaktív objektum"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (személyes adatok védelme)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Ön szerint mi lesz igaz erre a reklámra mindig, amikor meglátogatja ezt az oldalt?"
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Cseh és szlovák"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Blokkolt hirdetések:"
   },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Az AdBlock egy régebbi verzióját használja. Kérem menjen <a href='#'>a bővítmények oldalára</a>, engedélyezze a \"Fejlesztői módot\", majd kattintson a \"Bővítmények frissítése most\" gombra"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock opciók"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Lehetséges hirdetéseket beadó malware keresése:"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"A lista törlése"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antiszociális szűrőlista (eltávolítja a közösségi média gombokat)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Hibakeresési kijelentések megjelenítése a Konzolnaplóban (ami lelassítja az AdBlock-ot)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Túllépte a Dropbox méretkorlátot. Kérjük töröljön néhány bejegyzést egyéni vagy letiltott szűrő közül, majd próbálja újra."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Az AdBlock felfüggesztésének feloldása"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Kész is! Újratöltöttük a hirdetést tartalmazó oldalt. Kérjük ellenőrizze, hogy a hirdetés eltűnt-e. Utána jöjjön vissza erre az oldalra és válaszoljon az alábbi kérdésre."
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Német"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Legyen óvatos: ez a szűrő minden $elementtype$ elemet blokkol az oldalon!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"ide"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"A nem lejátszódó Hulu.com videók megkerülése (a böngésző újraindítását igényli)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Kizárás"
-  },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Az AdBlock kivételével tiltson le minden kiegészítőt:"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Milyen nyelven van írva az az oldal?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Biztos benne, hogy szeretné törölni a(z) $count$ blokkolást, amelyet a(z) $host$ tartományhoz hozott létre?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"kép"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"A fordításért járó elismerést illeti:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"BETÖLTÉS..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Jobb klikkeljen egy reklámra egy oldalon annak blokkolásához -- vagy blokkolja itt manuálisan."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"A gomb elrejtéséhez jobb klikkeljen rá, majd válassza a Gomb elrejtése menüpontot. Újból megjelenítheti a chrome://chrome/extensions alatt."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Román"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Letiltott szűrők szerkesztése:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Elfogadható hirdetések (ajánlott)"
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Valami elromlott a frissítések keresése közben."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Az Elfogadható hirdetések szűrőinek ellenőrzése:"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"A gomb elrejtéséhez kattintson jobb gombbal a Safari eszköztárára, majd válassza az Eszköztár testreszabása menüpontot, aztán húzza le az AdBlock gombját az eszköztárról. Az eszköztárra való visszahúzásával újra megjelenítheti."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Letiltottunk minden egyéb kiegészítőt. Most újratöltjük a hirdetést tartalmazó oldalt. Egy másodpercet kérünk."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"1 perce frissítve"
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"oldal"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Koreai"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Tudassa velünk <a>ügyfélszolgálatunk oldalán</a>!"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Blokkolásaim visszavonása ebben a tartományban"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Szűrők manuális szerkesztése:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Linkek megjelenítése a szűrőlistáknak"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (ajánlott)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"1. lépés: Kitalálni mi legyen blokkolva"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Van egy <a>oldalunk</a>, amely az AdBlock mögött álló embereket is segít kiismerni!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Webhely:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"ide"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"előugró ablak"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"Az AdBlock naprakész!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Az oldal újratöltése."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Csak angolul"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Az AdBlock egy régebbi verzióját használja. Kérem menjen <a href='#'>a bővítmények oldalára</a>, engedélyezze a \"Fejlesztői módot\", majd kattintson a \"Bővítmények frissítése most\" gombra"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"Az AdBlock fel van föggesztve."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>VAGY</b>, csak kattintson erre a gombra, hogy a fent említetteket mi végezzük el: <a>Minden egyéb bővítmény letiltása</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Mi új van a legújabb kiadásban? Nézze meg a <a style='cursor:pointer;'>változásnaplót</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antiszociális szűrőlista (eltávolítja a közösségi média gombokat)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Hirdetések keresése...<br/><br/><i>Csak egy pillanat az egész.</i>"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"Az AdBlock nem fut az alábbiakkal megegyező oldalakon:"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Abban a böngészőben iratkozzon fel ugyanazon szűrőlistákra, amelyekre itt is fel van."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Egy hirdetés blokkolása"
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Túllépte a Dropbox méretkorlátot. Kérjük töröljön néhány bejegyzést egyéni vagy letiltott szűrő közül, majd próbálja újra."
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Vagy írjon be egy URL-t:"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Figyelmeztetés: Az összes többi oldalon reklámokat fog látni!<br>Ez felülbírálja azokhoz az oldalakhoz a többi szűrőt."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Van egy frissítés az AdBlock-hoz! Irány $here$ a frissítéshez. <br> Megjegyzés: Ha automatikusan szeretné kapni a frissítéseket, csak kattintson a Safari > Környezeti beállítások > Bővítmények > Frissítések menüpontra <br> és jelölje be a \"Frissítések automatikus telepítése\" opciót.",
     "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"A következő szűrő:<br/> $filter$ <br/> hibát jelez: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Olasz"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Szeretné látni mitől ketyeg az AdBlock?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock egyéni szűrők (ajánlott)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Típus"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Mi ez?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1016,319 +653,91 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Vagy írjon be egy URL-t:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"vagy az AdBlock-ot Chrome-ra"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"A Safari egy régebbi verzióját használja. Szerezze be a legújabbat az AdBlock eszköztár gomb használata érdekében, az AdBlock, a fehér listás eboldalak és a hirdetés jelentések szüneteltetésére, <a>Frissítsen most</a>."
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Feliratkozás szűrőlistákra"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Nyelv kiválasztása -- "
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"A fordításért járó elismerést illeti:"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Kattintson a Safari menüben &rarr; a Környezeti beállítások &rarr; Bővítmények menüpontjára."
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formátum: ~webhely1.hu|~webhely2.hu|~hírek.webhely3.org"
   },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Telepítse az AdBlock-ot Firefox alá $chrome$, ha még nem lenne meg.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Abbahagyni a hirdetések blokkolását:"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"A legnépszerűbb Chrome kiegészítő, több mint 40 millió felhasználóval! Reklámokat blokkol szerte a weben."
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Továbbra is megjelenik a hirdetés?"
-  },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Támogatás"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bolgár"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Szeretné látni mitől ketyeg az AdBlock?"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videók és Flash"
   },
   "reenableadsonebyone":{
     "description":"Tells the user to reenable the extensions one by one",
     "message":"Remek! Most pedig keresse meg melyik kiegészítő a kiváltója ennek. Menjen végig és engedélyezze a kiegészítőket egyesével. Az a kiegészítő, amelyik visszahozza a hirdetés(eke)t az, amelyiket el kell távolítani."
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Sikertelen!"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"A szűrőlisták blokkolják a legtöbb reklámot a weben. Továbbá lehet még:"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"A szűrő, amely az Opciók oldalon módosítható:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"A gomb elrejtéséhez kattintson jobb gombbal a Safari eszköztárára, majd válassza az Eszköztár testreszabása menüpontot, aztán húzza le az AdBlock gombját az eszköztárról. Az eszköztárra való visszahúzásával újra megjelenítheti."
   },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Szűrők manuális szerkesztése:"
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Remek! Minden kész."
   },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"A következő szűrő:<br/> $filter$ <br/> hibát jelez: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"előugró ablak"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Csúsztassa addig a csúszkát, amíg a reklám megfelelően nincs blokkolva az oldalon, és a blokkolt elem hasznosan néz ki."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Típus"
-  },
-  "lang_slovak":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Szlovák"
+    "message":"Magyar"
   },
   "orchrome":{
     "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
     "message":"vagy a Chrome-ot"
   },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Abban a böngészőben is megjelenik a hirdetés?"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Feliratkozás"
   },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Ne fusson ezen az oldalon"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Fizess, amennyit akarsz!"
   },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Litván"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Hirdetések blokkolása csak ezeken az oldalakon:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Tudassa velünk <a>ügyfélszolgálatunk oldalán</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"Az AdBlock fel van föggesztve."
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Túllépte az AdBlock által használható tárterületet. Kérem iratkozzon le néhány szűrőlistáról!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Még nem tudunk hirdetéseket blokkolni Flash-ben és más beépülőkben. Várjuk a támogatást a böngészőtől és a WebKit-től."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Reklámot talált az egyik oldalon? Mi segítünk megtalálni a jelentéshez megfelő helyet!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OKÉ, az Opciók oldalon még mindig blokkolhatja magának a hirdetést. Köszönjük!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Általános"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Ha inkább nem szeretne ehhez hasonló hirdetéseket látni, érdemesebb az Elfogadható hirdetések szűrőlistát kikapcsolva hagyni."
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"egyéb"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Beküldés"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Nem lett szűrő megadva!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"ismeretlen"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finn"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"Az AdBlock le van tiltva ezen az oldalon."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"hang/videó"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japán"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Néhány nem tolakodó hirdetés engedélyezése"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Letiltott szűrők szerkesztése:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Ez egy szűrőlista probléma. Jelentse itt: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Ne fusson ezen tartománynak az oldalain"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blokkolt elem:"
   },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Nem sikerült lekérni ezt a szűrőt!"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Megjegyzés: bejelentése nyilvánosan elérhetővé válhat. Ezt tartsa szem előtt, mielőtt bármi bizalmasat foglalna bele."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Linkek megjelenítése a szűrőlistáknak"
-  },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Csak angolul"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Mégse"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Segítsen terjeszteni az igét!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Alul a csúsztatással módosíthatja, hogy pontosan mely oldalakon ne fusson az AdBlock."
-  },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"Az AdBlock egy olyan oldalról származó letöltést blokkolt, amely közismerten malware-t tartalmaz."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Ellenőrzés a Firefox-ban $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"ClickToFlash kompatibilitási üzemmód engedélyezése"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Iratkozzon fel a következő szűrőlistára, majd próbálja újra: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Hirdetés bejelentéséhez kapcsolódnia kell az internethez."
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Kérdése vagy új ötlete van?"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Érvénytelen lista URL. Törlődni fog."
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"1. lépés: Kitalálni mi legyen blokkolva"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Igen"
-  },
-  "filteritalian":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Olasz"
+    "message":"Litván"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Jól fest"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (ajánlott)"
+  "typepage":{
+    "description":"A resource type",
+    "message":"oldal"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1338,5 +747,636 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Továbbra is megjelenik a hirdetés?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"egyéb"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Kattintson erre: <a>Frissítse a szűrőimet!</a>"
+  },
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Győződjön meg róla, hogy a megfelelő nyelvi szűrő(ke)t használja:"
+  },
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Győződjön meg róla, hogy szűrőlistái naprakészek:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"A gomb elrejtéséhez menjen az opera://extensions oldalra, majd jelölje be az \"Elrejtés az eszköztárról\" opciót. Újból megjelenítheti az opció előtti jelölés törlésével."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Valami elromlott a frissítések keresése közben."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Kattintson a Safari menüben &rarr; a Környezeti beállítások &rarr; Bővítmények menüpontjára."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Beküldés"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Oldal:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Töltse újra a hirdetést tartalmazó oldalt."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Leiratkozva."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"hang/videó"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Lett"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Egy hirdetés blokkolása az oldalon"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokkold!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Abbahagyni a hirdetések blokkolását:"
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Kattintson ide: <a>Elfogadható hirdetések letiltása</a>"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Adott YouTube csatornák fehér listára tételének engedélyezése"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Milyen nyelven van írva az az oldal?"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Eltávolítás a listáról"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Még nem tudunk hirdetéseket blokkolni Flash-ben és más beépülőkben. Várjuk a támogatást a böngészőtől és a WebKit-től."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Alul a csúsztatással módosíthatja, hogy pontosan mely oldalakon ne fusson az AdBlock."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"elrejtés"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"Az AdBlock le van tiltva ezen az oldalon."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"A hirdetés egy filmben vagy az előtt jelenik meg, vagy más beépülő modulban, mint egy Flash játékban?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Orosz és ukrán"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spanyol"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokkolja ezt a hirdetést"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Legyen óvatos: ez a szűrő minden $elementtype$ elemet blokkol az oldalon!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"ClickToFlash kompatibilitási üzemmód engedélyezése"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nem"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"AdBlock engedélyezése ezen az oldalon"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"A szűrő, amely az Opciók oldalon módosítható:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"A blokkolt hirdetések számának megjelenítése az AdBlock gombján"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Sikertelen!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Az AdBlock felfüggesztése"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Iratkozzon fel a következő szűrőlistára, majd próbálja újra: $list_title$",
+    "placeholders":{
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Angol"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Elemek hozzáadása a jobb klikk menühöz"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Reklámot talált az egyik oldalon? Mi segítünk megtalálni a jelentéshez megfelő helyet!"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Az AdBlock kivételével tiltson le minden kiegészítőt:"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Orosz"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Ha hirdetést lát, ne hibajelentést tegyen, hanem <a>hirdetés jelentést</a>!"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"A Safari egy régebbi verzióját használja. Szerezze be a legújabbat az AdBlock eszköztár gomb használata érdekében, az AdBlock, a fehér listás eboldalak és a hirdetés jelentések szüneteltetésére, <a>Frissítsen most</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (személyes adatok védelme)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"A(z) $attribute$ $value$ lesz",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Jobb klikkeljen egy reklámra egy oldalon annak blokkolásához -- vagy blokkolja itt manuálisan."
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Befejezve!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Az AdBlock felfüggesztésének feloldása"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Szűrők hozzáadása másik nyelvhez: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"BETÖLTÉS..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Csapatunk netán némi hibakeresési információt kérelmezett? Ehhez kattintson <a href='#' id='debug'>ide</a>!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Kártevő védelem"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Hirdetés bejelentése ezen az oldalon"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Hibakeresési kijelentések megjelenítése a Konzolnaplóban (ami lelassítja az AdBlock-ot)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Telepítse a Firefox-ot $chrome$, ha még nincs meg.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Csúsztassa addig a csúszkát, amíg a reklám megfelelően nincs blokkolva az oldalon, és a blokkolt elem hasznosan néz ki."
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Túllépte az AdBlock által használható tárterületet. Kérem iratkozzon le néhány szűrőlistáról!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"A legnépszerűbb Chrome kiegészítő, több mint 40 millió felhasználóval! Reklámokat blokkol szerte a weben."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Programhibát talált?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Tudjon meg többet a kártevőkröl"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"parancsfájl"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Szűrőlisták"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Haladó felhasználó vagyok, jelenjenek meg a haladó opciók"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Kínai"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"A szűrő érvénytelen: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Feliratkozás szűrőlistára..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Nyissa meg a bővítmények oldalt az előzetesen letiltott bővítmények engedélyezéséhez."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Ezen értesítések letiltása"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Ez $matchcount$ elemmel egyezik az oldalon.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"1 órája frissítve"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Nyelv kiválasztása -- "
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Értesítsen az AdBlock, ha kártevőt észlel?"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonéz"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"kép"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Szerkesztés"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Nem sikerült lekérni ezt a szűrőt!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"Összesen $count$",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Támogatás"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Egy hirdetés blokkolása annak URL-je alapján"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Mégse"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Ne felejtsen el menteni!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Töltse be az oldalt a hirdetéssel abban a böngészőben."
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Elfogadható hirdetések (ajánlott)"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Verzió: $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Izlandi"
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"A hirdetések jelentése önkéntes alapú. Úgy segít másoknak, hogy lehetővé teszi a szűrőlista karbantartóknak a hirdetés blokkolását mindekni rászáre. Ha épp nincs önzetlen hangulatban, semmi gond. Zárja be ezt az oldalt, és <a>blokkolja a hirdetést</a> csak magának."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Biztos abban, hogy fel akar iratkozni a(z) $title$ szűrőlistára?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"A forráskód <a>szabadon elérhető</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holland"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Kérem gépelje be lent a helyes szűrőt, majd nyomja meg az OK gombot"
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Az előzetesen letiltott bővítmények újraengedélyezésre kerültek."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Ez <b>1</b> elemmel egyezik az oldalon."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japán"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"A lista törlése"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"$hours$ órája frissítve",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Vissza"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock opciók"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Béta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"Az AdBlock egy olyan oldalról származó letöltést blokkolt, amely közismerten malware-t tartalmaz."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Ne iratkozzon fel a szükségesnél többre -- mindegyik lelassítja egy aprócskát! A stáblista és még több lista <a>itt</a> találhatók."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Frissítések keresése (csak pár másodpercig tarthat)..."
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Oldal tartománya, amelyre alkalmazandó"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"éppen most frissítve"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"$minutes$ perce frissítve",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Cseh"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Néhány nem tolakodó hirdetés engedélyezése"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Svéd"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock ügyfélszolgálat"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Típus"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francia"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"1 perce frissítve"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"adatkeret"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - kattintson a részletekért"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Figyelmeztetés: nem lett szűrő megadva!"
   }
 }

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -1,759 +1,199 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Laporkan sebuah iklan"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Daftar filter pemblokiran iklan"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Klik ini: <a>Nonaktifkan Iklan Yang Dapat Diterima</a>"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Situs:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Izinkan daftar putih pada saluran Youtube tertentu"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Tidak ada malware yang diketahui ditemukan."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Di peramban itu, berlangganan ke daftar filter yang sama seperti yang Anda miliki di sini."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - Klik untuk melihat detilnya"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Pada browser tersebut, muatlah halaman yang ada iklannya."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Swedia"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Apa baru dalam rilis terbaru? Lihat <a style='cursor:pointer;'>changelog</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blokir lebih banyak iklan:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Rusia"
+    "message":"Denmark"
   },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Ekstensi yang telah dinonaktifkan sebelumnya telah diaktifkan kembali."
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Cek filter iklan yang dapat diterima:"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Tidak berlangganan."
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Bantu Sebarkan!"
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Bahasa Islandia"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Bahasa Yunani"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"China"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Spanyol"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Perlindungan Malware"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Apa yang anda pikir benar tentang iklan ini setiap anda mengunjungi halaman ini?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Mengaktifkan AdBlock pada Halaman ini"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Kembali"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Tampilkan jumlah iklan yang diblokir di tombol AdBlock"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Langkah terakhir: Apa yang membuat hal ini sebagai iklan?"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Punya pertanyaan atau ide baru?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Latvia"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Daftar filter memblokir banyak iklan di web. Anda juga bisa:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Kode sumber tersedia <a>secara gratis</a>!"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Ketahui lebih lanjut mengenai program iklan yang dapat diterima."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Perlihatkan iklan pada sebuah halama atau domain"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"<b>1</b> item yang sama pada halaman ini."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Sembunyikan sebagian dari halaman Web"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Daftar putih saluran $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Pengaturan Umum"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Komputer Anda mungkin terinfeksi oleh malware. Klik <a>di sini</a> untuk informasi lebih lanjut."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock tidak akan berjalan pada halaman yang sama dengan:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Kami tidak memiliki filter baku untuk bahasa tersebut.<br/>Silahkan mencari daftar yang cocok yang mendukung bahasa ini $link$ atau or blokir iklan ini untuk anda sendiri pada tab 'Penyesuaian'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Berlangganan"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Saya pengguna tingkat lanjut, perlihatkan pilihan tingkat lanjut"
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blok sebuah iklan oleh URLnya"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Sembunyikan tombol ini"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Saya akan mengambil pembaharuan secara otomatis; Anda juga dapat melakukan <a>pembaharuan sekarang</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Klik ini: <a>Perbaharui filter saya!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Bahasa Estonia"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"$matchcount$ item yang sama pada halaman ini.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Kami mempunyai sebuah <a>laman</a> untuk membantu Anda menemukan orang-orang di belakang AdBlock juga!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesia"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tipe"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Ada pembaruan untuk AdBlock! Pergi $here$ untuk update. <br>Catatan: jika Anda ingin menerima update secara otomatis, klik pada Safari > preferensi > ekstensi > update <br>dan centang pilihan 'Memasang pembaruan secara otomatis'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turki"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Apa ini?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Daftar Filter sendiri"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Jangan berangganan lebih dari yang anda butuhkan -- setiap satunya akan sedikit memperlambat anda! Kredit dan lebih banyak daftar dapat ditemukan <a>Disini</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definisi style"
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Dihapus dari daftar"
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Tujuan dari pertanyaan ini adalah untuk menentukan siapa yang harus menerima laporan anda. Jika anda menjawab pertanyaan dengan salah, laporannya akan terkirim kepada orang yang salah, jadi mungkin laporan anda akan diabaikan."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polandia"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Tambahkan barang ke menu klik kanan"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video dan Flash"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokir iklan ini"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"diperbaharui $hours$ jam lalu",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"diperbaharui $seconds$ detik yang lalu",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Tim kami meminta beberapa informasi debug? Klik <a href='#' id='debug'> di sini</a> untuk itu!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"objek interaktif"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Hungaria"
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Melaporkan iklan bersifat sukarela. Hal ini membantu orang lain dengan mengaktifkan pengelola daftar filter untuk memblokir iklan untuk semua orang. Jika Anda tidak merasa altruistik sekarang ini, tidak apa-apa. Tutup halaman ini dan <a>blok iklan</a> hanya untuk diri sendiri."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Catatan: laporan anda mungkin akan tersedia untuk umum. Ingatlah itu sebelum anda menyertakan apapun yang bersifat pribadi."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Muat ulang laman."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"halaman"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Belanda"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Jangan lupa untuk menyimpan!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ adalah $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Tutup"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Elemen terblokir:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filter ini tidak sah: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Perhatian: tidak ada filter yang ditentukan!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Ijinkan AdBlock untuk mengumpulkan data dan penggunaan daftar filter secara anonim"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Haruskah AdBlock memberitahu Anda ketika mendeteksi malware?"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Jika Anda melihat iklan, jangan membuat laporan bug, melainkan buatlah <a>laporan iklan</a>!"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Perlihatkan iklan <i>dimanapun</i> kecuali pada domain-domain ini..."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Fitur AdBlock ini tidak bekerja di situs ini karena menggunakan teknologi usang. Anda bisa memasukkannya ke sumber blacklist atau whitelist secara manual di tab 'Customize' halaman pengaturan."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Tampilkan jumlah iklan yang diblokir di menu AdBlock"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Pilihan"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Jangan jalankan AdBlock pada..."
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Iklan yang terblokir:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"filter AdBlock yang diinginkan (dianjurkan)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Tambahkan filter untuk bahasa lain: "
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (hapus gangguan di web)"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Pastikan Anda menggunakan filter bahasa yang tepat:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS untuk dicari"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Untuk menyembunyikan tombol, pergi ke opera://extensions dan centang opsi 'Hide from toolbar'. Anda dapat menampilkannya lagi dengan tidak mencentang opsi tersebut."
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Klik iklannya, dan saya akan menuntun anda memblokirnya."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Laporkan sebuah iklan pada halaman ini"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Hebat! Anda sudah siap."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Rusia dan Ukraina"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Mengambil... Silahkan tunggu."
   },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Hati hati: jika anda membuat kesalahan disini banyak filter, termasuk filter resmi juga akan rusak!<br/>Baca <a>Panduan filter syntax</a> untuk belajar bagaimana menambah filter daftar hitam dan daftar putih yang lebih maju."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Umum"
   },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Dukungan AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Sesuaikan AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock sudah veri tebaru!"
-  },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Pelajari lebih lanjut tentang malware"
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Ibrani"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Maaf, AdBlock dimatikan pada halaman ini oleh salah satu daftar filter anda."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blok URL yang mengandung teks ini"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Batalkan blok saya pada domain ini"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Silahkan ketik filter yang benar di bawah ini dan tekan OK"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"diperbaharui 1 hari lalu"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (hapus gangguan di web)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ di halaman ini",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Tidak yakin?</b> tekan saja 'Tutup!' dibawah."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Daftar URL yang tidak sah. Daftar ini akan dihapus."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"diperbaharui 1 jam lalu"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Polandia"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versi $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Pengaturan Umum"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Berlangganan pada daftar filter"
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Yang lain"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"sembunyikan"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Daftar Filter"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Apakah iklannya muncul didalam atau sebelum film atau plugin lainnya seperti game Flash?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Daftar filter lainnya"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS untuk dicari"
   },
   "disableforchromeandsafaristeptwo":{
     "description":"Step 2 for disabling Chrome and Safari extensions",
     "message":"Hilangkan centang 'Enabled' dipinggir setiap ekstensi <b>kecuali</b> untuk AdBlock. <b>Biarkan AdBlock berjalan</b>."
   },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Tutup!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Selesai!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blok sebuah iklan pada halaman ini"
-  },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Pastikan daftar filter Anda telah diperbaharui:"
-  },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Saya tidak ingin memeriksa hal ini"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Perlihatkan iklan <i>dimanapun</i> kecuali pada domain-domain ini..."
   },
-  "lang_english":{
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Hati hati: jika anda membuat kesalahan disini banyak filter, termasuk filter resmi juga akan rusak!<br/>Baca <a>Panduan filter syntax</a> untuk belajar bagaimana menambah filter daftar hitam dan daftar putih yang lebih maju."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Inggris"
+    "message":"Bahasa Slowakia"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Penyesuaian"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Bekukan AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Apakah Anda yakin bahwa Anda ingin berlangganan ke daftar filter $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Buka laman ekstensi untuk mngaktifkan ekstensi yang telah dinonaktifkan sebelumnya."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domain dari halaman untuk diterapkan"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Korea"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Halaman:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Menemukan bug?"
-  },
-  "filtereasylist_plus_arabic":{
-    "description":"language",
-    "message":"Bahasa Arab"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Ceko"
-  },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Membayar apa yang Anda inginkan!"
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"atau AdBlock untukChrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokir sebuah iklan"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Ya"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Apakah iklannya muncul juga pada browser itu?"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Jangan sertakan"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Simpan"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Denmark"
+    "message":"Romania"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Untuk menyembunyikan tombolnya, klik kanan dan pilih Sembunyikan tombol. Anda dapat memunculkannya lagi di chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Ibrani"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Fitur AdBlock ini tidak bekerja di situs ini karena menggunakan teknologi usang. Anda bisa memasukkannya ke sumber blacklist atau whitelist secara manual di tab 'Customize' halaman pengaturan."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Yang lain"
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Ceko dan Slowakia"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Kami telah dinonaktifkan semua ekstensi lainnya. Sekarang kita akan memuat ulang halaman dengan iklan. Harap tunggu sebentar."
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Daftar filter lainnya"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Pilihan"
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Komputer Anda mungkin terinfeksi oleh malware. Klik <a>di sini</a> untuk informasi lebih lanjut."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Saya akan mengambil pembaharuan secara otomatis; Anda juga dapat melakukan <a>pembaharuan sekarang</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"tidak diketahui"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Edit"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Perlihatkan iklan pada sebuah halama atau domain"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Mencari iklan...<br/><br/><i>hanya sebentar saja.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turki"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domain atau URL dimana AdBlock tidak boleh memblokir apapun"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Memeriksa pembaruan (hanya memerlukan beberapa detik)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Semakin banyak daftar filter yang anda gunakan, semakinlambat AdBlock bekerja. Menggunakan terlalu banyak daftar bahkan dapat membuat browser anda berhenti bekerja pada beberapa situs. Tekan OK untuk tetap berlangganan pada daftar ini."
   },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skrip"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"Total $count$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Pasang AdBlock Plus untuk Firefox $chrome$ jika Anda tidak memilikinya.",
     "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Muat ulang halaman yang ada iklannya."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Pasang Firefox $chrome$ jika anda tidak memilikinya.",
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Kami tidak memiliki filter baku untuk bahasa tersebut.<br/>Silahkan mencari daftar yang cocok yang mendukung bahasa ini $link$ atau or blokir iklan ini untuk anda sendiri pada tab 'Penyesuaian'.",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -761,250 +201,447 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Klik iklannya, dan saya akan menuntun anda memblokirnya."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"definisi style"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Perbarui AdBlock"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Tidak"
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Ketahui lebih lanjut mengenai program iklan yang dapat diterima."
   },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Semakin banyak daftar filter yang anda gunakan, semakinlambat AdBlock bekerja. Menggunakan terlalu banyak daftar bahkan dapat membuat browser anda berhenti bekerja pada beberapa situs. Tekan OK untuk tetap berlangganan pada daftar ini."
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Maaf, AdBlock dimatikan pada halaman ini oleh salah satu daftar filter anda."
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"diperbaharui 1 hari lalu"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Tidak ada filter yang ditentukan!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Jerman"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Bahasa Yunani"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"diperbaharui $seconds$ detik yang lalu",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Tidak yakin?</b> tekan saja 'Tutup!' dibawah."
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Membetulkan video Hulu.com yang tidak bisa dimainkan (harus muat ulang browser anda)"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Bahasa Arab"
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Cek perangkat lunak jahat yang dapat menyuntikkan iklan:"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Hanya blokir iklan di situs-situs ini:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Penyesuaian"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Untuk melaporkan iklan, Anda harus terhubung ke internet."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Selesai! Kami memuat ulang halaman dengan iklan. Silakan periksa halaman tersebut untuk melihat apakah iklan hilang. Kemudian kembali ke halaman ini dan menjawab pertanyaan di bawah ini."
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Daftar putih saluran $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, anda tetap bisa memblokir iklan ini untuk anda sendiri pada halaman pengaturan, Terima kasih!"
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Sembunyikan sebagian dari halaman Web"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Bahasa Estonia"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Tampilkan jumlah iklan yang diblokir di menu AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Laporkan sebuah iklan"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgaria"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Jangan jalankan pada halaman-halaman di domain ini"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Daftar Filter sendiri"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blokir lebih banyak iklan:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukrania"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"diperbaharui $minutes$ menit lalu",
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domain atau URL dimana AdBlock tidak boleh memblokir apapun"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Jangan jalankan AdBlock pada..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blok URL yang mengandung teks ini"
+  },
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Jika Anda lebih tidak suka melihat iklan seperti ini, Anda dapat mematikan daftar filter iklan yang dapat diterima."
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Tutup"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Periksa di Firefox $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "filtereasylist_plus_french":{
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Langkah terakhir: Apa yang membuat hal ini sebagai iklan?"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Apakah Anda yakin ingin menghapus blok $count$ yang telah Anda buat pada $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Tujuan dari pertanyaan ini adalah untuk menentukan siapa yang harus menerima laporan anda. Jika anda menjawab pertanyaan dengan salah, laporannya akan terkirim kepada orang yang salah, jadi mungkin laporan anda akan diabaikan."
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Terlihat bagus"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Sesuaikan AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Tidak ada malware yang diketahui ditemukan."
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Ijinkan AdBlock untuk mengumpulkan data dan penggunaan daftar filter secara anonim"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Jangan jalankan pada halama ini"
+  },
+  "filtereasylist_plus_finnish":{
     "description":"language",
-    "message":"Prancis"
+    "message":"Finlandia"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ATAU</b>, cukup klik tombol ini untuk kita untuk melakukan semua hal di atas: <a>Nonaktifkan semua ekstensi lainnya</a>"
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Sembunyikan tombol ini"
   },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"diperbaharui sekarang"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Simpan"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Peringatan: pada semua situs lain anda akan melihat iklan!<br>Hal ini mengesampingkan semua filter lain untuk situs-situs tersebut."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Nonaktifkan pemberitahuan ini"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Berlangganan daftar filter..."
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Daftar filter pemblokiran iklan"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"diperbaharui $days$ hari lalu",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"objek interaktif"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (perlindungan privasi)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Apa yang anda pikir benar tentang iklan ini setiap anda mengunjungi halaman ini?"
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Ceko dan Slowakia"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Iklan yang terblokir:"
   },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Anda menggunakan AdBlock versi lama. Silahkan kunjungi <a href='#'>halaman ekstensi</a>, nyalakan 'Mode pengembang' dan klik 'Perbaharui ektensi sekarang'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Pengaturan AdBlock"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Cek perangkat lunak jahat yang dapat menyuntikkan iklan:"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Bersihkan daftar ini"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Daftar Antisocial filter (hapus tombol social media)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Perlihatkan pernyataan debug pada Console Log (akan memperlambat AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Anda telah melebihi batas ukuran Dropbox. Harap menghapus beberapa entri dari filter buatan Anda atau yang nonaktif, dan coba lagi."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Lanjutkan AdBlock"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Selesai! Kami memuat ulang halaman dengan iklan. Silakan periksa halaman tersebut untuk melihat apakah iklan hilang. Kemudian kembali ke halaman ini dan menjawab pertanyaan di bawah ini."
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Jerman"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Hati hati: Filter ini memblokir semua $elementtype$ elemen yang ada di halaman!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"disini"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Membetulkan video Hulu.com yang tidak bisa dimainkan (harus muat ulang browser anda)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Jangan sertakan"
-  },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Nonaktifkan semua ekstensi kecuali AdBlock:"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Ditulis dalam bahasa apa halaman itu?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Apakah Anda yakin ingin menghapus blok $count$ yang telah Anda buat pada $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"gambar"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Diterjemahkan oleh:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"MEMUAT..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Klik kanan sebuah iklan pada halaman untuk memblokirnya -- atau blokir secara manual disini."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Untuk menyembunyikan tombolnya, klik kanan dan pilih Sembunyikan tombol. Anda dapat memunculkannya lagi di chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Romania"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Edit filter nonaktif:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Iklan yang dapat diterima (disarankan)"
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Terjadi kesalahan saat memeriksa pembaruan."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Cek filter iklan yang dapat diterima:"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Untuk menyembunyikan tombol, klik kanan toolbar Safari dan pilih Customize Toolbar, kemudian tarik tombol AdBlock dari toolbar. Anda dapat menampilkannya lagi dengan menariknya kembali ke toolbar."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Kami telah dinonaktifkan semua ekstensi lainnya. Sekarang kita akan memuat ulang halaman dengan iklan. Harap tunggu sebentar."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"diperbaharui 1 menit lalu"
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"halaman"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Korea"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Beritahukan kami di <a>situs dukungan</a> ini!"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Batalkan blok saya pada domain ini"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Edit secara Manual filter anda:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Tunjukkan alamat ke daftar filter"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (dianjurkan)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Langkah 1: Tentukan apa yang akan diblokir"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Kami mempunyai sebuah <a>laman</a> untuk membantu Anda menemukan orang-orang di belakang AdBlock juga!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Situs:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"disini"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock sudah veri tebaru!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Muat ulang laman."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Hanya Inggris"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Anda menggunakan AdBlock versi lama. Silahkan kunjungi <a href='#'>halaman ekstensi</a>, nyalakan 'Mode pengembang' dan klik 'Perbaharui ektensi sekarang'"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock sedang dibekukan."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ATAU</b>, cukup klik tombol ini untuk kita untuk melakukan semua hal di atas: <a>Nonaktifkan semua ekstensi lainnya</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Apa baru dalam rilis terbaru? Lihat <a style='cursor:pointer;'>changelog</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Daftar Antisocial filter (hapus tombol social media)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Mencari iklan...<br/><br/><i>hanya sebentar saja.</i>"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock tidak akan berjalan pada halaman yang sama dengan:"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Di peramban itu, berlangganan ke daftar filter yang sama seperti yang Anda miliki di sini."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokir sebuah iklan"
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Anda telah melebihi batas ukuran Dropbox. Harap menghapus beberapa entri dari filter buatan Anda atau yang nonaktif, dan coba lagi."
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Atau masukan sebuah URL:"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Peringatan: pada semua situs lain anda akan melihat iklan!<br>Hal ini mengesampingkan semua filter lain untuk situs-situs tersebut."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Ada pembaruan untuk AdBlock! Pergi $here$ untuk update. <br>Catatan: jika Anda ingin menerima update secara otomatis, klik pada Safari > preferensi > ekstensi > update <br>dan centang pilihan 'Memasang pembaruan secara otomatis'.",
     "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Filter berikut: <br/> $filter$ <br/> memiliki kesalahan: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Italia"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Ingin melihat bagaimana AdBlock bekerja?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"filter AdBlock yang diinginkan (dianjurkan)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tipe"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Apa ini?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1016,319 +653,91 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Atau masukan sebuah URL:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"atau AdBlock untukChrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Anda menggunakan Safari versi lama. Ambillah versi terbaru untuk menggunakan tombol toolbar AdBlock untuk menjeda AdBlock, membebaskan situs web, dan melaporkan iklan. <a>Perbaharui sekarang</a>"
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Berlangganan pada daftar filter"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" --Pilih bahasa-- "
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Diterjemahkan oleh:"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Klik pada menu Safari &rarr; Preferences &rarr; Extension."
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~site1.com|~site2.com|~news.site3.org"
   },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Pasang AdBlock Plus untuk Firefox $chrome$ jika Anda tidak memilikinya.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Berhenti memblokir iklan:"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Ekstensi Chrome paling populer, dengan lebih dari 40 juta pengguna! Blokir iklan di seluruh web."
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Apa iklannya masih muncul?"
-  },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Dukungan"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bulgaria"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Ingin melihat bagaimana AdBlock bekerja?"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video dan Flash"
   },
   "reenableadsonebyone":{
     "description":"Tells the user to reenable the extensions one by one",
     "message":"Hebat! Sekarang mari kita menemukan ekstensi yang adalah penyebab. Pergi dan aktifkan ekstensi setiap satu per satu. Ekstensi yang membawa kembali iklan adalah yang Anda butuhkan untuk dihapus untuk menyingkirkan iklan."
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Gagal!"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Daftar filter memblokir banyak iklan di web. Anda juga bisa:"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filter, yang bisa diubah di halaman pengaturan:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Untuk menyembunyikan tombol, klik kanan toolbar Safari dan pilih Customize Toolbar, kemudian tarik tombol AdBlock dari toolbar. Anda dapat menampilkannya lagi dengan menariknya kembali ke toolbar."
   },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Edit secara Manual filter anda:"
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Hebat! Anda sudah siap."
   },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Filter berikut: <br/> $filter$ <br/> memiliki kesalahan: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Geser pengatur hingga iklan terblokir dengan benar pada halaman, dan elemen yang terblokir tidak terlihat."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tipe"
-  },
-  "lang_slovak":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Bahasa Slowakia"
+    "message":"Hungaria"
   },
   "orchrome":{
     "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
     "message":"atau Chrome"
   },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Apakah iklannya muncul juga pada browser itu?"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Berlangganan"
   },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Jangan jalankan pada halama ini"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Membayar apa yang Anda inginkan!"
   },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Bahasa Lithuania"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Hanya blokir iklan di situs-situs ini:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Beritahukan kami di <a>situs dukungan</a> ini!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock sedang dibekukan."
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Anda melebihi jumlah penyimpanan yang bisa dipakai oleh AdBlock. Batalkanlah langganan anda dari beberapa daftar filter!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Kami belum bisa memblokir iklan iklan didalam Flash dan plugin lainnya. Kami menunggu dukungan dari browser dan WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Menemukan sebuah iklan pada halaman web? Kami akan membantu Anda menemukan tempat yang tepat untuk melaporkannya!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, anda tetap bisa memblokir iklan ini untuk anda sendiri pada halaman pengaturan, Terima kasih!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Umum"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Jika Anda lebih tidak suka melihat iklan seperti ini, Anda dapat mematikan daftar filter iklan yang dapat diterima."
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"lainnya"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Masukkan"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Tidak ada filter yang ditentukan!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"tidak diketahui"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finlandia"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock dimatikan pada halaman ini."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Jepang"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Izinkan beberapa iklan yang tidak mengganggu"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Edit filter nonaktif:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Ini adalah sebuah masalah daftar filter. Laporkan disini: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Jangan jalankan pada halaman-halaman di domain ini"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Elemen terblokir:"
   },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Gagal mengambil filter ini!"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Catatan: laporan anda mungkin akan tersedia untuk umum. Ingatlah itu sebelum anda menyertakan apapun yang bersifat pribadi."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Tunjukkan alamat ke daftar filter"
-  },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Hanya Inggris"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Batal"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Bantu Sebarkan!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Anda dapat menggeser yang dibawah ini untuk mengganti secara tepat pada halaman apa AdBlock tidak akan berjalan."
-  },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock telah memblokir unduhan dari situs terkenal akan host malware."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Periksa di Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Aktifkan modus kompatibilitas ClickToFlash"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Berlangganan pada daftar filter ini, lalu coba lagi: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Untuk melaporkan iklan, Anda harus terhubung ke internet."
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Punya pertanyaan atau ide baru?"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Daftar URL yang tidak sah. Daftar ini akan dihapus."
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Langkah 1: Tentukan apa yang akan diblokir"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Ya"
-  },
-  "filteritalian":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Italia"
+    "message":"Bahasa Lithuania"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Terlihat bagus"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (dianjurkan)"
+  "typepage":{
+    "description":"A resource type",
+    "message":"halaman"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1338,5 +747,636 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Apa iklannya masih muncul?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"lainnya"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Klik ini: <a>Perbaharui filter saya!</a>"
+  },
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Pastikan Anda menggunakan filter bahasa yang tepat:"
+  },
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Pastikan daftar filter Anda telah diperbaharui:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Untuk menyembunyikan tombol, pergi ke opera://extensions dan centang opsi 'Hide from toolbar'. Anda dapat menampilkannya lagi dengan tidak mencentang opsi tersebut."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Terjadi kesalahan saat memeriksa pembaruan."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Klik pada menu Safari &rarr; Preferences &rarr; Extension."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Masukkan"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Halaman:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Muat ulang halaman yang ada iklannya."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Tidak berlangganan."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Latvia"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blok sebuah iklan pada halaman ini"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Tutup!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Berhenti memblokir iklan:"
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Klik ini: <a>Nonaktifkan Iklan Yang Dapat Diterima</a>"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Izinkan daftar putih pada saluran Youtube tertentu"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Ditulis dalam bahasa apa halaman itu?"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Dihapus dari daftar"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Kami belum bisa memblokir iklan iklan didalam Flash dan plugin lainnya. Kami menunggu dukungan dari browser dan WebKit."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Anda dapat menggeser yang dibawah ini untuk mengganti secara tepat pada halaman apa AdBlock tidak akan berjalan."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"sembunyikan"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock dimatikan pada halaman ini."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Apakah iklannya muncul didalam atau sebelum film atau plugin lainnya seperti game Flash?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Rusia dan Ukraina"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spanyol"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokir iklan ini"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Hati hati: Filter ini memblokir semua $elementtype$ elemen yang ada di halaman!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Aktifkan modus kompatibilitas ClickToFlash"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Tidak"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Mengaktifkan AdBlock pada Halaman ini"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filter, yang bisa diubah di halaman pengaturan:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Tampilkan jumlah iklan yang diblokir di tombol AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Gagal!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Bekukan AdBlock"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Berlangganan pada daftar filter ini, lalu coba lagi: $list_title$",
+    "placeholders":{
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Inggris"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Tambahkan barang ke menu klik kanan"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Menemukan sebuah iklan pada halaman web? Kami akan membantu Anda menemukan tempat yang tepat untuk melaporkannya!"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Nonaktifkan semua ekstensi kecuali AdBlock:"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Rusia"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Jika Anda melihat iklan, jangan membuat laporan bug, melainkan buatlah <a>laporan iklan</a>!"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Anda menggunakan Safari versi lama. Ambillah versi terbaru untuk menggunakan tombol toolbar AdBlock untuk menjeda AdBlock, membebaskan situs web, dan melaporkan iklan. <a>Perbaharui sekarang</a>"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (perlindungan privasi)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ adalah $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Klik kanan sebuah iklan pada halaman untuk memblokirnya -- atau blokir secara manual disini."
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Selesai!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Lanjutkan AdBlock"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Tambahkan filter untuk bahasa lain: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"MEMUAT..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Tim kami meminta beberapa informasi debug? Klik <a href='#' id='debug'> di sini</a> untuk itu!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Perlindungan Malware"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Laporkan sebuah iklan pada halaman ini"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Perlihatkan pernyataan debug pada Console Log (akan memperlambat AdBlock)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Pasang Firefox $chrome$ jika anda tidak memilikinya.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Geser pengatur hingga iklan terblokir dengan benar pada halaman, dan elemen yang terblokir tidak terlihat."
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Anda melebihi jumlah penyimpanan yang bisa dipakai oleh AdBlock. Batalkanlah langganan anda dari beberapa daftar filter!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Ekstensi Chrome paling populer, dengan lebih dari 40 juta pengguna! Blokir iklan di seluruh web."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Menemukan bug?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Pelajari lebih lanjut tentang malware"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skrip"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Daftar Filter"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Saya pengguna tingkat lanjut, perlihatkan pilihan tingkat lanjut"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"China"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filter ini tidak sah: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Berlangganan daftar filter..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Buka laman ekstensi untuk mngaktifkan ekstensi yang telah dinonaktifkan sebelumnya."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Nonaktifkan pemberitahuan ini"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"$matchcount$ item yang sama pada halaman ini.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"diperbaharui 1 jam lalu"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" --Pilih bahasa-- "
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Haruskah AdBlock memberitahu Anda ketika mendeteksi malware?"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesia"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"gambar"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Edit"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Gagal mengambil filter ini!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"Total $count$",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Dukungan"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blok sebuah iklan oleh URLnya"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Batal"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Jangan lupa untuk menyimpan!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Pada browser tersebut, muatlah halaman yang ada iklannya."
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Iklan yang dapat diterima (disarankan)"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versi $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Bahasa Islandia"
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Melaporkan iklan bersifat sukarela. Hal ini membantu orang lain dengan mengaktifkan pengelola daftar filter untuk memblokir iklan untuk semua orang. Jika Anda tidak merasa altruistik sekarang ini, tidak apa-apa. Tutup halaman ini dan <a>blok iklan</a> hanya untuk diri sendiri."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Apakah Anda yakin bahwa Anda ingin berlangganan ke daftar filter $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Kode sumber tersedia <a>secara gratis</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Belanda"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Silahkan ketik filter yang benar di bawah ini dan tekan OK"
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Ekstensi yang telah dinonaktifkan sebelumnya telah diaktifkan kembali."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"<b>1</b> item yang sama pada halaman ini."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Jepang"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Bersihkan daftar ini"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"diperbaharui $hours$ jam lalu",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Kembali"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Pengaturan AdBlock"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock telah memblokir unduhan dari situs terkenal akan host malware."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Jangan berangganan lebih dari yang anda butuhkan -- setiap satunya akan sedikit memperlambat anda! Kredit dan lebih banyak daftar dapat ditemukan <a>Disini</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Memeriksa pembaruan (hanya memerlukan beberapa detik)..."
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domain dari halaman untuk diterapkan"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"diperbaharui sekarang"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"diperbaharui $minutes$ menit lalu",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Ceko"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Izinkan beberapa iklan yang tidak mengganggu"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Swedia"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Dukungan AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tipe"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Prancis"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"diperbaharui 1 menit lalu"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - Klik untuk melihat detilnya"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Perhatian: tidak ada filter yang ditentukan!"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -1,1351 +1,1169 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Allega uno screenshot:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Nessun malware noto trovato."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"In un altro browser, sottoscrivi gli stessi elenchi dei filtri come qua."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"In questo browser, carica la pagina con la pubblicità."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Svedese"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Bloccare più pubblicità:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Russo"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Annullata sottoscrizione."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Cinese"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Se hai creato un filtro funzionante utilizzando la procedura guidata \"blocca un annuncio\", incollalo nel box sottostante:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Lista filtri Antisocial (rimuove i bottoni dei social media)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Trovato un annuncio su una pagina web? Ti aiuteremo a trovare il posto giusto per segnalarlo!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Visualizza il numero di annunci bloccati sul pulsante di AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Il codice sorgente è <a>liberamente disponibile</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"aggiornato 1 minuto fa"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Errore nel recupero del filtro!"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Il computer potrebbe essere infetto da malware.  Clicca <a>qui</a> per ulteriori informazioni."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blocca una pubblicità inserendo la sua URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Nascondi questo bottone"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Gli aggiornamenti saranno scaricati automaticamente; puoi anche <a>aggiornare ora</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formato: ~sito1.com|~sito2.com|~news.sito3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estone"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tipo"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"E' disponibile un aggiornamento per AdBlock! Vai $here$ per aggiornare. <br>Attenzione: se vuoi ricevere gli aggiornamenti automaticamente, clicca su Safari > Preferenze > Estensioni >Aggiornamenti<br> e spunta l'opzione 'Installa gli aggiornamenti automaticamente'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Cos'è?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Non abbonarti a più liste di quante te ne servano -- ciascuna rallenta un po' (veramente poco) le prestazioni. Altre liste si trovano <a>qui</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Questa funzione AdBlock non funziona su questo sito perché utilizza tecnologia antiquata. Può mettere manualente in blacklist o whitelist le risorse nella scheda 'Personalizza' della pagina opzioni."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polacco"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Scopri maggiori informazioni sul programma Annunci Accettabili."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"aggiornato $seconds$ secondi fa",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Ungherese"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Nota: il tuo report potrebbe diventare disponibile pubblicamente. Tienilo a mente prima di includere qualcosa di privato."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Si prega di disattivare alcuni elenchi di filtri. Ulteriori informazioni nelle opzioni di AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Origine del filtro:$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Spiacenti, AdBlock è disabilitato su questa pagina da qualcuna delle tue liste filtri."
-  },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Islandese"
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Attenzione: nessun filtro specificato!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock è disabilitato su questa pagina."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Mostra le pubblicità <i>ovunque</i> tranne per questi domini..."
+    "message":"Hai una domanda o una nuova idea?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Opzioni"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Pubblicità bloccate:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Aggiungi filtri per altre lingue: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Clicca quello che vuoi bloccare e ti guiderò nell'operazione."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>O</b>, clicca su questo pulsante per fare tutto quanto indicato sopra: <a>disattiva tutte le altre estensioni</a>"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Grande! Sei a posto."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Altra"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Supporto AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Personalizza AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Le informazioni richieste sono incomplete o non valide.  Compila le domande che hanno un bordo rosso."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Errore di salvataggio del file caricato."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Per favore, inserisci il filtro corretto qui sotto e premi OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Passo 1: Identifica quello che vuoi bloccare"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Danese"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (raccomandato)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ su questa pagina",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Subframe"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"aggiornato 1 ora fa"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Coreano"
+    "message":"Polacco"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"o Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Come ti chiami?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"La più popolare estensione di Chrome, con oltre 40 milioni di utilizzatori! Blocca le pubblicità su tutto il web."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Visualizza tutte le richieste"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Non mi va di controllare"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Sì"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Annulla i miei blocchi su questo dominio"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Personalizza"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Metti in pausa AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Sei sicuro di volerti sottoscrivere alla lista del filtro $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Esattamente dov'é in quella pagina è l'annuncio? Che cosa ti sembra?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"o AdBlock per Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definizione stile"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Superato il limite di regole blocco contenuto"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Ricerca pubblicità...<br/><br/><i>Ci vorrà solo un momento.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Il dominio o url dove AdBlock non dovrebbe bloccare nulla"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ in totale",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Tutti a posto!  Ti contatteremo presto, probabilmente entro un giorno, due se si tratta di un giorno festivo. Nel frattempo, controlla se è arrivata un'email da AdBlock. Ci troverai un link per un posto sul nostro sito di assistenza. Se preferisci seguirci via email, puoi ancora farlo!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"No"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Qualcosa è andato storto. Nessuna risorsa è stata ancora inviata. Questa pagina sarà chiusa. Prova a ricaricare il sito."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ucraino"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"aggiornato $minutes$ minuti fa",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Non sei iscritto all'elenco del filtro Acceptable Ads."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Protezione Malware"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Salva"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Avviso: su tutti gli altri siti vedrai le pubblicità!<br>Questa regola annulla gli altri filtri per quei siti."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Disattiva queste notifiche"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"In abbonamento alla lista filtri..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Stai usando una vecchia versione di AdBlock. Vai a <a href='#'>the extensions page</a>, abilita 'Modalità sviluppatore' e clicca 'Aggiorna estensioni adesso'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Opzioni di AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Verifica malware che potrebbero essere responsabili dell'inserzione di annunci:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Mostra messaggi di debug nella Console dei Log (rallenta AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Hai superato le dimensioni limite di Dropbox. Rimuovi alcune voci dai filtri personalizzati o disabilitati e riprova."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Riabilita AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Aggira il problema dei video Hulu.com che non vengono riprodotti (richiede il riavvio del browser)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS da bloccare"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Escludi"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disabilita tutte le estensioni tranne AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"I crediti per la traduzione vanno a:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"CARICAMENTO..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Clicca col tasto destro su una pubblicità per bloccarla -- oppure bloccala qui manualmente."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Nota: Mettere in Whitelist (permette annunci su) una pagina o un sito non è supportato con il blocco contenuti di Safari attivato."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Lo useremo per contattarti solo se avremo bisogno di ulteriori informazioni."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Modifica i filtri disabilitati:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Attivare il blocco dei contenuti Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Qual è il tuo indirizzo email?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Per nascondere il pulsante, fare clic destro sulla barra degli strumenti di Safari e scegliere Personalizza Barra degli Strumenti, quindi trascinare il pulsante AdBlock fuori dalla barra. È possibile visualizzarlo nuovamente trascinandolo nella barra degli strumenti."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"C'è stato un errore di elaborazione della tua richiesta."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"pagina"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Fatto! Abbiamo ricaricato la pagina con l'annuncio. Controlla questa pagina per vedere se l'annuncio è apparso. Poi torna su questa pagina e rispondi alla domanda qui sotto."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"O inserire un URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Stai usando una vecchia versione di Safari. Scarica l'ultima versione per poter usare il bottone di AdBlock nella toolbar per mettere in pausa AdBlock, permettere contenuti, e riportare pubblicità. <a>Upgrade now</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Clicca il menu Safari &rarr; Preferenze &rarr; Estensioni."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Arrestare il blocco delle pubblicità:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Bloccalo!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"La pubblicità compare ancora?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bulgaro"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Grande! Ora andiamo a scoprire quale estensione ne è la causa. Abilita ogni estensione una per una. L'estensione che fa ricomparire l'annuncio è quello che avete bisogno di disinstallare per sbarazzarvi degli annunci."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Fallito!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Modificare manualmente i filtri:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italiano"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tipo"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovacco"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Abbonati a una lista filtri"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Puoi tornare indietro e supportare i siti Web che ami selezionando l'opzione \"Consenti alcune pubblicità non intrusive\" sotto."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"La pubblicità continua ad apparire in questo browser?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Non abilitare su questa pagina"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Lituano"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Fatecele sapere sul nostro <a>sito di supporto tecnico</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock è in pausa."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Non possiamo ancora bloccare pubblicità all'interno di Flash e altri plugins. Siamo in attesa di supporto da parte del browser e WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Cos'è cambiato nell'ultimo rilascio? Guarda il <a style='cursor:pointer;'>changelog</a>!"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Se preferisci non visualizzare annunci come questo, è possibile lasciare disattivato l'elenco dei filtri Annunci Accettabili."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"altro"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Nessun filtro specificato!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"sconosciuto"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Giapponese"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Permetti alcuni annunci non invadenti"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Cancella"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Puoi scorrere in basso per selezionare esattamente in quali pagine AdBlock non verrà abilitato."
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Ultimo passo: segnalaci il problema."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Controlla in Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Per segnalare una pubblicità devi essere connesso a internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (raccomandato)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Segnala una pubblicità"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Liste Filtri"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Come?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Consenti la whitelist di specifici canali YouTube"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Terze parti"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (rimuove i fastidi sul Web)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - clicca per dettagli"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"aggiornato $hours$ ore fa",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Russo e Ucraino"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Consenti ad AdBlock di raccogliere anonimamente dati sull'utilizzo della lista filtri"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Le estensioni che sono state precedentemente disattivate sono state riattivate."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Greco"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Nascondi una sezione di una pagina web"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video e Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Quando tornerai su questa pagina, quale credi che sarà la situazione di questa pubblicità?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Abilita AdBlock su questa pagina"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Indietro"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Le liste filtri bloccano la maggior parte delle pubblicità sul web.  E' anche possibile:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Controlla i filtri degli Annunci Accettabili:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Mostra le pubblicità su una pagina web o dominio"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"<b>1</b> elemento dello stesso tipo trovato sulla pagina"
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Non mi va di controllare"
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Attenzione: Se fai un errore molti altri filtri, compresi quelli ufficiali, potrebbero smettere di funzionare!<br/>Leggi il <a>filter syntax tutorial</a> per imparare le funzionalità avanzate e scrivere da solo i tuoi filtri."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Canale $name$ in Whitelist",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"La pubblicità continua ad apparire in questo browser?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opzioni generali"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Se preferisci non visualizzare annunci come questo, è possibile lasciare disattivato l'elenco dei filtri Annunci Accettabili."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock non verrà eseguito su qualsiasi pagina corrispondente:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Non abbiamo una lista filtri di default per questa lingua.<br/>Per favore prova a cercare una lista adatta che supporta questa lingua $link$ o blocca questa pubblicità da solo nella scheda 'Personalizza'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Abbonati"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Sono un utente esperto, mostrami le opzioni avanzate"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Spagnolo"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Caricata sulla pagina con dominio:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Clicca qui: <a>Aggiorna i miei filtri!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Più liste filtri usi, più lentamente funzionerà AdBlock. Utilizzando molte liste il browser può crashare su alcuni siti. Premi OK per sottoscriverti a questa lista ugualmente."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Ultimo passo: Cosa rende questa una pubblicità?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"$matchcount$ elementi dello stesso tipo trovati sulla pagina.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Abbiamo anche una <a>pagina</a> per aiutarvi a scoprire le persone che lavorano ad AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesiano"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turco"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blocca una pubblicità"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Liste Filtri Personalizzati"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"Frame URL: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Lo scopo di questa domanda è determniare chi dovrebbe ricevere il tuo report. Se rispondi a questa domanda in modo sbagliato, il report sarà inviato alla persona sbagliata, e così sarà ignorato."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Aggiungi AdBlock al menù contestuale (click destro)"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"selettore"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blocca questa pubblicità"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Il nostro team richiede alcune informazioni di debug? Clicca <a href='#' id='debug'> qui</a>!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Non eseguire AdBlock su..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Segnalare un annuncio è facoltativo. Aiuta altri utenti abilitando la lista filtri manutentori per bloccare l'annuncio per tutti. Se adesso non ti senti altruistia destra, va bene. Chiudi questa pagina e <a>blocca l'annuncio</a> solo per te stesso."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Elementi nascosti"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Ricarica la pagina."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"pagina"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Olandese"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Il nome del file è troppo lungo. Assegna al file un nome più breve."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Non dimenticare di salvare!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Controlla aggiornamenti (dovrebbero bastare pochi secondi)..."
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Generale"
+    "message":"Lituano"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Abbonati a questa lista filtro, poi prova ancora: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Permetti ad AdBolck di notificarti quando rileva un malware?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Il computer potrebbe essere infetto da malware.  Clicca <a>qui</a> per ulteriori informazioni."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Visualizza il numero di annunci bloccati nel menu di AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Mostra le pubblicità su una pagina web o dominio"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Sito:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Filtri personalizzati di AdBlock (raccomandato)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Lettone"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Assicurati di utilizzare i filtri della lingua giusta:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS da bloccare"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Per nascondere il bottone, andare in opera://extension e spuntare 'Nascondi dalla toolbar'. Puoi tornare a visualizzarla deselezionando l'opzione."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Non sei sicuro?</b> allora premi 'Bloccalo!' qui in basso."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Filtro adattato"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"In fase di recupero..."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Tutte le risorse"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock è aggiornato!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Non attivare sulle pagine di questo dominio"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Ebraico"
+    "message":"Slovacco"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Spostare il cursore fino a bloccare correttamente l'elemento selezionato e a dare alla pagina l'aspetto desiderato."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blocca le URL che contengono questo testo"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Il numero di regole filtro supera il limite di 50.000 ed è stato ridotto automaticamente. Si prega di eliminare alcuni elenchi di filtri o disattivare il blocco dei contenuti Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"aggiornato 1 giorno fa"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Annunci Accettabili (consigliato)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Fare clic qua: <a>Disabilitare Annunci Accettabili</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versione $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Installa Adblock Plus per Firefox $chrome$ se non ce l'hai.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Rimuovi dalla lista"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Non abbiamo una lista filtri di default per questa lingua.<br/>Per favore prova a cercare una lista adatta che supporta questa lingua $link$ o blocca questa pubblicità da solo nella scheda 'Personalizza'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Non è un file immagine. Carica un file .png, .gif o .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Perché non ci invii una <a>segnalazione di bug</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"nascondi"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Lista filtri"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Dominio del frame: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Clicca quello che vuoi bloccare e ti guiderò nell'operazione."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Top frame"
   },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Finito!"
-  },
-  "headerresource":{
-    "description":"Resource list page: title of a column",
-    "message":"Risorse"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blocca una pubblicità su questa pagina"
-  },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Assicurati che gli elenchi dei filtri siano aggiornati:"
-  },
-  "lang_english":{
-    "description":"language",
-    "message":"Inglese"
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Apri la pagina delle estensioni per attivare le estensioni precedentemente disabilitate."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Dominio della pagina a cui applicarlo"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Pagina:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Trovato un bug?"
-  },
-  "filtereasylist_plus_arabic":{
-    "description":"language",
-    "message":"Arabo"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Ceco"
-  },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Dona ciò che ti senti!"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Vuoi vedere cosa fa AdBlock?"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Lista URL non valida. Sarà cancellata."
-  },
-  "typesub_frame":{
+  "typestylesheet":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"definizione stile"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Modifica"
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"sconosciuto"
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Hai una domanda o una nuova idea?"
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Spiacenti, AdBlock è disabilitato su questa pagina da qualcuna delle tue liste filtri."
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Hai dimenticato di allegare uno screenshot! Non possiamo aiutarti senza vedere l'annuncio(i) che stai segnalando."
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Terze parti"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Nessun filtro specificato!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Greco"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Stai usando una vecchia versione di AdBlock. Vai a <a href='#'>the extensions page</a>, abilita 'Modalità sviluppatore' e clicca 'Aggiorna estensioni adesso'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Come ti chiami?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Aggira il problema dei video Hulu.com che non vengono riprodotti (richiede il riavvio del browser)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Attenzione: nessun filtro specificato!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Personalizza"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Trovato un annuncio su una pagina web? Ti aiuteremo a trovare il posto giusto per segnalarlo!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estone"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgaro"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Contenuti nella whitelist"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Superato il limite di regole blocco contenuto"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Non eseguire AdBlock su..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blocca le URL che contengono questo testo"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Chiudi"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Controlla in Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Ultimo passo: Cosa rende questa una pubblicità?"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Personalizza AdBlock"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Coreano"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Perché non ci invii una <a>segnalazione di bug</a>?"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finlandese"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ucraino"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Nessun malware noto trovato."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Si prega di disattivare alcuni elenchi di filtri. Ulteriori informazioni nelle opzioni di AdBlock."
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Abbiamo anche una <a>pagina</a> per aiutarvi a scoprire le persone che lavorano ad AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"qui"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
   },
   "ad_report_please":{
     "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
     "message":"Se visualizzi una pubblicità, non riportare un bug, fai una <a>segnalazione di pubblicità</a>!"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Maggiori informazioni sui malware"
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Ricarica la pagina."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"In che lingua è scritta questa pagina?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock è in pausa."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Riabilita AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Ricerca pubblicità...<br/><br/><i>Ci vorrà solo un momento.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock è disabilitato su questa pagina."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"In un altro browser, sottoscrivi gli stessi elenchi dei filtri come qua."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blocca una pubblicità"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Avviso: su tutti gli altri siti vedrai le pubblicità!<br>Questa regola annulla gli altri filtri per quei siti."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"E' disponibile un aggiornamento per AdBlock! Vai $here$ per aggiornare. <br>Attenzione: se vuoi ricevere gli aggiornamenti automaticamente, clicca su Safari > Preferenze > Estensioni >Aggiornamenti<br> e spunta l'opzione 'Installa gli aggiornamenti automaticamente'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Finito!"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Filtri personalizzati di AdBlock (raccomandato)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tipo"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Cos'è?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Giapponese"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Origine del filtro:$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Abbonati a una lista filtri"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Sito:"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Aggiungi filtri per altre lingue: "
+  },
+  "headerfilter":{
+    "description":"Resource list page: title of a column",
+    "message":"Filtro adattato"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Le liste filtri bloccano la maggior parte delle pubblicità sul web.  E' anche possibile:"
+  },
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Per nascondere il pulsante, fare clic destro sulla barra degli strumenti di Safari e scegliere Personalizza Barra degli Strumenti, quindi trascinare il pulsante AdBlock fuori dalla barra. È possibile visualizzarlo nuovamente trascinandolo nella barra degli strumenti."
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Hai superato le dimensioni limite di Dropbox. Rimuovi alcune voci dai filtri personalizzati o disabilitati e riprova."
+  },
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Abbonati"
+  },
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Nota: Mettere in Whitelist (permette annunci su) una pagina o un sito non è supportato con il blocco contenuti di Safari attivato."
+  },
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Elemento bloccato:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"pagina"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"altro"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Clicca qui: <a>Aggiorna i miei filtri!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Elementi nascosti"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Per nascondere il bottone, andare in opera://extension e spuntare 'Nascondi dalla toolbar'. Puoi tornare a visualizzarla deselezionando l'opzione."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Pagina:"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Bloccalo!"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Consenti la whitelist di specifici canali YouTube"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Non possiamo ancora bloccare pubblicità all'interno di Flash e altri plugins. Siamo in attesa di supporto da parte del browser e WebKit."
+  },
+  "filterhungarian":{
+    "description":"language",
+    "message":"Ungherese"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blocca questa pubblicità"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Abilita AdBlock su questa pagina"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Visualizza il numero di annunci bloccati sul pulsante di AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Fallito!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Metti in pausa AdBlock"
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Inglese"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Aggiungi AdBlock al menù contestuale (click destro)"
+  },
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Vai sul <a>nostro sito di supporto</a>."
+  },
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Elenco avvisi rimozione di adblock (rimuove avvertenze sull'utilizzo di annuncio bloccanti)"
+  },
+  "typemain_frame":{
+    "description":"A resource type",
+    "message":"pagina"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Sei sicuro di voler rimuovere i $count$ blocchi che hai creato su $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legenda: "
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"aggiornato $minutes$ minuti fa",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Allega uno screenshot:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Rumeno"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Modifica i filtri disabilitati:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Subframe"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Ricarica la pagina che contiene la pubblicità."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Attivare il blocco dei contenuti Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Installa Firefox $chrome$ se non ce l'hai.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Lista filtri"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Se hai creato un filtro funzionante utilizzando la procedura guidata \"blocca un annuncio\", incollalo nel box sottostante:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Questo file è troppo grande. Assicurarti che il file sia più piccolo di 10 MB."
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Sono un utente esperto, mostrami le opzioni avanzate"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Cinese"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Il filtro non è valido: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"In abbonamento alla lista filtri..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Apri la pagina delle estensioni per attivare le estensioni precedentemente disabilitate."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Disattiva queste notifiche"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turco"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Non abbonarti a più liste di quante te ne servano -- ciascuna rallenta un po' (veramente poco) le prestazioni. Altre liste si trovano <a>qui</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesiano"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"immagine"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ in totale",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Cancella"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Non dimenticare di salvare!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"selettore"
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Islandese"
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Sei sicuro di volerti sottoscrivere alla lista del filtro $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blocca solo le pubblicità di questi siti:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Caricata sulla pagina con dominio:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Le estensioni che sono state precedentemente disattivate sono state riattivate."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Pulisci questa lista"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Aiuta a diffondere il messaggio!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Aggiornamenti di AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Elenco avvisi rimozione di adblock (rimuove avvertenze sull'utilizzo di annuncio bloccanti)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Opzioni di AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"C'è stato un errore di elaborazione della tua richiesta."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"aggiornato 1 ora fa"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Controlla aggiornamenti (dovrebbero bastare pochi secondi)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"appena aggiornato"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Clicca col tasto destro su una pubblicità per bloccarla -- oppure bloccala qui manualmente."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Verifica malware che potrebbero essere responsabili dell'inserzione di annunci:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Supporto AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tipo"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Spostare il cursore fino a bloccare correttamente l'elemento selezionato e a dare alla pagina l'aspetto desiderato."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"aggiornato 1 minuto fa"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Risorsa bloccata"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Le seguenti informazioni appariranno anche nella segnalazione dell'annuncio."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Danese"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Controlla i filtri degli Annunci Accettabili:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Puoi tornare indietro e supportare i siti Web che ami selezionando l'opzione \"Consenti alcune pubblicità non intrusive\" sotto."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"In fase di recupero..."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Lista URL non valida. Sarà cancellata."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opzioni generali"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Deseleziona 'Abilitata' vicino ad ogni estensione <b>eccetto</b> AdBlock. <b>Lascia abilitata AdBlock</b>"
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"In questo browser, carica la pagina con la pubblicità."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Mostra le pubblicità <i>ovunque</i> tranne per questi domini..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Hai dimenticato di allegare uno screenshot! Non possiamo aiutarti senza vedere l'annuncio(i) che stai segnalando."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"E manualmente crea un biglietto, copiando e incollando le informazioni qui di seguito nella sezione \"Aggiungi qualunque dettaglio che pensi ci aiuterà a capire il tuo problema\"."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Per nascondere il bottone, cliccaci sopra col destro e scegli Nascondi Bottone. Puoi farlo apparire di nuovo andando in chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Ebraico"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Questa funzione AdBlock non funziona su questo sito perché utilizza tecnologia antiquata. Può mettere manualente in blacklist o whitelist le risorse nella scheda 'Personalizza' della pagina opzioni."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Ceco e Slovacco"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Abbiamo disabilitato tutte le altre estensioni. Ora ricaricaricheremo la pagina con l'annuncio. Un secondo, prego."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Altre Liste Filtri"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Francese"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Gli aggiornamenti saranno scaricati automaticamente; puoi anche <a>aggiornare ora</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Elemento bloccato:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Visualizza tutte le richieste"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"oggetto interattivo"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Più liste filtri usi, più lentamente funzionerà AdBlock. Utilizzando molte liste il browser può crashare su alcuni siti. Premi OK per sottoscriverti a questa lista ugualmente."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Grande! Sei a posto."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Apri la <a href='#'> pagina delle estensioni</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Tutti a posto!  Ti contatteremo presto, probabilmente entro un giorno, due se si tratta di un giorno festivo. Nel frattempo, controlla se è arrivata un'email da AdBlock. Ci troverai un link per un posto sul nostro sito di assistenza. Se preferisci seguirci via email, puoi ancora farlo!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Scopri maggiori informazioni sul programma Annunci Accettabili."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Permetti ad AdBolck di notificarti quando rileva un malware?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"appena aggiornato"
+    "message":"aggiornato 1 giorno fa"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"Frame URL: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Tedesco"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Il nome del file è troppo lungo. Assegna al file un nome più breve."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"aggiornato $seconds$ secondi fa",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Non abilitare su questa pagina"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Fatecele sapere sul nostro <a>sito di supporto tecnico</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Fatto! Abbiamo ricaricato la pagina con l'annuncio. Controlla questa pagina per vedere se l'annuncio è apparso. Poi torna su questa pagina e rispondi alla domanda qui sotto."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Tutte le risorse"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Canale $name$ in Whitelist",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Risorse"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Visualizza il numero di annunci bloccati nel menu di AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Segnala una pubblicità"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Come?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Non attivare sulle pagine di questo dominio"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Liste Filtri Personalizzati"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Bloccare più pubblicità:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Le informazioni richieste sono incomplete o non valide.  Compila le domande che hanno un bordo rosso."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Il dominio o url dove AdBlock non dovrebbe bloccare nulla"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Non sei iscritto all'elenco del filtro Acceptable Ads."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (rimuove i fastidi sul Web)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock ha bloccato un download da un sito noto per ospitare malware."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Salva"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Non sei sicuro?</b> allora premi 'Bloccalo!' qui in basso."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Ultimo passo: segnalaci il problema."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Lo scopo di questa domanda è determniare chi dovrebbe ricevere il tuo report. Se rispondi a questa domanda in modo sbagliato, il report sarà inviato alla persona sbagliata, e così sarà ignorato."
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Va bene"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Consenti ad AdBlock di raccogliere anonimamente dati sull'utilizzo della lista filtri"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Per segnalare una pubblicità devi essere connesso a internet."
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Liste Filtri"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"aggiornato $days$ giorni fa",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"oggetto interattivo"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Quando tornerai su questa pagina, quale credi che sarà la situazione di questa pubblicità?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Pubblicità bloccate:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arabo"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Annulla i miei blocchi su questo dominio"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Modificare manualmente i filtri:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Passo 1: Identifica quello che vuoi bloccare"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Per favore, inserisci il filtro corretto qui sotto e premi OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"I crediti per la traduzione vanno a:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock è aggiornato!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Solo in inglese"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>O</b>, clicca su questo pulsante per fare tutto quanto indicato sopra: <a>disattiva tutte le altre estensioni</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Cos'è cambiato nell'ultimo rilascio? Guarda il <a style='cursor:pointer;'>changelog</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (protezione della privacy)"
+    "message":"Lista filtri Antisocial (rimuove i bottoni dei social media)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Segnala una pubblicità su questa pagina"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Protezione Malware"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Pulisci questa lista"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock non verrà eseguito su qualsiasi pagina corrispondente:"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Tedesco"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Hai superato la quantità di spazio che AdBlock può utilizzare. Per favore elimina la sottoscrizione da alcune liste filtri!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Attenzione: questo filtro blocca tutti gli elementi $elementtype$ sulla pagina!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"qui"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Qual è il tuo indirizzo email?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"In che lingua è scritta questa pagina?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Vuoi vedere cosa fa AdBlock?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Sei sicuro di voler rimuovere i $count$ blocchi che hai creato su $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"immagine"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Nascondi una sezione di una pagina web"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"E manualmente crea un biglietto, copiando e incollando le informazioni qui di seguito nella sezione \"Aggiungi qualunque dettaglio che pensi ci aiuterà a capire il tuo problema\"."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Generale"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Per nascondere il bottone, cliccaci sopra col destro e scegli Nascondi Bottone. Puoi farlo apparire di nuovo andando in chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"o AdBlock per Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumeno"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video e Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Qualcosa non ha funzionato durante il controllo aggiornamenti."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Abbiamo disabilitato tutte le altre estensioni. Ora ricaricaricheremo la pagina con l'annuncio. Un secondo, prego."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Contenuti nella whitelist"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Grande! Ora andiamo a scoprire quale estensione ne è la causa. Abilita ogni estensione una per una. L'estensione che fa ricomparire l'annuncio è quello che avete bisogno di disinstallare per sbarazzarvi degli annunci."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1357,190 +1175,412 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Ceco e Slovacco"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"o Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Tipo di frame: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formato: ~sito1.com|~sito2.com|~news.sito3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Scegli una lingua --"
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Installa Adblock Plus per Firefox $chrome$ se non ce l'hai.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Risorsa bloccata"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"La pubblicità viene visualizzata all'interno o prima di un film o di un qualsiasi altro plugin come un gioco Flash?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"L'attributo $attribute$ sarà $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Il filtro, che può essere modificato nella pagina Opzioni:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Il seguente filtro: <br/> $filter$ <br/> ha un errore: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Chiudi"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blocca solo le pubblicità di questi siti:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Hai superato la quantità di spazio che AdBlock può utilizzare. Per favore elimina la sottoscrizione da alcune liste filtri!"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Il filtro non è valido: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, puoi ancora bloccare questa pubblicità da solo sulla pagina Opzioni. Grazie!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Invia"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finlandese"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Questo file è troppo grande. Assicurarti che il file sia più piccolo di 10 MB."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Le seguenti informazioni appariranno anche nella segnalazione dell'annuncio."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Dona ciò che ti senti!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"E' un problema della lista filtri, segnalalo qui: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Deseleziona 'Abilitata' vicino ad ogni estensione <b>eccetto</b> AdBlock. <b>Lascia abilitata AdBlock</b>"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Nota: il tuo report potrebbe diventare disponibile pubblicamente. Tienilo a mente prima di includere qualcosa di privato."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Mostra i collegamenti alle liste filtri"
+  "filteritalian":{
+    "description":"language",
+    "message":"Italiano"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Solo in inglese"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Aiuta a diffondere il messaggio!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"La pubblicità compare ancora?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock ha bloccato un download da un sito noto per ospitare malware."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Assicurati di utilizzare i filtri della lingua giusta:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legenda: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Assicurati che gli elenchi dei filtri siano aggiornati:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Qualcosa non ha funzionato durante il controllo aggiornamenti."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Clicca il menu Safari &rarr; Preferenze &rarr; Estensioni."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Invia"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Annullata sottoscrizione."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Lettone"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blocca una pubblicità su questa pagina"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Arrestare il blocco delle pubblicità:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Errore di salvataggio del file caricato."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"$matchcount$ elementi dello stesso tipo trovati sulla pagina.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Errore nel recupero del filtro!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Puoi scorrere in basso per selezionare esattamente in quali pagine AdBlock non verrà abilitato."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"nascondi"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"La pubblicità viene visualizzata all'interno o prima di un film o di un qualsiasi altro plugin come un gioco Flash?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Russo e Ucraino"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spagnolo"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Attenzione: questo filtro blocca tutti gli elementi $elementtype$ sulla pagina!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Attiva la compatibilità con ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"No"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Il filtro, che può essere modificato nella pagina Opzioni:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Nascondi questo bottone"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Altra"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, puoi ancora bloccare questa pubblicità da solo sulla pagina Opzioni. Grazie!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Russo"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Stai usando una vecchia versione di Safari. Scarica l'ultima versione per poter usare il bottone di AdBlock nella toolbar per mettere in pausa AdBlock, permettere contenuti, e riportare pubblicità. <a>Upgrade now</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (protezione della privacy)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"L'attributo $attribute$ sarà $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"O inserire un URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Il seguente filtro: <br/> $filter$ <br/> ha un errore: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Tipo di frame: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"CARICAMENTO..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Il nostro team richiede alcune informazioni di debug? Clicca <a href='#' id='debug'> qui</a>!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Il numero di regole filtro supera il limite di 50.000 ed è stato ridotto automaticamente. Si prega di eliminare alcuni elenchi di filtri o disattivare il blocco dei contenuti Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Segnala una pubblicità su questa pagina"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Mostra messaggi di debug nella Console dei Log (rallenta AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Dominio del frame: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"La più popolare estensione di Chrome, con oltre 40 milioni di utilizzatori! Blocca le pubblicità su tutto il web."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Trovato un bug?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Ceco"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Non è un file immagine. Carica un file .png, .gif o .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Mostra i collegamenti alle liste filtri"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Permetti alcuni annunci non invadenti"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Svedese"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Rimuovi dalla lista"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Scegli una lingua --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francese"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Modifica"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Supporto"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Vai sul <a>nostro sito di supporto</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blocca una pubblicità inserendo la sua URL"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versione $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Esattamente dov'é in quella pagina è l'annuncio? Che cosa ti sembra?"
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Segnalare un annuncio è facoltativo. Aiuta altri utenti abilitando la lista filtri manutentori per bloccare l'annuncio per tutti. Se adesso non ti senti altruistia destra, va bene. Chiudi questa pagina e <a>blocca l'annuncio</a> solo per te stesso."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Sì"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Il codice sorgente è <a>liberamente disponibile</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Olandese"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Lo useremo per contattarti solo se avremo bisogno di ulteriori informazioni."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"<b>1</b> elemento dello stesso tipo trovato sulla pagina"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"aggiornato $hours$ ore fa",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Indietro"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Fare clic qua: <a>Disabilitare Annunci Accettabili</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Dominio della pagina a cui applicarlo"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Aggiornamenti di AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Qualcosa è andato storto. Nessuna risorsa è stata ancora inviata. Questa pagina sarà chiusa. Prova a ricaricare il sito."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Maggiori informazioni sui malware"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Annunci Accettabili (consigliato)"
   },
   "safaricontentblockingpausemessage":{
     "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
     "message":"Per mettere in pausa AdBlock quando è abilitato il blocco dei contenuti, si prega di selezionare Safari (nella barra dei menu) > Preferenze > Estensioni e deselezionare 'Abilitare AdBlock'."
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - clicca per dettagli"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Va bene"
-  },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Apri la <a href='#'> pagina delle estensioni</a>."
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disabilita tutte le estensioni tranne AdBlock:"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,665 +1,177 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - 広告を報告"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"広告ブロックフィルターのリスト"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"サイト："
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"特定の YouTube チャンネルのホワイトリスト化を許可する"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (ウェブ上のイライラの種を削除します)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - 詳細はこちら"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Ｆｉｒｅｆｏｘdで広告のあるページを読み込みください。"
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"スウェーデン語"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Type"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"もっと広告をブロック："
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"ロシア語"
+    "message":"デンマーク語"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"支払える分だけお支払いください！"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"周りに広める"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"無効にしました。"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"ギリシャ語"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"中国語"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"ウェブページの一部を隠す"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"スペイン語"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"マルウェア対策"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"このページにアクセスする度に表示される要素について、どれが該当すると思いますか？"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocial フィルターリスト（ソーシャルメディアボタンを削除します）"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"戻る"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"質問、または新たなアイディアがありますか？"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"ほとんどの広告はフィルターリストでブロックされます。オプションとして更に："
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"ソースコードは <a>自由に入手できます</a>！"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"ウェブページとドメインにある広告を表示"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"<b>1</b>個のアイテムを発見しました。"
-  },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"警告： ここで作成したフィルターに問題がある場合、公式フィルターを含む他のフィルターが破損する場合があります。<br/>ブラックリスト、ホワイトリストの詳細な記法は<a>こちら（英語）</a>です。"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"フィルターの取得に失敗しました！"
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"一般設定"
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock won't run on any page matching:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"指定された言語のフィルターリストがありません。<br/>この言語をサポートする適切なリストを。$link$ もしくはこの要素をブロックするようにブラックリストを編集してください。",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"登録"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"私は上級者ユーザーです。詳細設定を見せてください。"
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"URLで広告をブロック"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"ボタンを隠す"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"自動的にアップデートを取得します。<a>今すぐアップデート</a>することも可能です。"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"こちらをクリック： <a>フィルターをアップデート！</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"例： ~site1.com|~site2.com|~news.site3.org"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlockは一時停止しています。"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"$matchcount$個のアイテムを発見しました。",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"AdBlock に携わる人々を見つけ出す助けになる<a>ページ</a>もあります！"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"インドネシア語"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Type"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"AdBlock のアップデートがあります！ $here$ を開いてアップデートしてください。 <br> 注意: アップデートを自動受信したい場合は、 Safari > 設定 > 拡張機能 > アップデートをクリックしてください。 <br> そしてオプション「自動的にアップデートをインストールする」にチェックを入れてください。",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"トルコ語"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"これは何ですか?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"カスタムフィルターリスト"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"必要以上に登録をしないでください。追加する度に重くなりますので！リストの作成者、その他のリストは<a>こちら</a>。"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"style definition"
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"リストから削除"
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"この質問の目的は、誰があなたの報告を受け取るべきか決定することです。この質問に不適切に回答した場合、間違った人物に報告が送られてしまい、そのために、無視されてしまうことになる場合があります。"
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"ポーランド語"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"右クリックメニューに項目を追加する。"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"動画とフラッシュ"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"この広告をブロック"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"$hours$時間前にアップデートしました",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"$seconds$秒前にアップデートしました",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"私たちのチームがデバッグ情報をいくらか要求しましたか？ それについては <a href='#' id='debug'>こちら</a>をクリック！"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interactive object"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"ハンガリー語"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"URLのリストが無効です。自動的に削除されます。"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"注意: 報告は公開される場合があります。私的な情報を含める前にご留意ください。"
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"ロシア語およびウクライナ語"
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"page"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"オランダ語"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"保存を忘れずに！"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ will be $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"閉じる"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"ブロックされている要素："
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"注意： フィルターが指定されていません！"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlockはこのページでは無効になっています。"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Show ads <i>everywhere</i> except for these domains..."
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"設定"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run AdBlock on..."
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"取得中・・・しばらくお待ちください。"
   },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"ブロックされた広告数:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlockカスタムフィルター (推奨)"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"まだ、フラッシュ内とプラグインにより出てくる広告はブロックができません。これらの広告の対処ついてはブラウザのサポートとWebKitの対応待ちです。"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"別の言語用のフィルターを追加: "
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"ラトビア語"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS指定"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"ボタンを非表示にするには、 opera://extensions を開き、「ツールバーから非表示にする」オプションにチェックを入れてください。そのオプションのチェックを外すと再び表示されるようになります。"
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"ブロックする広告をクリックして下さい。ウィザードでご案内します。"
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"このページにある広告をレポート"
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>よく分かりませんか？</b>とりあえず、「ブロック！」を押してください。"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock サポート"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"AdBlockをカスタマイズ"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock は最新版です！"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"このドメイン上のページで稼動させない"
-  },
-  "filterisraeli":{
+  "filterjapanese":{
     "description":"language",
-    "message":"ヘブライ語"
+    "message":"日本語"
   },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"申し訳ありませんが、あなたが設定したフィルターリストによってAdBlockがこのページで無効となっています。"
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"入力されたテキストを含むURLをブロック"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"このドメイン上の自分のブロックを取り消し"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"手動でフィルターを入力して、OKを押してください。"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"1日前アップデートしました"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"ベータ"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (ウェブ上のイライラの種を削除します)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"このページで $count$ 件",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"1時間前アップデートしました"
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"URLのリストが無効です。自動的に削除されます。"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"バージョン $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"ポーランド語"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"一般設定"
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"フィルターリストの登録"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"その他"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS指定"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"hiding"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"フィルターリスト"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Does the ad appear in or before a film or any other plugin like a Flash game?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"その他のフィルターリスト"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"または Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"ブロック！"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"完了！"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"このページにある広告をブロック"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"閉じる"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"これを確認したくありません。"
   },
-  "lang_english":{
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock won't run on any page matching:"
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Show ads <i>everywhere</i> except for these domains..."
+  },
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"警告： ここで作成したフィルターに問題がある場合、公式フィルターを含む他のフィルターが破損する場合があります。<br/>ブラックリスト、ホワイトリストの詳細な記法は<a>こちら（英語）</a>です。"
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"英語"
+    "message":"スロバキア語"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"カスタマイズ"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"AdBlockを一時停止"
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"適用するドメインを入力"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"韓国語"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"ページ："
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"バグが有りましたか？"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"ステップ1： ブロック対象の指定"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"チェコ語"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"フィルターリストの使用頻度が高くなるにつれ、AdBlockの動作が重くなります。たくさんのフィルターリストはブラウザがクラッシュする原因となりえます。それでも追加する場合はOKを押してください。"
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"または Chrome 用 AdBlock"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"広告をブロック"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"はい"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Firefoxでも広告は表示されますか？"
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"最終ステップ： 何故これは広告になるのでしょうか？"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"このページでは実行しない"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"デンマーク語"
+    "message":"ルーマニア語"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"ボタンを非表示にするには、そのボタンを右クリックして、ボタンを非表示を選択してください。 chrome://chrome/extensions で再表示することができます。"
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"ヘブライ語"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"その他"
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"チェコ語およびスロバキア語"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"その他のフィルターリスト"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"設定"
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"自動的にアップデートを取得します。<a>今すぐアップデート</a>することも可能です。"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"unknown"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"編集"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"ウェブページとドメインにある広告を表示"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"広告を検索中・・・<br/><br/><i>少々お待ちください。</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"トルコ語"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"ブロックしないドメインやURLを指定"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"アップデートを確認中 (数秒しかからないはずです)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"フィルターリストの使用頻度が高くなるにつれ、AdBlockの動作が重くなります。たくさんのフィルターリストはブラウザがクラッシュする原因となりえます。それでも追加する場合はOKを押してください。"
   },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"このページで AdBlock を有効にする"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"合計 $count$ 件",
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"指定された言語のフィルターリストがありません。<br/>この言語をサポートする適切なリストを。$link$ もしくはこの要素をブロックするようにブラックリストを編集してください。",
     "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"広告のあるページを更新してください。"
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Firefoxをお持ちではない場合は $chrome$ インストールしてください。",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -667,210 +179,387 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"ブロックする広告をクリックして下さい。ウィザードでご案内します。"
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"style definition"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock アップデート"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"いいえ"
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"ページ内にある広告を右クリックし、ブロックをしてください。または、こちらでマニュアルでブロック。"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"申し訳ありませんが、あなたが設定したフィルターリストによってAdBlockがこのページで無効となっています。"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"1日前アップデートしました"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"フィルターが指定されていません！"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"ドイツ語"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"フィルターリストの登録"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"AdBlock <b>以外</b>の全ての拡張機能の隣にある「有効」チェックボックスのチェックを外してください。  <b>AdBlock は有効のままにしてください</b>。"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"ギリシャ語"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"$seconds$秒前にアップデートしました",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>よく分かりませんか？</b>とりあえず、「ブロック！」を押してください。"
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Ｆｉｒｅｆｏｘdで広告のあるページを読み込みください。"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"<a>サポートサイト</a>でお知らせください！"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"これらのサイトの広告をブロックする："
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"カスタマイズ"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"広告を報告するには、インターネットに接続されていなければなりません。"
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK！"
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"ウェブページの一部を隠す"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - 広告を報告"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"ブルガリア語"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"最新版では何が変わりましたか？<a style='cursor:pointer;'>変更履歴</a>をご確認ください！"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"このドメイン上のページで稼動させない"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"カスタムフィルターリスト"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"もっと広告をブロック："
   },
   "lang_ukranian":{
     "description":"language",
     "message":"ウクライナ語"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"$minutes$分前にアップデートしました",
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"ブロックしないドメインやURLを指定"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"注意： フィルターが指定されていません！"
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"入力されたテキストを含むURLをブロック"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"除外"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Firefoxでも表示されるかどうかをチェックしてください $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"フランス語"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"広告を見つけたら、バグ報告ではなく、<a>広告報告</a>をしてください！"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"アップデートされました"
   },
   "savebutton":{
     "description":"Save button",
     "message":"保存"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"注意： on all other sites you will see ads!<br>This overrules all other filters for those sites."
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"$host$ に関して作成した  $count$ 個のブロックを本当に削除しますか？",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"フィルターリストに登録・・・"
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"決定"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"AdBlockをカスタマイズ"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Hulu.com のビデオが再生されないのを回避する (ブラウザの再起動が必要です)"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"フィンランド語"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"$days$日前にアップデートしました",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"interactive object"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (プライバシー保護)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"このページにアクセスする度に表示される要素について、どれが該当すると思いますか？"
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"チェコ語およびスロバキア語"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"古いバージョンの AdBlock を使用しています。 <a href='#'>拡張機能ページ</a> を開き、「デベロッパーモード」を有効にし、「今すぐ拡張機能をアップデート」をクリックしてください。"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock設定"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"このリストを掃除:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"デバック情報を更新履歴に表示(AdBlockの動作が重くなります)"
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"AdBlock の一時停止を解除"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"ドイツ語"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"警告： 指定されたフィルターはページの$elementtype$要素をすべてブロックします！",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"こちら"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Hulu.com のビデオが再生されないのを回避する (ブラウザの再起動が必要です)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"除外"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"どの言語でページは書かれていますか？"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"$host$ に関して作成した  $count$ 個のブロックを本当に削除しますか？",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"image"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"翻訳者："
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"読み込み中・・・"
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"ページ内にある広告を右クリックし、ブロックをしてください。または、こちらでマニュアルでブロック。"
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"ボタンを非表示にするには、そのボタンを右クリックして、ボタンを非表示を選択してください。 chrome://chrome/extensions で再表示することができます。"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"ルーマニア語"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"アップデートを確認中に不具合が発生しました。"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"1分前アップデートしました"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"ブロックされた広告数:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"page"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"韓国語"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"このドメイン上の自分のブロックを取り消し"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"手動でフィルターを編集："
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"フィルターリストへのリンクを表示する："
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (推奨)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"ステップ1： ブロック対象の指定"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"AdBlock に携わる人々を見つけ出す助けになる<a>ページ</a>もあります！"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"サイト："
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"こちら"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock は最新版です！"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"英語のみ"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"古いバージョンの AdBlock を使用しています。 <a href='#'>拡張機能ページ</a> を開き、「デベロッパーモード」を有効にし、「今すぐ拡張機能をアップデート」をクリックしてください。"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlockは一時停止しています。"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"AdBlock の一時停止を解除"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antisocial フィルターリスト（ソーシャルメディアボタンを削除します）"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"広告を検索中・・・<br/><br/><i>少々お待ちください。</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlockはこのページでは無効になっています。"
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"広告をブロック"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"注意： on all other sites you will see ads!<br>This overrules all other filters for those sites."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"AdBlock のアップデートがあります！ $here$ を開いてアップデートしてください。 <br> 注意: アップデートを自動受信したい場合は、 Safari > 設定 > 拡張機能 > アップデートをクリックしてください。 <br> そしてオプション「自動的にアップデートをインストールする」にチェックを入れてください。",
     "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock の仕組みを確認したいですか？"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlockカスタムフィルター (推奨)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Type"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"これは何ですか?"
+  },
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"一般"
+  },
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"または Chrome 用 AdBlock"
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"翻訳者："
+  },
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"例： ~site1.com|~site2.com|~news.site3.org"
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"動画とフラッシュ"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"ほとんどの広告はフィルターリストでブロックされます。オプションとして更に："
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -882,245 +571,39 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"URL直接指定："
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"または Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"あなたは古いバージョンのSafariを使用しています。AdBlockの全機能を利用していただくには最新バージョンが必要です。<a>今すぐアップデート</a>."
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"登録"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- 言語を選択 -- "
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Safari のメニュー&rarr; 設定 &rarr; 拡張機能をクリックしてください。"
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"広告ブロックをやめる："
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock の仕組みを確認したいですか？"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"広告はまだ表示されますか？"
-  },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"サポート"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"ブルガリア語"
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"失敗！"
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"フィルターは設定ページで変更可能："
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"手動でフィルターを編集："
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"イタリア語"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"スライダーを広告が見えなくなるまでスライドをしてください。"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"最新版では何が変わりましたか？<a style='cursor:pointer;'>変更履歴</a>をご確認ください！"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"スロバキア語"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Firefoxでも広告は表示されますか？"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"このページでは実行しない"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"これらのサイトの広告をブロックする："
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"<a>サポートサイト</a>でお知らせください！"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"最終ステップ： 何故これは広告になるのでしょうか？"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"AdBlockで使用できる容量を超えました。フィルターリストにあるフィルターを幾つか除外してください！"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"フィルターが無効： $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK！"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"設定ページを使って自分で広告をブロックします！"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"一般"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"others"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"フィルターが指定されていません！"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"unknown"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"フィンランド語"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"日本語"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"支払える分だけお支払いください！"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"フィルターリストの問題です。報告はこちら： $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"AdBlock <b>以外</b>の全ての拡張機能の隣にある「有効」チェックボックスのチェックを外してください。  <b>AdBlock は有効のままにしてください</b>。"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"ブロックされている要素："
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"フィルターリストへのリンクを表示する："
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"注意: 報告は公開される場合があります。私的な情報を含める前にご留意ください。"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"英語のみ"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"キャンセル"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"周りに広める"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages AdBlock won't run on."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Firefoxでも表示されるかどうかをチェックしてください $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"このフィルターリストを適用し、ページを更新して要素が消去できたか確認してください。 $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"広告を報告するには、インターネットに接続されていなければなりません。"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"質問、または新たなアイディアがありますか？"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"はい"
-  },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"決定"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (推奨)"
+  "typepage":{
+    "description":"A resource type",
+    "message":"page"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1130,5 +613,562 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"広告はまだ表示されますか？"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"others"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"こちらをクリック： <a>フィルターをアップデート！</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"イタリア語"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"ボタンを非表示にするには、 opera://extensions を開き、「ツールバーから非表示にする」オプションにチェックを入れてください。そのオプションのチェックを外すと再び表示されるようになります。"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"アップデートを確認中に不具合が発生しました。"
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Safari のメニュー&rarr; 設定 &rarr; 拡張機能をクリックしてください。"
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"ページ："
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"広告のあるページを更新してください。"
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"無効にしました。"
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"ラトビア語"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"このページにある広告をブロック"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"ブロック！"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"広告ブロックをやめる："
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"特定の YouTube チャンネルのホワイトリスト化を許可する"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"どの言語でページは書かれていますか？"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"このページにある広告をレポート"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"リストから削除"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"フィルターの取得に失敗しました！"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"まだ、フラッシュ内とプラグインにより出てくる広告はブロックができません。これらの広告の対処ついてはブラウザのサポートとWebKitの対応待ちです。"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages AdBlock won't run on."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"hiding"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Does the ad appear in or before a film or any other plugin like a Flash game?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"ロシア語およびウクライナ語"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"スペイン語"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"この広告をブロック"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"警告： 指定されたフィルターはページの$elementtype$要素をすべてブロックします！",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"いいえ"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"このページで AdBlock を有効にする"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"フィルターは設定ページで変更可能："
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"ボタンを隠す"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"失敗！"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"AdBlockを一時停止"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"このフィルターリストを適用し、ページを更新して要素が消去できたか確認してください。 $list_title$",
+    "placeholders":{
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"英語"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"右クリックメニューに項目を追加する。"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"設定ページを使って自分で広告をブロックします！"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"ロシア語"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"広告を見つけたら、バグ報告ではなく、<a>広告報告</a>をしてください！"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"あなたは古いバージョンのSafariを使用しています。AdBlockの全機能を利用していただくには最新バージョンが必要です。<a>今すぐアップデート</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (プライバシー保護)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ will be $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"URL直接指定："
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"完了！"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"別の言語用のフィルターを追加: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"読み込み中・・・"
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"私たちのチームがデバッグ情報をいくらか要求しましたか？ それについては <a href='#' id='debug'>こちら</a>をクリック！"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"マルウェア対策"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"デバック情報を更新履歴に表示(AdBlockの動作が重くなります)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Firefoxをお持ちではない場合は $chrome$ インストールしてください。",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"スライダーを広告が見えなくなるまでスライドをしてください。"
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"AdBlockで使用できる容量を超えました。フィルターリストにあるフィルターを幾つか除外してください！"
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"バグが有りましたか？"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"フィルターリスト"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"私は上級者ユーザーです。詳細設定を見せてください。"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"中国語"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"image"
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"フィルターリストに登録・・・"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"$matchcount$個のアイテムを発見しました。",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"1時間前アップデートしました"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- 言語を選択 -- "
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"インドネシア語"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"フィルターが無効： $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"編集"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"合計 $count$ 件",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"サポート"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"URLで広告をブロック"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"キャンセル"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"保存を忘れずに！"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"バージョン $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"この質問の目的は、誰があなたの報告を受け取るべきか決定することです。この質問に不適切に回答した場合、間違った人物に報告が送られてしまい、そのために、無視されてしまうことになる場合があります。"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"広告ブロックフィルターのリスト"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"ソースコードは <a>自由に入手できます</a>！"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"オランダ語"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"手動でフィルターを入力して、OKを押してください。"
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"<b>1</b>個のアイテムを発見しました。"
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"このリストを掃除:"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"$hours$時間前にアップデートしました",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"戻る"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock設定"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"ベータ"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"必要以上に登録をしないでください。追加する度に重くなりますので！リストの作成者、その他のリストは<a>こちら</a>。"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"アップデートを確認中 (数秒しかからないはずです)..."
+  },
+  "filterhungarian":{
+    "description":"language",
+    "message":"ハンガリー語"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"適用するドメインを入力"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"アップデートされました"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"$minutes$分前にアップデートしました",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"チェコ語"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"スウェーデン語"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock サポート"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Type"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"フランス語"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"1分前アップデートしました"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - 詳細はこちら"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run AdBlock on..."
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,665 +1,177 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - 미차단 광고 보고"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"광고 차단 필터 목록"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"사이트 : "
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"특정 YouTube 채널에 대한 화이트리스트 허용"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"오빠부대 성가심 (웹상에 성가신 요소 제거)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - 상세 내용 보기"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"브라우져를 통해 광고가 노출된 사이트에 접속하십시오."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"스웨덴어"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"형식"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"차단 필터 추가"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"러시아어"
+    "message":"덴마크어"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"자발적 기부"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"SNS를 통해 공유하기"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"구독 중지"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"그리스어"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"중국어"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"요소 숨김 필터"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"비디오와 플래시"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"악성 코드로부터 보호"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"광고를 숨기기 위해 필요한 속성을 지정하십시오."
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocial 필터 목록 (소셜 미디어 버튼 제거)"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"뒤로"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"질문 또는 제안할 게 있나요?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"사용자가 지정한 필터로 광고를 차단/허용할 수 있습니다."
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"소스 코드는 <a>무료로 배포</a>됩니다."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"사이트/페이지 허용 필터"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"현재 페이지에서 <b>1</b>개 요소와 일치합니다."
-  },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"주의 : 필터를 잘못 작성하면 웹 페이지에 이상 증상이 발생하거나 페이지를 불러오는 속도가 느려질 수 있습니다!<br/>필터 작성 방법은 표준화된 필터 정보를 제공하는 애드블록 플러스 홈페이지를 참고하십시오 : <a>바로가기</a>"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"구독 필터를 가져오는데 실패했습니다!"
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"일반 옵션"
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"다음 사이트를 허용합니다."
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"현재 이 언어에 대한 구독 필터를 지원하지 않습니다.<br/>이 언어를 지원하는 적절한 구독 필터를 찾아보십시오 : $link$<br/>그렇지 않으면 사용자 필터를 추가하십시오.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"추가"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"고급사용자 옵션 보기"
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"차단 필터"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"툴바 버튼 숨기기"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"자동으로 업데이트 됩니다. 또한 <a>바로 업데이트</a> 가능합니다. "
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"최신의 구독 필터로 업데이트합니다. <a>업데이트</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"형식 : ~site1.com|~site2.com|~news.site3.org"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"사용 중지됨."
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"현재 페이지에서 $matchcount$개 요소와 일치합니다.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"AdBlock에 이바지하는 사람들을 소개하는 <a>페이지</a> 또한 확인할 수 있습니다. "
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"인도네시아어"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"형식"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"AdBlock 업데이트가 준비되어있습니다! $here$에서 업데이트 하십시오. <br> 참고: 자동으로 업데이트 하고 싶다면, Safari > Preferences > Extensions > Updates<br> 를 클릭하고 '자동으로 업데이트 설치' 옵션에 체크하세요.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"터키어"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"이게 뭐죠?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"사용자 설정 필터 목록"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"구독 필터를 구독한 후 <b>미차단 광고</b>나 <b>차단 오류</b>가 있으면 해당 국가별 필터 유지자에게 신고하십시오.<br/>필터 유지자 연락처 및 전체 구독 필터 목록 : <b><a>바로가기</a></b><br/>비슷한 기능을 하는 구독 필터가 많으면 느려질 수 있으니 필요한 구독 필터만 추가하십시오."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"스타일시트"
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"제거"
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"이 질문은 여러분의 리포트를 접수할 사람을 가려내기 위함입니다. 답변이 정확하지 않을 시 엉뚱한 사람에게 리포트가 전달될 수 있고, 따라서 처리되지 않을 수 있게 됩니다."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"폴란드어"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"마우스 오른쪽 버튼 메뉴에 메뉴 아이템 추가"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"마우스 커서가 위치해 있는 광고 숨기기"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"$hours$시간 전에 업데이트됨",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"$seconds$초 전에 업데이트됨",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"우리 팀으로부터 디버깅 정보를 요청받으셨나요? <a href='#' id='debug'>여기</a>를 클릭해주세요."
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"객체"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"헝가리어"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"올바르지 않은 URL은 삭제됩니다."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"참고: 여러분께서 제공하신 정보는 공개되어질 수 있습니다. 내용 작성 시 개인정보에 대해 유의하시기 바랍니다. "
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"페이지를 다시 로드합니다."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"페이지"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"네덜란드어"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"저장하는 것을 잊지마십시오!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ : $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"닫기"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"<b>숨기려는 요소 :</b><br/>"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"경고 : 필터가 지정되지 않았습니다!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"허용된 페이지"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"비지정 사이트 허용 필터"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"옵션"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"사이트 허용"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"구독 필터를 가져오는 중이니 잠시만 기다려주십시오..."
   },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"차단된 광고들:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock custom filters (애드블록 구독 필터)"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"플래시나 다른 플러그인의 내부 광고 차단 기능은 아직 지원하지 않습니다. 브라우저와 웹키트에서 그 기능을 지원하기를 기다리고 있습니다."
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"다른 언어로 필터 추가: "
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"라트비아어"
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"다음 텍스트를 포함하는 URL 차단"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS와 일치하는 요소 숨김"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"버튼을 보이지 않게 하려면 opera://extensions 에 접속하여 'Hide from toolbar' 옵션을 체크하십시오. 해당 옵션에 대한 체크를 해제하므로써 다시 보이도록 설정할 수 있습니다."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"숨기려는 광고를 클릭하십시오."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"미차단 광고 보고"
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"속성 지정 후 '추가' 버튼을 누르십시오.<br/>"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"러시아어와 우크라이나어"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"스크립트"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock 지원 방법"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"사용자 필터 관리"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock은 현재 최신버젼입니다!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"사이트 허용"
-  },
-  "filterisraeli":{
+  "filterjapanese":{
     "description":"language",
-    "message":"히브리어"
+    "message":"일본어"
   },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"죄송합니다. 구독 필터에 의해 허용된 페이지입니다."
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"해당 도메인에 대한 제한 풀기"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"필터를 알맞게 입력한 후 확인을 누르십시오."
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"1일 전에 업데이트됨"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"베타"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"오빠부대 성가심 (웹상에 성가신 요소 제거)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"이 페이지에서 $count$",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"1시간 전에 업데이트됨"
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"올바르지 않은 URL은 삭제됩니다."
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"$version$ 버전",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"폴란드어"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"일반 옵션"
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"구독 필터 목록"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"기타 언어"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS와 일치하는 요소 숨김"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"숨겨진 요소"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"<b>구독 필터</b>"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"플래시 게임의 광고 또는 비디오 내부와 시작하기 전에 광고와 같이 다른 플러그인에 광고가 존재합니까?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"기타 필터 목록"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"또는 Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"추가"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"완료됨!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"현재 페이지의 광고 숨기기"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"닫기"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"체크하지 않음"
   },
-  "lang_english":{
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"다음 사이트를 허용합니다."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"비지정 사이트 허용 필터"
+  },
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"주의 : 필터를 잘못 작성하면 웹 페이지에 이상 증상이 발생하거나 페이지를 불러오는 속도가 느려질 수 있습니다!<br/>필터 작성 방법은 표준화된 필터 정보를 제공하는 애드블록 플러스 홈페이지를 참고하십시오 : <a>바로가기</a>"
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"영어"
+    "message":"슬로바키아어"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"<b>사용자 필터</b>"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"사용 중지"
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"[옵션] 지정된 사이트에만 적용"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"한국어"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"페이지 : "
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"버그를 발견하셨나요?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"1단계 : 숨기려는 요소 선택"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"체코어"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"과도하게 많은 구독 필터를 애드블록에 추가하면 인터넷 성능이 저하될 수 있습니다."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"또는 Chrome 전용 AdBlock"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"요소 숨김 마법사"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"예"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"광고가 브라우져를 통해 노출되어있습니까?"
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"마지막 단계 : 속성 지정"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"현재 페이지 허용"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"덴마크어"
+    "message":"루마니아어"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"버튼을 보이지 않게 하려면 버튼 위에 마우스 오른쪽 버튼을 클릭한 후 Hide Button 을 선택하십시오. chrome://chrome/extensions 에서 다시 보이도록 설정할 수 있습니다."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"히브리어"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"기타 언어"
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"체코어와 스로바키아어"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"기타 필터 목록"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"옵션"
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"자동으로 업데이트 됩니다. 또한 <a>바로 업데이트</a> 가능합니다. "
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"프레임"
+    "message":"기타"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"편집"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"사이트/페이지 허용 필터"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"광고를 찾는 중...<br/><br/><i>잠시만 기다려주십시오.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"터키어"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"광고를 차단하지 않을 사이트 또는 페이지의 URL을 입력하십시오."
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"업데이트 확인 중(몇 초 이내에 곧 끝납니다)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"과도하게 많은 구독 필터를 애드블록에 추가하면 인터넷 성능이 저하될 수 있습니다."
   },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"해당 페이지에 AdBlock 적용"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"총 $count$",
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"현재 이 언어에 대한 구독 필터를 지원하지 않습니다.<br/>이 언어를 지원하는 적절한 구독 필터를 찾아보십시오 : $link$<br/>그렇지 않으면 사용자 필터를 추가하십시오.",
     "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"광고가 있는 웹 페이지를 새로 고치십시오."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Firefox $chrome$ 이 없다면 설치하십시오.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -667,210 +179,391 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"숨기려는 광고를 클릭하십시오."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"스타일시트"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock 업데이트"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"아니오"
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"광고를 차단하기 위해 문맥 메뉴로 광고 영역을 숨기거나 사용자 필터를 직접 추가하십시오."
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"죄송합니다. 구독 필터에 의해 허용된 페이지입니다."
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"1일 전에 업데이트됨"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"필터가 지정되지 않았습니다!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"독일어"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"구독 필터 목록"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"AdBlock 을 <b>제외한</b> 모든 익스텐션 옆의 '사용' 체크박스 해제. <b>AdBlock 사용을 유지함</b>."
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"그리스어"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"$seconds$초 전에 업데이트됨",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"속성 지정 후 '추가' 버튼을 누르십시오.<br/>"
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"브라우져를 통해 광고가 노출된 사이트에 접속하십시오."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"<a>지원 사이트</a>를 통해 알려주시기 바랍니다."
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"지정된 사이트를 제외한 모든 사이트의 광고 허용"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"<b>사용자 필터</b>"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"광고리포트를 전송하시려면 인터넷에 접속되어있어야 합니다."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"확인"
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"요소 숨김 필터"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - 미차단 광고 보고"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"불가리아어"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"새로이 갱신된 내용이 궁금하신가요? <a style='cursor:pointer;'>변경이력</a>에서 확인하세요! "
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"사이트 허용"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"사용자 설정 필터 목록"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"차단 필터 추가"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"우크라이나어"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"$minutes$분 전에 업데이트됨",
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"광고를 차단하지 않을 사이트 또는 페이지의 URL을 입력하십시오."
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"경고 : 필터가 지정되지 않았습니다!"
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"다음 텍스트를 포함하는 URL 차단"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"허용"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Firefox $chrome$ 에서 확인",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"프랑스어"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"혹시 차단되어야 할 광고가 보여지고 있다면 버그 리포트 대신 <a>광고 리포트</a>를 해주시기 바랍니다."
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"지금 업데이트됨"
   },
   "savebutton":{
     "description":"Save button",
     "message":"저장"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"주의 : 지정된 사이트의 광고는 차단하지만 그외 다른 사이트의 광고는 허용합니다."
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"$host$ 에서 생성한 $count$ 개의 차단내역을 삭제하시겠습니까?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"구독 필터를 추가하는 중..."
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"선택"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"사용자 필터 관리"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Hulu.com 동영장 재생 안되는 문제 해결 (브라우져 재시작 필요함)"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"핀란드어"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"$days$일 전에 업데이트됨",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"프레임"
+    "message":"객체"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"광고를 숨기기 위해 필요한 속성을 지정하십시오."
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"체코어와 스로바키아어"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"구버젼의 AdBlock 을 사용하고 있습니다. <a href='#'>익스텐션</a> 으로 가서 '개발자 모드'를 활성화한 후 '익스텐션 바로 업데이트' 를 클릭하세요."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock - 애드블록 옵션"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"위 목록 삭제"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"콘솔 로그에 차단/요소 숨김 상태 기록 (애드블록의 필터 처리 속도가 느려짐)"
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"AdBlock 작동 유지"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"독일어"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"주의 : 이 필터는 $elementtype$ 요소를 모두 숨깁니다!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"여기"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Hulu.com 동영장 재생 안되는 문제 해결 (브라우져 재시작 필요함)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"허용"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"웹 페이지가 어떤 언어로 작성되었습니까?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"$host$ 에서 생성한 $count$ 개의 차단내역을 삭제하시겠습니까?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"이미지"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"한국어 번역 공헌자 :"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"로딩 중..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"광고를 차단하기 위해 문맥 메뉴로 광고 영역을 숨기거나 사용자 필터를 직접 추가하십시오."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"버튼을 보이지 않게 하려면 버튼 위에 마우스 오른쪽 버튼을 클릭한 후 Hide Button 을 선택하십시오. chrome://chrome/extensions 에서 다시 보이도록 설정할 수 있습니다."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"루마니아어"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"업데이트 확인 중 문제가 발생했습니다."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"1분 전에 업데이트됨"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"차단된 광고들:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"페이지"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"한국어"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"해당 도메인에 대한 제한 풀기"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"사용자 필터 목록"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"필터 목록에 링크 표시"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (영어권 기본 구독 필터)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"1단계 : 숨기려는 요소 선택"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"AdBlock에 이바지하는 사람들을 소개하는 <a>페이지</a> 또한 확인할 수 있습니다. "
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"사이트 : "
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"여기"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock은 현재 최신버젼입니다!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"페이지를 다시 로드합니다."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"영문 전용"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"구버젼의 AdBlock 을 사용하고 있습니다. <a href='#'>익스텐션</a> 으로 가서 '개발자 모드'를 활성화한 후 '익스텐션 바로 업데이트' 를 클릭하세요."
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"사용 중지됨."
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"AdBlock 작동 유지"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antisocial 필터 목록 (소셜 미디어 버튼 제거)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"광고를 찾는 중...<br/><br/><i>잠시만 기다려주십시오.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"허용된 페이지"
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"요소 숨김 마법사"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"주의 : 지정된 사이트의 광고는 차단하지만 그외 다른 사이트의 광고는 허용합니다."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"AdBlock 업데이트가 준비되어있습니다! $here$에서 업데이트 하십시오. <br> 참고: 자동으로 업데이트 하고 싶다면, Safari > Preferences > Extensions > Updates<br> 를 클릭하고 '자동으로 업데이트 설치' 옵션에 체크하세요.",
     "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock이 어떻게 만들어지는지 궁금하세요?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock custom filters (애드블록 구독 필터)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"형식"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"이게 뭐죠?"
+  },
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"<b>일반</b>"
+  },
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"또는 Chrome 전용 AdBlock"
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"한국어 번역 공헌자 :"
+  },
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"형식 : ~site1.com|~site2.com|~news.site3.org"
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"비디오와 플래시"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"사용자가 지정한 필터로 광고를 차단/허용할 수 있습니다."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -882,249 +575,39 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"구독 필터의 URL : "
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"또는 Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"구버젼의 Safari를 사용중입니다. 최신 버젼을 사용하면 AdBlock을 일시적으로 멈추고, 웹사이트들에 대한 화이트리스트를 작성하거나, 광고 리포트를 작성하기 위한 AdBlock 툴바 버튼을 사용할 수 있게 됩니다. <a>지금 업그레이드</a>"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"추가"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- 언어 선택 -- "
-  },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Safari menu &rarr; Preferences &rarr; Extensions 클릭."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"허용 필터 추가"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock이 어떻게 만들어지는지 궁금하세요?"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"광고가 여전히 존재합니까?"
-  },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"지원"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"불가리아어"
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"실패함"
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"다음 필터는 옵션 페이지에서 변경할 수 있습니다."
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"사용자 필터 목록"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"이탈리아어"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"웹 페이지의 광고가 숨겨질 때까지 슬라이더를 움직이십시오.<br/>"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"새로이 갱신된 내용이 궁금하신가요? <a style='cursor:pointer;'>변경이력</a>에서 확인하세요! "
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"슬로바키아어"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"광고가 브라우져를 통해 노출되어있습니까?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"현재 페이지 허용"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"지정된 사이트를 제외한 모든 사이트의 광고 허용"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"<a>지원 사이트</a>를 통해 알려주시기 바랍니다."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"마지막 단계 : 속성 지정"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"AdBlock 이 허용하는 저장공간을 초과했습니다. 일부 필터 목록을 삭제해주시기 바랍니다."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"필터가 올바르지 않습니다. $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"확인"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"옵션 페이지에 이 광고를 차단할 수 있는 필터를 추가할 수 있습니다. 고맙습니다!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"<b>일반</b>"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"other"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"필터가 지정되지 않았습니다!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"기타"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"핀란드어"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"오디오/비디오"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"일본어"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"자발적 기부"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"이것은 구독 필터의 문제이며, 그것을 신고해주십시오 : $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"AdBlock 을 <b>제외한</b> 모든 익스텐션 옆의 '사용' 체크박스 해제. <b>AdBlock 사용을 유지함</b>."
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"<b>숨기려는 요소 :</b><br/>"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"필터 목록에 링크 표시"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"참고: 여러분께서 제공하신 정보는 공개되어질 수 있습니다. 내용 작성 시 개인정보에 대해 유의하시기 바랍니다. "
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"영문 전용"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"취소"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"SNS를 통해 공유하기"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"슬라이더를 움직여 광고 허용 사이트의 범위를 조절하십시오."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Firefox $chrome$ 에서 확인",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"$list_title$를 구독한 후 웹 페이지를 다시 열어보십시오.",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"광고리포트를 전송하시려면 인터넷에 접속되어있어야 합니다."
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"질문 또는 제안할 게 있나요?"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"예"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"스페인어"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"선택"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (영어권 기본 구독 필터)"
+  "typepage":{
+    "description":"A resource type",
+    "message":"페이지"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1134,5 +617,562 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"광고가 여전히 존재합니까?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"other"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"최신의 구독 필터로 업데이트합니다. <a>업데이트</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"이탈리아어"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"버튼을 보이지 않게 하려면 opera://extensions 에 접속하여 'Hide from toolbar' 옵션을 체크하십시오. 해당 옵션에 대한 체크를 해제하므로써 다시 보이도록 설정할 수 있습니다."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"업데이트 확인 중 문제가 발생했습니다."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Safari menu &rarr; Preferences &rarr; Extensions 클릭."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"페이지 : "
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"광고가 있는 웹 페이지를 새로 고치십시오."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"구독 중지"
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"오디오/비디오"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"라트비아어"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"현재 페이지의 광고 숨기기"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"추가"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"허용 필터 추가"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"특정 YouTube 채널에 대한 화이트리스트 허용"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"웹 페이지가 어떤 언어로 작성되었습니까?"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"미차단 광고 보고"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"제거"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"구독 필터를 가져오는데 실패했습니다!"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"플래시나 다른 플러그인의 내부 광고 차단 기능은 아직 지원하지 않습니다. 브라우저와 웹키트에서 그 기능을 지원하기를 기다리고 있습니다."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"슬라이더를 움직여 광고 허용 사이트의 범위를 조절하십시오."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"숨겨진 요소"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"플래시 게임의 광고 또는 비디오 내부와 시작하기 전에 광고와 같이 다른 플러그인에 광고가 존재합니까?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"러시아어와 우크라이나어"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"스페인어"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"마우스 커서가 위치해 있는 광고 숨기기"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"주의 : 이 필터는 $elementtype$ 요소를 모두 숨깁니다!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"아니오"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"해당 페이지에 AdBlock 적용"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"다음 필터는 옵션 페이지에서 변경할 수 있습니다."
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"툴바 버튼 숨기기"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"실패함"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"사용 중지"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"$list_title$를 구독한 후 웹 페이지를 다시 열어보십시오.",
+    "placeholders":{
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"영어"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"마우스 오른쪽 버튼 메뉴에 메뉴 아이템 추가"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"옵션 페이지에 이 광고를 차단할 수 있는 필터를 추가할 수 있습니다. 고맙습니다!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"러시아어"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"혹시 차단되어야 할 광고가 보여지고 있다면 버그 리포트 대신 <a>광고 리포트</a>를 해주시기 바랍니다."
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"구버젼의 Safari를 사용중입니다. 최신 버젼을 사용하면 AdBlock을 일시적으로 멈추고, 웹사이트들에 대한 화이트리스트를 작성하거나, 광고 리포트를 작성하기 위한 AdBlock 툴바 버튼을 사용할 수 있게 됩니다. <a>지금 업그레이드</a>"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ : $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"구독 필터의 URL : "
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"완료됨!"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"다른 언어로 필터 추가: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"로딩 중..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"우리 팀으로부터 디버깅 정보를 요청받으셨나요? <a href='#' id='debug'>여기</a>를 클릭해주세요."
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"악성 코드로부터 보호"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"콘솔 로그에 차단/요소 숨김 상태 기록 (애드블록의 필터 처리 속도가 느려짐)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Firefox $chrome$ 이 없다면 설치하십시오.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"웹 페이지의 광고가 숨겨질 때까지 슬라이더를 움직이십시오.<br/>"
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"AdBlock 이 허용하는 저장공간을 초과했습니다. 일부 필터 목록을 삭제해주시기 바랍니다."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"버그를 발견하셨나요?"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"스크립트"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"<b>구독 필터</b>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"고급사용자 옵션 보기"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"중국어"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"이미지"
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"구독 필터를 추가하는 중..."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"현재 페이지에서 $matchcount$개 요소와 일치합니다.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"1시간 전에 업데이트됨"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- 언어 선택 -- "
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"프레임"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"인도네시아어"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"필터가 올바르지 않습니다. $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"편집"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"총 $count$",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"지원"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"차단 필터"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"취소"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"저장하는 것을 잊지마십시오!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"$version$ 버전",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"이 질문은 여러분의 리포트를 접수할 사람을 가려내기 위함입니다. 답변이 정확하지 않을 시 엉뚱한 사람에게 리포트가 전달될 수 있고, 따라서 처리되지 않을 수 있게 됩니다."
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"광고 차단 필터 목록"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"소스 코드는 <a>무료로 배포</a>됩니다."
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"네덜란드어"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"필터를 알맞게 입력한 후 확인을 누르십시오."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"현재 페이지에서 <b>1</b>개 요소와 일치합니다."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"위 목록 삭제"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"$hours$시간 전에 업데이트됨",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"뒤로"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock - 애드블록 옵션"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"베타"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"구독 필터를 구독한 후 <b>미차단 광고</b>나 <b>차단 오류</b>가 있으면 해당 국가별 필터 유지자에게 신고하십시오.<br/>필터 유지자 연락처 및 전체 구독 필터 목록 : <b><a>바로가기</a></b><br/>비슷한 기능을 하는 구독 필터가 많으면 느려질 수 있으니 필요한 구독 필터만 추가하십시오."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"업데이트 확인 중(몇 초 이내에 곧 끝납니다)..."
+  },
+  "filterhungarian":{
+    "description":"language",
+    "message":"헝가리어"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"[옵션] 지정된 사이트에만 적용"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"지금 업데이트됨"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"$minutes$분 전에 업데이트됨",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"체코어"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"스웨덴어"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock 지원 방법"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"형식"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"프랑스어"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"1분 전에 업데이트됨"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"프레임"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - 상세 내용 보기"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"사이트 허용"
   }
 }

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -1,719 +1,195 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Rapporter en annonse"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Liste over annonsefiltre"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Side:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Ikke blokker annonser på bestemte YouTube-kanaler"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Vi kan ikke finne skadevare vi kjenner igjen."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"I den nettleseren, abonner på de samme filterlistene som her."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - Klikk for mer informasjon"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"I den nettleseren, last inn nettsiden med annonsen."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Svensk"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Hva er nytt i den siste versjonen? Se  <a style='cursor:pointer;'>oppdateringloggen</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blokker flere annonser:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Russisk"
+    "message":"Dansk"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Betal det du vil!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Hjelp oss å spre ordet!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Avmeldt."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blokker en annonse ved dens URL"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Gresk"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Kinesisk"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Skjul en del av en nettside"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videoer og Flash"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Beskyttelse mot skadelig programvare"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Tror du dette vil være sant om annonsen hver gang du besøker denne siden?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Aktiver AdBlock på denne siden"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Tilbake"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Vis antall annonser blokkert på AdBlock-knappen"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Har du et spørsmål eller en idé?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Latvisk"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Filterlistene blokkerer de fleste annonsene på nettet.  Du kan også:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Kildekoden er <a>fritt tilgjengelig </a>!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Vis annonser på en nettside eller domene"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Det samsvarer med <b>ett</b> element på denne siden."
-  },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Vær forsiktig: hvis du gjør en feil her kan mange andre filtere, inkludert de offisielle, bli ødelagt!<br/>Les <a>filtersyntax-veiledningen</a> for å lære hvordan du kan legge til avanserte svarteliste- og hvitelistefiltere."
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Hvitelist kanalen $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Generelle innstillinger"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Datamaskinen din kan være infisert av skadevare. Klikk<a>her</a> for mer informasjon."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock vil ikke kjøre på disse sidene:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Vi har ikke en standard filerliste for det språket.<br />Vennligst prøv å finne en passende liste som støtter dette språket $link$ eller blokker denne annonsen kun for deg selv på 'Tilpass'-fanen.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Abboner"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Jeg er en erfaren bruker, vis meg avanserte innstillinger"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Tsjekkisk"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Skjul denne knappen"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Jeg vil laste ned oppdateringer automatisk; du kan også <a>oppdatere nå</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Trykk her: <a>Oppdater filtere!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~side1.no|~side2.com|~nyheter.side3.org"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Siste steg: Hva gjør dette til en annonse?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Det samsvarer med $matchcount$ elementer på denne siden.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Vi har en <a>side</a> som hjelper deg med å finne folkene bak AdBlock også!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesisk"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Type"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Det er en oppdatering tilgjengelig for AdBlock. Klikk $here$ for å oppdatere. <br>Merk: Hvis du vil ha automatiske oppdateringer, klikk på Safari -> Innstillinger -> Utvidelser -> Oppdateringer<br> og huk av for \"installer oppdateringer automatisk\".",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Tyrkisk"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Hva er dette?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Egendefinerte filterlister"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Ikke abonner på flere enn du trenger -- hver liste bremser deg ned bittelitt! Bidragsytere og flere lister finner du <a>her</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"stildefinisjon"
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Ikke sikker?</b> bare klikk 'Blokker!' nedenfor."
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Formålet med dette spørsmålet er å avgjøre hvem som skal motta rapporten. Hvis du svarer på dette spørsmålet feil, vil rapporten sendes til feil person, så det kan bli ignorert."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polsk"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Legg til elementer på høyreklikkmenyen"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokker denne annonsen"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"oppdatert for $hours$ timer siden",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"oppdatert for $seconds$ sekunder siden",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Har vårt team etterspurt feilsøkingsinfo? Klikk <a href='#' id='debug'>her</a>for det!"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Ungarsk"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Ugyldig liste-URL. Den vil bli slettet."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Merk: rapporten din kan bli offentlig tilgjengelig. Husk det før du inkluderer noe privat."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Last inn siden på nytt."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"side"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Nederlandsk"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Ikke glem å lagre!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ kommer til å være $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Lukk"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blokkert element:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filteret er ugyldig: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Advarsel: intet filter valgt!"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Skal AdBlock varsle deg når skadelig programvare oppdages?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Vis reklame <i>overalt</i> unntatt på disse domenene..."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Denne AdBlock-funksjonen virker ikke fordi den bruker gammel teknologi. Du kan svarteliste eller hviteliste ressurser manuelt under Tilpass-fanen på Alternativer-siden."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Vis antall annonser blokkert i AdBlock-menyen"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Valg"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Ikke kjør AdBlock på..."
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Henter... vennligst vent."
   },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Blokkerte annonser:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock-tilpassede filtre (anbefalt)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Legg til filter for et annet språk: "
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Generelt"
   },
   "filterannoyances":{
     "description":"A filter list",
     "message":"Fanboy's Annoyances (fjerner irritasjonsmomenter på nettet)"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"De tidligere deaktiverte utvidelsene har blitt aktivert igjen."
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS til å samsvare med"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"For å fjerne knappen, gå til opera://extensions og sett en markering i boksen ved menylinjen \"Skjul fra verktøylinjen\" . For å vise knappen igjen må markeringen du satte ved menylinjen fjernes ."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Klikk på annonsen, så hjelper jeg deg med å blokkere den."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Rapporter en annonse på denne siden"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Russisk og ukrainsk"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skript"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock Støtte"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Tilpass AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock er oppdatert!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ totalt",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Hebraisk"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Beklager, AdBlock er deaktivert på denne siden av en av dine filerlister."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokker URLer som inneholder denne teksten"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Angre all blokkering på dette domene"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Venligst skriv det korrekte filteret nedenfor og trykk OK"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"oppdatert for en dag siden"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ på denne siden",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"oppdatert for en time siden"
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Ugyldig liste-URL. Den vil bli slettet."
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versjon $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Polsk"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Generelle innstillinger"
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Fjern fra liste"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Annet"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS til å samsvare med"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"skjuler"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Filterlister"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Vises annonsen i eller før en film eller hvilket som helst annet objekt som et Flash-spill?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Andre filtre"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"eller Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokker!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Fullført!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blokker en annonse på denne siden"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Lukk"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Jeg vil ikke sjekke dette."
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock vil ikke kjøre på disse sidene:"
   },
-  "lang_english":{
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Vis reklame <i>overalt</i> unntatt på disse domenene..."
+  },
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Vær forsiktig: hvis du gjør en feil her kan mange andre filtere, inkludert de offisielle, bli ødelagt!<br/>Les <a>filtersyntax-veiledningen</a> for å lære hvordan du kan legge til avanserte svarteliste- og hvitelistefiltere."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Engelsk"
+    "message":"Slovakisk"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Tilpass"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Sett AdBlock på pause"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Er du sikker på at du vil abonnere på filterlisten $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Åpne utvidelses-siden for å aktivere utvidelser som har vært deaktivert."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domenet til siden den skal påvirke"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Koreansk"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Side:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Har du funnet en feil?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Steg 1: Finn ut hva du skal blokkere."
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Jo flere lister du velger, dess tregere kjører AdBlock. Hvis du bruker for mange lister, kan nettleseren slutte å virke på noen sider. Trykk OK for å abonnere på listen uansett."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"eller AdBlock for Chrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokker en annonse"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Ja"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Vises reklamen også i den nettleseren?"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Lagre"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Ikke kjør på denne siden"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Dansk"
+    "message":"Rumensk"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"For å skjule knappen, høyreklikk og velg Skjul knappen. Du kan vise den igjen ved å skrive chrome://extensions/ i adresselinjen."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebraisk"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Denne AdBlock-funksjonen virker ikke fordi den bruker gammel teknologi. Du kan svarteliste eller hviteliste ressurser manuelt under Tilpass-fanen på Alternativer-siden."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Tsjekkisk og slovakisk"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Andre filtre"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Valg"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Datamaskinen din kan være infisert av skadevare. Klikk<a>her</a> for mer informasjon."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Jeg vil laste ned oppdateringer automatisk; du kan også <a>oppdatere nå</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"ramme"
+    "message":"ukjent"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Rediger"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Vis annonser på en nettside eller domene"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Finner annonser...<br/><br/><i>Dette tar bare øyeblikk.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Tyrkisk"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domenet eller urlen hvor AdBlock ikke skal blokkere noe"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Ser etter oppdateringer (dette bør kun ta et par sekunder)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Jo flere lister du velger, dess tregere kjører AdBlock. Hvis du bruker for mange lister, kan nettleseren slutte å virke på noen sider. Trykk OK for å abonnere på listen uansett."
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Drag glidebryteren helt til annonsen(e) er blokkert riktig på nettsiden, og det blokkerte elementet ser brukbart ut."
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Deaktiver på sider under dette domenet"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Oppdater siden annonsen er på."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Installer Firefox $chrome$ hvis du ikke har det.",
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Abonner på denne filterlisten, og prøv igjen: $list_title$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Vi har ikke en standard filerliste for det språket.<br />Vennligst prøv å finne en passende liste som støtter dette språket $link$ eller blokker denne annonsen kun for deg selv på 'Tilpass'-fanen.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -721,234 +197,377 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Klikk på annonsen, så hjelper jeg deg med å blokkere den."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"stildefinisjon"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock-oppdateringer"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nei"
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Beklager, AdBlock er deaktivert på denne siden av en av dine filerlister."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Skal AdBlock varsle deg når skadelig programvare oppdages?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"oppdatert for en dag siden"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Ingen filtre valgt!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Tysk"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Abonner på filterlister"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Gresk"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"oppdatert for $seconds$ sekunder siden",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Ikke sikker?</b> bare klikk 'Blokker!' nedenfor."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"I den nettleseren, last inn nettsiden med annonsen."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"La oss få vite det på vår <a>støtteside</a>!"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokker kun annonser på disse sidene:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Tilpass"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"For å rapportere en annonse, må du være tilkoblet Internett."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Hvitelist kanalen $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Skjul en del av en nettside"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"ramme"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Vis antall annonser blokkert i AdBlock-menyen"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Rapporter en annonse"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgarsk"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Deaktiver på sider under dette domenet"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Egendefinerte filterlister"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blokker flere annonser:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukrainsk"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"oppdatert for $minutes$ minutter siden",
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Type"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domenet eller urlen hvor AdBlock ikke skal blokkere noe"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Ikke kjør AdBlock på..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokker URLer som inneholder denne teksten"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Ekskluder"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Sjekk i Firefox $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "filtereasylist_plus_french":{
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Siste steg: Hva gjør dette til en annonse?"
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Ser bra ut"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Tilpass AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Vi kan ikke finne skadevare vi kjenner igjen."
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Rett en feil som gjør at video ikke spilles på Hulu.com (krever omstart av nettleseren)"
+  },
+  "filtereasylist_plus_finnish":{
     "description":"language",
-    "message":"Fransk"
+    "message":"Finsk"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ELLER</b> så kan du bare klikke på denne knappen, så fikser vi alt: <a>Deaktiver alle andre utvidelser</a>"
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Skjul denne knappen"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktivt objekt"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"oppdatert akkurat nå"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Lagre"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Advarsel: på alle andre sider vil du se annonser! <br>Dette overskriver alle andre filtre for disse sidene."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Skru av disse varslene"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Abonner på filterlister..."
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Liste over annonsefiltre"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"oppdatert for $days$ dager siden",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"ramme"
+    "message":"interaktivt objekt"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (beskyttelse av privatliv)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Tror du dette vil være sant om annonsen hver gang du besøker denne siden?"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Lær mer om skadelig programvare"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Tsjekkisk og slovakisk"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Du bruker en gammel versjon av AdBlock. Vennligst gå til <a href=#>utvidelsessiden</a>, aktiver 'Utviklermodus' og klikk 'Oppdater utvidelser nå'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock-innstillinger"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Rydd opp i denne listen"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisosial filterliste (tar bort knapper for sosiale media)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Vis feilsøkningsopplysninger i Konsoll (som vil gjøre AdBlock tregere)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Du har overskredet lagringsplassen i din Dropbox. Vennligst fjern noen oppføringer fra dine egendefinerte eller deaktiverte filter, og prøv igjen."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Start AdBlock igjen"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Tysk"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Vær forsiktig: Dette filteret blokkerer alle $elementtype$-elementer på siden!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"her"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Ja"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Rett en feil som gjør at video ikke spilles på Hulu.com (krever omstart av nettleseren)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Ekskluder"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Hvilket språk er siden skrevet på?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Er du sikker på at du vil ta bort $count$ blokkeringene som du har fjernet på $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"bilde"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Bidragsytere til oversettelsen:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"LASTER..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Høyreklikk på en annonse på en side for å blokkere den -- eller blokker den manuelt her."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"For å skjule knappen, høyreklikk og velg Skjul knappen. Du kan vise den igjen ved å skrive chrome://extensions/ i adresselinjen."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumensk"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Rediger deaktiverte filtre:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Noe gikk galt under sjekkingen av oppdateringer."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"For å gjemme knappen, høyreklikk på Safaris verktøylinje og velg tilpass verktøylinje. Deretter dra AdBlockknappen ut av verktøylinjen. Du kan vise den igjen ved å dra den tilbake til verktøylinjen"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"oppdatert for ett minutt siden"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Blokkerte annonser:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"side"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Koreansk"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Angre all blokkering på dette domene"
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Manuelt endre dine filtere:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Vis linker til filterlistene"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (anbefalt)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Steg 1: Finn ut hva du skal blokkere."
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Vi har en <a>side</a> som hjelper deg med å finne folkene bak AdBlock også!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Side:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"her"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Hvis du ser en annonse, ikke send en feilrapport. Send en <a>annonserapport</a> i stedet!"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock er oppdatert!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Last inn siden på nytt."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Bare Engelsk"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Du bruker en gammel versjon av AdBlock. Vennligst gå til <a href=#>utvidelsessiden</a>, aktiver 'Utviklermodus' og klikk 'Oppdater utvidelser nå'"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock er satt på pause."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ELLER</b> så kan du bare klikke på denne knappen, så fikser vi alt: <a>Deaktiver alle andre utvidelser</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Hva er nytt i den siste versjonen? Se  <a style='cursor:pointer;'>oppdateringloggen</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antisosial filterliste (tar bort knapper for sosiale media)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Finner annonser...<br/><br/><i>Dette tar bare øyeblikk.</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Jeg er en erfaren bruker, vis meg avanserte innstillinger"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"I den nettleseren, abonner på de samme filterlistene som her."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokker en annonse"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Advarsel: på alle andre sider vil du se annonser! <br>Dette overskriver alle andre filtre for disse sidene."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"De tidligere deaktiverte utvidelsene har blitt aktivert igjen."
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Vil du se hva som får AdBlock til å virke?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock-tilpassede filtre (anbefalt)"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Hva er dette?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -960,273 +579,83 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Eller skriv en URL:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"eller AdBlock for Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Du bruker en gammel versjon av Safari. Få den siste versjonen for å bruke AdBlock-verktøylinjen for å pause AdBlock, hviteliste nettsider, og rapporter annonser. <a>Oppdater nå</a>."
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" --Velg språk-- "
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Bidragsytere til oversettelsen:"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~side1.no|~side2.com|~nyheter.side3.org"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Klikk på Safari-menyen &rarr; Innstillinger &rarr; Utvidelser."
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Stopp blokkering av annonser:"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videoer og Flash"
   },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Den mest populære Chrome utvidelsen med over 40 millioner brukere! Blokkerer annonser over hele internett."
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Filterlistene blokkerer de fleste annonsene på nettet.  Du kan også:"
   },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Er den fremdeles der?"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"For å gjemme knappen, høyreklikk på Safaris verktøylinje og velg tilpass verktøylinje. Deretter dra AdBlockknappen ut av verktøylinjen. Du kan vise den igjen ved å dra den tilbake til verktøylinjen"
   },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Støtte"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Du har overskredet lagringsplassen i din Dropbox. Vennligst fjern noen oppføringer fra dine egendefinerte eller deaktiverte filter, og prøv igjen."
   },
-  "filtereasylist_plus_bulgarian":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Bulgarsk"
+    "message":"Ungarsk"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Vil du se hva som får AdBlock til å virke?"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"eller Chrome"
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Mislyktes!"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Abboner"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filteret, som kan bli forandret under innstillingssiden:"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Betal det du vil!"
   },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"Manuelt endre dine filtere:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Følgende filter:<br/>$filter$<br/> har en feil: <br/>$message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Type"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovakisk"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Abonner på filterlister"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Vises reklamen også i den nettleseren?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Ikke kjør på denne siden"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokker kun annonser på disse sidene:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"La oss få vite det på vår <a>støtteside</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock er satt på pause."
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Du har brukt mer plass enn AdBlock har til rådighet! Vennligst avslutt abonnementet fra noen filterlister!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Vi kan ikke blokkere annonser inni Flash og andre objekter enda. Vi venter på støtte fra nettleseren og WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, du kan fremdeles blokkere denne reklamen selv, under innstillinger. Takk!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Generelt"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"annet"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Ingen filtre valgt!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"ukjent"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finsk"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock er deaktivert på denne siden."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"lyd/film"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japansk"
+    "message":"Rediger deaktiverte filtre:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Dette er et filterlisteproblem. Rapporter det her: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Fjern krysset ved Aktiver ved alle utvidelser <b>unntatt</b> for AdBlock. <b>La AdBlock være aktivert</b>."
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blokkert element:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Vis linker til filterlistene"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Merk: rapporten din kan bli offentlig tilgjengelig. Husk det før du inkluderer noe privat."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Bare Engelsk"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Avbryt"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Hjelp oss å spre ordet!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Du kan skyve under for å endre akkurat hvilke sider AdBlock ikke kjører på."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Sjekk i Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Aktiver kompatibilitetsmodus for ClickToFlash"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Abonner på denne filterlisten, og prøv igjen: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"For å rapportere en annonse, må du være tilkoblet Internett."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (anbefalt)"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Kunne ikke hente dette filteret."
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italiensk"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Spansk"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Ser bra ut"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Hvis du ser en annonse, ikke send en feilrapport. Send en <a>annonserapport</a> i stedet!"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Har du et spørsmål eller en idé?"
+  "typepage":{
+    "description":"A resource type",
+    "message":"side"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1236,5 +665,616 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Er den fremdeles der?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"annet"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Trykk her: <a>Oppdater filtere!</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Italiensk"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"For å fjerne knappen, gå til opera://extensions og sett en markering i boksen ved menylinjen \"Skjul fra verktøylinjen\" . For å vise knappen igjen må markeringen du satte ved menylinjen fjernes ."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Noe gikk galt under sjekkingen av oppdateringer."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Klikk på Safari-menyen &rarr; Innstillinger &rarr; Utvidelser."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Side:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Oppdater siden annonsen er på."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Avmeldt."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"lyd/film"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Latvisk"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blokker en annonse på denne siden"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokker!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Stopp blokkering av annonser:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Ikke blokker annonser på bestemte YouTube-kanaler"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Hvilket språk er siden skrevet på?"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Fjern krysset ved Aktiver ved alle utvidelser <b>unntatt</b> for AdBlock. <b>La AdBlock være aktivert</b>."
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Rapporter en annonse på denne siden"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Fjern fra liste"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Vi kan ikke blokkere annonser inni Flash og andre objekter enda. Vi venter på støtte fra nettleseren og WebKit."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Du kan skyve under for å endre akkurat hvilke sider AdBlock ikke kjører på."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"skjuler"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock er deaktivert på denne siden."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Vises annonsen i eller før en film eller hvilket som helst annet objekt som et Flash-spill?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Russisk og ukrainsk"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spansk"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokker denne annonsen"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Vær forsiktig: Dette filteret blokkerer alle $elementtype$-elementer på siden!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Aktiver kompatibilitetsmodus for ClickToFlash"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nei"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Aktiver AdBlock på denne siden"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filteret, som kan bli forandret under innstillingssiden:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Vis antall annonser blokkert på AdBlock-knappen"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Mislyktes!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Sett AdBlock på pause"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Følgende filter:<br/>$filter$<br/> har en feil: <br/>$message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Engelsk"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Legg til elementer på høyreklikkmenyen"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, du kan fremdeles blokkere denne reklamen selv, under innstillinger. Takk!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Russisk"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Er du sikker på at du vil ta bort $count$ blokkeringene som du har fjernet på $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Du bruker en gammel versjon av Safari. Få den siste versjonen for å bruke AdBlock-verktøylinjen for å pause AdBlock, hviteliste nettsider, og rapporter annonser. <a>Oppdater nå</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (beskyttelse av privatliv)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ kommer til å være $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Eller skriv en URL:"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Fullført!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Start AdBlock igjen"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Legg til filter for et annet språk: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"LASTER..."
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Høyreklikk på en annonse på en side for å blokkere den -- eller blokker den manuelt her."
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Beskyttelse mot skadelig programvare"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Vis feilsøkningsopplysninger i Konsoll (som vil gjøre AdBlock tregere)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Installer Firefox $chrome$ hvis du ikke har det.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Du har brukt mer plass enn AdBlock har til rådighet! Vennligst avslutt abonnementet fra noen filterlister!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Den mest populære Chrome utvidelsen med over 40 millioner brukere! Blokkerer annonser over hele internett."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Har du funnet en feil?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Lær mer om skadelig programvare"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skript"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Filterlister"
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Skru av disse varslene"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Kinesisk"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filteret er ugyldig: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Abonner på filterlister..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Åpne utvidelses-siden for å aktivere utvidelser som har vært deaktivert."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Det samsvarer med $matchcount$ elementer på denne siden.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"oppdatert for en time siden"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" --Velg språk-- "
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Drag glidebryteren helt til annonsen(e) er blokkert riktig på nettsiden, og det blokkerte elementet ser brukbart ut."
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesisk"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"bilde"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Rediger"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Kunne ikke hente dette filteret."
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ totalt",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Støtte"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blokker en annonse ved dens URL"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Avbryt"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Ikke glem å lagre!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versjon $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Formålet med dette spørsmålet er å avgjøre hvem som skal motta rapporten. Hvis du svarer på dette spørsmålet feil, vil rapporten sendes til feil person, så det kan bli ignorert."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Er du sikker på at du vil abonnere på filterlisten $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Kildekoden er <a>fritt tilgjengelig </a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Nederlandsk"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Venligst skriv det korrekte filteret nedenfor og trykk OK"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Det er en oppdatering tilgjengelig for AdBlock. Klikk $here$ for å oppdatere. <br>Merk: Hvis du vil ha automatiske oppdateringer, klikk på Safari -> Innstillinger -> Utvidelser -> Oppdateringer<br> og huk av for \"installer oppdateringer automatisk\".",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Det samsvarer med <b>ett</b> element på denne siden."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japansk"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Rydd opp i denne listen"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"oppdatert for $hours$ timer siden",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Tilbake"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock-innstillinger"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Ikke abonner på flere enn du trenger -- hver liste bremser deg ned bittelitt! Bidragsytere og flere lister finner du <a>her</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Ser etter oppdateringer (dette bør kun ta et par sekunder)..."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Annet"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domenet til siden den skal påvirke"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"oppdatert akkurat nå"
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Har vårt team etterspurt feilsøkingsinfo? Klikk <a href='#' id='debug'>her</a>for det!"
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"oppdatert for $minutes$ minutter siden",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Tsjekkisk"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Svensk"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock Støtte"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Type"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Fransk"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"oppdatert for ett minutt siden"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"ramme"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - Klikk for mer informasjon"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Advarsel: intet filter valgt!"
   }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Voeg een schermafbeelding toe:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Geen gekende malware gevonden."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Abonneer je in die browser op dezelfde filters als in deze browser."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Herlaad de pagina met de desbetreffende advertentie in die browser."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Zweeds"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Meer advertenties blokkeren:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Russisch"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Afgemeld."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Chinees"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Als je een werkende filter hebt kunnen creëren met de \"Blokkeer een advertentie\" wizard, kopieer deze dan in het vak hieronder:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocial filter (verwijdert social media knoppen)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Heb je een advertentie gevonden op een webpagina? We zullen je helpen om de juiste plaats te vinden om deze te melden!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Toon het aantal geblokkeerde advertenties op de AdBlock knop"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"De broncode is <a>gratis beschikbaar</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"1 minuut geleden bijgewerkt"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Deze filter kon niet worden opgehaald!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Herstart Safari aub om content blocking volledig uit te schakelen."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blokkeer een advertentie via haar URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Verberg deze knop"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Ik werk de filters automatisch bij, maar je kan deze ook <a>nu bijwerken</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formaat: ~website1.com|~website2.com|~nieuws.website3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estlands"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Type"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Er is een update voor AdBlock beschikbaar! Ga $here$ om te updaten. <br>Opmerking: Om updates automatisch te installeren klik je op Safari > Voorkeuren > Extensies > Updates <br>en selecteer je de optie 'Installeer updates automatisch'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Wat is dit?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Meld je niet aan voor meer filters dan je nodig hebt. Elke filter zal je browser iets vertragen! Credits en andere filters kan je <a>hier</a> terugvinden."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Deze AdBlock functie werkt niet op deze website omdat deze verouderde technologie gebruikt. Je kan items op deze website manueel blokkeren of uitsluiten in het 'Personaliseren' menu van de opties pagina."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Pools"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Lees meer over ons aanvaardbare advertenties programma."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"$seconds$ seconden geleden bijgewerkt",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object subverzoek"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Hongaars"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Let op: dit rapport kan openbaar gemaakt worden. Dit betekent dat iedereen je rapport kan zien. Denk hieraan voor je persoonlijke informatie toevoegt."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Schakel aub enkele filters uit. Meer informatie in de AdBlock Opties."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Oorsprong van de filter:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, AdBlock is op deze site uitgeschakeld door een van uw filter lijsten."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"De filter is ongeldig: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Waarschuwing: geen filter opgegeven!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"Deze pagina is uitgesloten van het blokkeren van advertenties."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Toon <i>overal</i> advertenties, behalve op bepaalde domeinen"
+    "message":"Heb je een vraag of een nieuw idee?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Opties"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"XML HTTP verzoek"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Geblokkeerde advertenties:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Voeg filters toe voor een andere taal: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Klik op de advertentie, en ik zal je helpen om deze te blokkeren."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"een zoekopdracht voor foto's (bv. <i>zeilboot race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Als je een advertentie ziet, maak dan geen foutenrapport, maar een <a>advertentierapport</a>!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Geweldig! Je bent helemaal klaar."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Anders"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock Ondersteuning"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"AdBlock Personaliseren"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Vereiste informatie ontbreekt of is ongeldig. Vul aub alle vragen in met een rode rand."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Fout bij het bewaren van het ge-uploade bestand."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Vul aub de juiste filter hieronder in en klik daarna op OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Stap 1: Uitzoeken wat er geblokkeerd moet worden"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Deens"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (aanbevolen)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ op deze pagina",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Subframe"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"1 uur geleden bijgewerkt"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Koreaans"
+    "message":"Pools"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"of Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Hoe heet je?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"De populairste Chrome extensie met meer dan 40 miljoen gebruikers! Blokkeert advertenties op het internet."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Toon alle verzoeken"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Ik wil dit niet controleren"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Opties"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Ja"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Maak mijn blokkeringen ongedaan op dit domein"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Personaliseren"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pauzeer AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Weet je zeker dat je je wilt abonneren op de $title$ filter lijst?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Waar precies op de pagina bevindt de advertentie zich? Hoe ziet hij eruit?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"of AdBlock voor Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"stylesheet"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Inhoud blokkering regels limiet overschreden"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Advertenties zoeken...<br/><br/><i>Dit duurt maar eventjes.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"een Flickr fotoset URL (bv. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Het domein of de URL waar AdBlock niets moet blokkeren"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ in totaal",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Klaar! We zullen binnenkort contact met je opnemen, waarschijnlijk binnen één dag, of 2 indien het een feestdag is. Ga in de tussentijd eens op zoek naar een e-mail van AdBlock. Daarin vind je namelijk een link naar je ticket op de help site. Als je liever het gesprek via e-mail volgt, is dat natuurlijk ook mogelijk!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nee"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Er is iets fout gegaan. De geladen items zijn niet doorgestuurd. Deze pagina zal nu sluiten. Probeer de website opnieuw te laden."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Oekraïens"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"$minutes$ minuten geleden bijgewerkt",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"We hebben je afgemeld van de aanvaardbare advertenties omdat u safari content blocking hebt ingeschakeld. Je kan slechts 1 van deze 2 opties tegelijk selecteren. (<a>Waarom?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Je bent niet langer geabonneerd op de aanvaardbare advertenties filter."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Malware bescherming"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Opslaan"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Waarschuwing: Advertenties zullen zichtbaar zijn op alle andere websites<br>Dit heeft voorrang op alle andere filters op deze website"
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Deze meldingen uitschakelen"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Aanmelden voor filters"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Je gebruikt een oude versie van AdBlock. Open de <a href='#'>pagina voor extensiebeheer</a>, schakel 'Ontwikkelaarmodus' in en klik op 'Extensies nu bijwerken'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock Opties"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Controleren op malware die advertenties zou kunnen injecteren:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Toon debug resultaten in de Console Logs (dit vertraagt AdBlock)."
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Je hebt de Dropbox opslagruimte overschreden. Gelieve enkele regels van je gepersonaliseerde of uitgeschakelde filters te verwijderen en het opnieuw te proberen."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"AdBlock hervatten"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Los problemen met Hulu.com op (vereist het opnieuw opstarten van de browser)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS waarop dit moet worden toegepast"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Uitsluiten"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Schakel alle extensies behalve AdBlock uit:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Vertaling door"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"LADEN..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Klik met de rechtermuisknop op een advertentie om hem te blokkeren -- of blokkeer het hier handmatig."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Opmerking: Het whitelisten (toelaten van advertenties) op een pagina of website is niet ondersteund met Safari Inhoud Blokkering geactiveerd."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"We gebruiken dit enkel indien we contact met je moeten opnemen voor als we nog meer informatie nodig hebben."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Bewerk uitgeschakelde filters:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Schakel Safari Content Blocking in"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Wat is je e-mailadres?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Om deze knop te verbergen, klik met de rechtermuisknop op de Safari werkbalk, kies pas knoppenbalk aan en sleep hierna de AdBlock knop uit de knoppenbalk. Je kan de knop opnieuw weergeven door het terug naar de werkbalk te slepen."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Er is een fout opgetreden bij de verwerking van je aanvraag."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"pagina"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Foto's toevoegen"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Klaar! We hebben de pagina met de advertentie herladen. Controleer deze pagina om te zien of de advertentie verdwenen is. Kom daarna terug naar deze pagina en beantwoordt de vraag hieronder."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Of voer een URL in:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Je gebruikt een oude versie van Safari. Werk aub je browser bij naar de nieuwste versie om volledige functionaliteit te behouden. <a>Update nu</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Klik op het Safari menu &rarr; Voorkeuren &rarr; Extensies."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Minder advertenties blokkeren:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokkeer!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Zie je de advertentie nog steeds?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bulgaars"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Geweldig! Laten we nu op zoek gaan naar welke extensie de oorzaak is. Ga door elke extensie en schakel deze een voor een in. De extensie die de advertentie(s) terugbrengt is degene die je moet verwijderen om van de advertenties af te geraken."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Mislukt!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Je filters handmatig bewerken:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italiaans"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"pop-up"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Type"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slowaaks"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Aanmelden voor officiële filters"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Je kan dit terug activeren en de websites waar je van houdt ondersteunen door het selectievakje 'Laat sommige, niet-opdringerige advertenties toe' weer in te schakelen."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Zie je de advertentie ook in die browser?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Blokkeer niets op deze pagina"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Litouws"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Laat het ons weten op onze <a>ondersteuningswebsite</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock is gepauzeerd."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"We kunnen nog geen advertenties in Flash of andere plugins blokkeren. We wachten op ondersteuning van de browser en WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Algemeen"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Indien je deze advertenties liever niet ziet, kan je de Aanvaardbare Advertenties filter uitzetten."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Je computer is mogelijk besmet met malware. Klik <a>hier</a> voor meer informatie."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"overig"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Geen filter opgegeven!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"onbekend"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japans"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Laat sommige, niet-opdringerige advertenties toe"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Annuleren"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Versleep de balk hieronder om aan te geven waar precies AdBlock niets moet doen."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"We hebben Safari Content Blocking uitgeschakeld omdat je opteerde om niet-opdringerige advertenties toe te staan. Je kan slechts 1 van deze 2 opties tegelijk selecteren. (<a>Waarom?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Laatste stap: meld het probleem aan ons."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Controle in Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Om een advertentie te rapporteren moet je verbinding hebben met het internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (aanbevolen)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"een Flickr fotoset ID (bv. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Advertentie rapporteren"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Advertentie Blokkerende Filters"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Hoe?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Sta het uitsluiten van specifieke Youtube kanalen toe"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Derde partij"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (verwijdert ergernissen)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - klik voor details"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"$hours$ uur geleden bijgewerkt",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Russisch en Oekraïens"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Wat is er nieuw in de laatste versie? Bekijk de <a style='cursor:pointer;'>changelog</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"De extensies die uitgeschakeld werden zijn nu opnieuw ingeschakeld."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grieks"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Verberg een deel van een pagina"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video's en Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Welke kenmerken gelden er elke keer als je deze pagina bezoekt?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Activeer AdBlock op deze pagina"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Vorige"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"De filters blokkeren al de meeste advertenties op het web. Je kan ook:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Controleer de Aanvaardbare Advertenties filters:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Toon advertenties op een pagina of domein"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Dit geldt voor <b>1</b> item op deze pagina."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Ik wil dit niet controleren"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Herstart Safari aub om content blocking volledig uit te schakelen."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Pas op: als je hier een fout maakt kunnen de andere filters, inclusief de officiële, onbruikbaar worden!<br/>Lees de <a>filter syntaxis uitleg (Engelstalig)</a> voor meer informatie over het maken van filters."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Sluit $name$'s kanaal uit",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Zie je de advertentie ook in die browser?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Algemene opties"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Indien je deze advertenties liever niet ziet, kan je de Aanvaardbare Advertenties filter uitzetten."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock zal niets doen op pagina's die voldoen aan:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"We hebben geen filter lijst voor deze taal.<br/>Probeer $link$ een geschikte lijst te zoeken of blokkeer deze advertentie zelf in de opties van AdBlock.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Aanmelden"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Ik ben een gevorderd gebruiker, toon me de geavanceerde opties"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Spaans"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Geladen op een pagina van het domein: \n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Klik hier: <a>Filters bijwerken</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Hoe meer lijsten je gebruikt, hoe langzamer AdBlock wordt. Teveel lijsten kunnen zelfs je browser laten crashen. Klik op OK om je toch aan te melden voor deze lijst."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Laatste stap: Waarom is dit een advertentie?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Dat geldt voor $matchcount$ items op deze pagina.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We hebben ook een <a>pagina</a> die je toont wie er allemaal achter AdBlock zit!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesisch"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turks"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokkeer een advertentie"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Aangepaste Filters"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"Frame URL: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Het doel van deze vraag is om na te gaan wie je melding moet ontvangen. Als je deze vraag incorrect beantwoordt zal de melding naar de verkeerde persoon gestuurd worden. Dit kan ervoor zorgen dat deze niet behandeld zal worden."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Voeg items toe aan het rechterklik menu"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"selectieschakelaar"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokkeer deze advertentie"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Heeft ons team gevraagd om debug info? Klik dan <a href='#' id='debug'>hier</a>!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Pas AdBlock niet toe op..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Het melden van advertenties is vrijwillig. Het helpt andere mensen doordat de onderhouders van de filters deze advertentie dan kunnen blokkeren voor iedereen. Als je niet het gevoel hebt dat je iemand wil helpen, is dat ok. Sluit deze pagina en <a>blokkeer de advertentie</a> dan gewoon voor jezelf."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Verborgen element"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Laad de pagina opnieuw."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"pagina"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Nederlands"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Deze bestandsnaam is te lang. Geef aub een kortere bestandsnaam."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Vergeet niet op te slaan!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Controleren op updates (duurt maar enkele seconden)..."
+    "message":"Litouws"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Meld je aan voor de volgende lijst en probeer het opnieuw: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Moet AdBlock je waarschuwen als het malware detecteert?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Je computer is mogelijk besmet met malware. Klik <a>hier</a> voor meer informatie."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Toon het aantal geblokkeerde advertenties in het AdBlock menu"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Toon advertenties op een pagina of domein"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Website:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock custom filters (aanbevolen)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Lets"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Zorg ervoor dat je de juiste taalfilter(s) gebruikt:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS waarop dit moet worden toegepast"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Om deze knop te verbergen, ga naar opera://extensions en selecteer de optie 'Verberg van knoppenbalk'. Je kan de knop opnieuw weergeven door deze optie te deselecteren."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Niet zeker?</b> Klik dan gewoon op 'Blokkeer!' hieronder."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Geschikte filter"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Ophalen... even geduld aub."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Alle Bronnen"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock is up-to-date!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Blokkeer niets op pagina's van dit domein"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Hebreeuws"
+    "message":"Slowaaks"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Verplaats de schuifbalk tot de advertentie verdwenen is, en het geblokkeerde element bruikbaar lijkt."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokkeer URL's die deze tekst bevatten"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Enkele foto's toevoegen</b> van Flickr! Je kan volgende zaken invoeren:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"De lijst met filter regels overschrijft de limiet van 50 000 en is automatisch verkleind. Meld je aub af voor enkele filters of schakel de Safari Inhoud Blokkering uit!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"1 dag geleden bijgewerkt"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Aanvaardbare Advertenties (aanbevolen)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Klik hierop: <a>Aanvaardbare Advertenties uitschakelen</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versie $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Installeer AdBlock Plus voor Firefox $chrome$ als je dit niet hebt.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Uit lijst verwijderen"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"We hebben geen filter lijst voor deze taal.<br/>Probeer $link$ een geschikte lijst te zoeken of blokkeer deze advertentie zelf in de opties van AdBlock.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Dat is geen afbeeldingsbestand. Upload aub een .png, .gif of .jpg bestand."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Waarom verstuur je ons geen <a>foutrapport</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"verborgen"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Filters"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Frame domein: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Klik op de advertentie, en ik zal je helpen om deze te blokkeren."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Bovenste frame"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"stylesheet"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"onbekend"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, AdBlock is op deze site uitgeschakeld door een van uw filter lijsten."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Derde partij"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Geen filter opgegeven!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Grieks"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Je gebruikt een oude versie van AdBlock. Open de <a href='#'>pagina voor extensiebeheer</a>, schakel 'Ontwikkelaarmodus' in en klik op 'Extensies nu bijwerken'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Hoe heet je?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Los problemen met Hulu.com op (vereist het opnieuw opstarten van de browser)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Waarschuwing: geen filter opgegeven!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Personaliseren"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Heb je een advertentie gevonden op een webpagina? We zullen je helpen om de juiste plaats te vinden om deze te melden!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estlands"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"AdBlock Personaliseren"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgaars"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Uitgesloten bronnen"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Inhoud blokkering regels limiet overschreden"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Vink de selectievakjes van de fotosets die je wil gebruiken aan."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Pas AdBlock niet toe op..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokkeer URL's die deze tekst bevatten"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Sluiten"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Controle in Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Laatste stap: Waarom is dit een advertentie?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Als je een advertentie ziet, maak dan geen foutenrapport, maar een <a>advertentierapport</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Koreaans"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Je gebruikt een oude versie van Safari. Werk aub je browser bij naar de nieuwste versie om volledige functionaliteit te behouden. <a>Update nu</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Fins"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Oekraïens"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Geen gekende malware gevonden."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Schakel aub enkele filters uit. Meer informatie in de AdBlock Opties."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"We hebben je afgemeld van de aanvaardbare advertenties omdat u safari content blocking hebt ingeschakeld. Je kan slechts 1 van deze 2 opties tegelijk selecteren. (<a>Waarom?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We hebben ook een <a>pagina</a> die je toont wie er allemaal achter AdBlock zit!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"hier"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"pop-up"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"XML HTTP verzoek"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Laad de pagina opnieuw."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"In welke taal is de pagina geschreven?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock is gepauzeerd."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Opties"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"AdBlock hervatten"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Advertenties zoeken...<br/><br/><i>Dit duurt maar eventjes.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"Deze pagina is uitgesloten van het blokkeren van advertenties."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Abonneer je in die browser op dezelfde filters als in deze browser."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokkeer een advertentie"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Waarschuwing: Advertenties zullen zichtbaar zijn op alle andere websites<br>Dit heeft voorrang op alle andere filters op deze website"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Er is een update voor AdBlock beschikbaar! Ga $here$ om te updaten. <br>Opmerking: Om updates automatisch te installeren klik je op Safari > Voorkeuren > Extensies > Updates <br>en selecteer je de optie 'Installeer updates automatisch'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Klaar!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock custom filters (aanbevolen)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Type"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Wat is dit?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japans"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Oorsprong van de filter:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Aanmelden voor officiële filters"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Frame type: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Voeg filters toe voor een andere taal: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Bron"
+    "message":"Geschikte filter"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blokkeer een advertentie op deze pagina"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"De filters blokkeren al de meeste advertenties op het web. Je kan ook:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Zorg ervoor dat je filters bijgewerkt zijn:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Om deze knop te verbergen, klik met de rechtermuisknop op de Safari werkbalk, kies pas knoppenbalk aan en sleep hierna de AdBlock knop uit de knoppenbalk. Je kan de knop opnieuw weergeven door het terug naar de werkbalk te slepen."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Engels"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Je hebt de Dropbox opslagruimte overschreden. Gelieve enkele regels van je gepersonaliseerde of uitgeschakelde filters te verwijderen en het opnieuw te proberen."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Ijslands"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Aanmelden"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Open de extensies pagina om de uitgeschakelde extensies weer in te schakelen."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Opmerking: Het whitelisten (toelaten van advertenties) op een pagina of website is niet ondersteund met Safari Inhoud Blokkering geactiveerd."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domein van de pagina waarop dit moet worden toegepast"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Geblokkeerd element:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"pagina"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"overig"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Klik hier: <a>Filters bijwerken</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Verborgen element"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Om deze knop te verbergen, ga naar opera://extensions en selecteer de optie 'Verberg van knoppenbalk'. Je kan de knop opnieuw weergeven door deze optie te deselecteren."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object subverzoek"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Pagina:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Heb je een fout gevonden?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokkeer!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Sta het uitsluiten van specifieke Youtube kanalen toe"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"een zoekopdracht voor foto's (bv. <i>zeilboot race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"We kunnen nog geen advertenties in Flash of andere plugins blokkeren. We wachten op ondersteuning van de browser en WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Arabisch"
+    "message":"Hongaars"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokkeer deze advertentie"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Activeer AdBlock op deze pagina"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Toon het aantal geblokkeerde advertenties op de AdBlock knop"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Mislukt!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pauzeer AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Tsjechisch"
+    "message":"Engels"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Betaal wat je wil!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Voeg items toe aan het rechterklik menu"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Wil je zien hoe AdBlock werkt?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Ga aub naar <a>onze support website</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"AdBlock Waarschuwing Verwijder Lijst (verwijdert waarschuwingen over het gebruik van ad blockers)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Ongeldige URL naar de filter. Deze filter zal verwijdert worden"
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"pagina"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Bewerk"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Weet je zeker dat je $count$ blokkeringen op $host$ wilt verwijderen?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Heb je een vraag of een nieuw idee?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legende: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Je bent vergeten een schermafbeelding toe te voegen! We kunnen je niet helpen zonder dat we de advertentie(s) zien die je aan ons wilt rapporteren."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>OF</b>, klik gewoon op deze knop om alle bovenstaande dingen te doen: <a>Alle andere extensies uitschakelen</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"$minutes$ minuten geleden bijgewerkt",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Leer meer over malware"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Voeg een schermafbeelding toe:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Roemeens"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Bewerk uitgeschakelde filters:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Subframe"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Herlaad de pagina waarop de desbetreffende advertentie zich bevind."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Schakel Safari Content Blocking in"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Installeer Firefox $chrome$ als je dit nog niet hebt.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Filters"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Als je een werkende filter hebt kunnen creëren met de \"Blokkeer een advertentie\" wizard, kopieer deze dan in het vak hieronder:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Dit bestand is te groot. Zorg ervoor dat het bestand minder dan 10 MB groot is."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock zal niets doen op pagina's die voldoen aan:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Chinees"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"De filter is ongeldig: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Aanmelden voor filters"
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Open de extensies pagina om de uitgeschakelde extensies weer in te schakelen."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Deze meldingen uitschakelen"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turks"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Meld je niet aan voor meer filters dan je nodig hebt. Elke filter zal je browser iets vertragen! Credits en andere filters kan je <a>hier</a> terugvinden."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesisch"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"afbeelding"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ in totaal",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Annuleren"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Vergeet niet op te slaan!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"selectieschakelaar"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"We hebben Safari Content Blocking uitgeschakeld omdat je opteerde om niet-opdringerige advertenties toe te staan. Je kan slechts 1 van deze 2 opties tegelijk selecteren. (<a>Waarom?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Ijslands"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Advertentie Blokkerende Filters"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokkeer alleen advertenties op deze websites:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Geladen op een pagina van het domein: \n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"De extensies die uitgeschakeld werden zijn nu opnieuw ingeschakeld."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Ruim deze filter op"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Help ons om dit te verspreiden!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock updates"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"AdBlock Waarschuwing Verwijder Lijst (verwijdert waarschuwingen over het gebruik van ad blockers)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock Opties"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Er is een fout opgetreden bij de verwerking van je aanvraag."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"1 uur geleden bijgewerkt"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Controleren op updates (duurt maar enkele seconden)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"zojuist bijgewerkt"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Klik met de rechtermuisknop op een advertentie om hem te blokkeren -- of blokkeer het hier handmatig."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Controleren op malware die advertenties zou kunnen injecteren:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock Ondersteuning"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Type"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Verplaats de schuifbalk tot de advertentie verdwenen is, en het geblokkeerde element bruikbaar lijkt."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"1 minuut geleden bijgewerkt"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Geblokkeerde bronnen"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"De volgende informatie zal ook opgenomen worden in het advertentierapport."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Deens"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Controleer de Aanvaardbare Advertenties filters:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Je kan dit terug activeren en de websites waar je van houdt ondersteunen door het selectievakje 'Laat sommige, niet-opdringerige advertenties toe' weer in te schakelen."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Ophalen... even geduld aub."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Ongeldige URL naar de filter. Deze filter zal verwijdert worden"
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Algemene opties"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Vink bij elke extensie het selectievakje 'Ingeschakeld' uit <b>behalve</b> bij die van AdBlock. <b>Houd AdBlock geactiveerd</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Herlaad de pagina met de desbetreffende advertentie in die browser."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Toon <i>overal</i> advertenties, behalve op bepaalde domeinen"
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Je bent vergeten een schermafbeelding toe te voegen! We kunnen je niet helpen zonder dat we de advertentie(s) zien die je aan ons wilt rapporteren."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"En maak handmatig een ticket aan. Kopieer en plak de onderstaande gegevens in de \"Fill in any details you think will help us understand your issue\" sectie."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Om deze knop te verbergen, klik er met de rechtermuisknop op en kies dan voor 'Knop verbergen'. Je kan de knop opnieuw weergeven door naar de volgende pagina te gaan: chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebreeuws"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Deze AdBlock functie werkt niet op deze website omdat deze verouderde technologie gebruikt. Je kan items op deze website manueel blokkeren of uitsluiten in het 'Personaliseren' menu van de opties pagina."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Tsjechisch en Slowaaks"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"We hebben alle andere extensies uitgeschakeld. We zullen nu de pagina met de advertentie herladen. Eventjes geduld aub."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Andere Filters"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Frans"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Ik werk de filters automatisch bij, maar je kan deze ook <a>nu bijwerken</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Geblokkeerd element:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Toon alle verzoeken"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interactief object"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Hoe meer lijsten je gebruikt, hoe langzamer AdBlock wordt. Teveel lijsten kunnen zelfs je browser laten crashen. Klik op OK om je toch aan te melden voor deze lijst."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Geweldig! Je bent helemaal klaar."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Open de <a href='#'>extensies pagina</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Klaar! We zullen binnenkort contact met je opnemen, waarschijnlijk binnen één dag, of 2 indien het een feestdag is. Ga in de tussentijd eens op zoek naar een e-mail van AdBlock. Daarin vind je namelijk een link naar je ticket op de help site. Als je liever het gesprek via e-mail volgt, is dat natuurlijk ook mogelijk!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Lees meer over ons aanvaardbare advertenties programma."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Moet AdBlock je waarschuwen als het malware detecteert?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"zojuist bijgewerkt"
+    "message":"1 dag geleden bijgewerkt"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"Frame URL: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Duits"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Deze bestandsnaam is te lang. Geef aub een kortere bestandsnaam."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"$seconds$ seconden geleden bijgewerkt",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Blokkeer niets op deze pagina"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Laat het ons weten op onze <a>ondersteuningswebsite</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Klaar! We hebben de pagina met de advertentie herladen. Controleer deze pagina om te zien of de advertentie verdwenen is. Kom daarna terug naar deze pagina en beantwoordt de vraag hieronder."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Alle Bronnen"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Sluit $name$'s kanaal uit",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Bron"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Toon het aantal geblokkeerde advertenties in het AdBlock menu"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Advertentie rapporteren"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Hoe?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Blokkeer niets op pagina's van dit domein"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Aangepaste Filters"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Meer advertenties blokkeren:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Vereiste informatie ontbreekt of is ongeldig. Vul aub alle vragen in met een rode rand."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Het domein of de URL waar AdBlock niets moet blokkeren"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Je bent niet langer geabonneerd op de aanvaardbare advertenties filter."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (verwijdert ergernissen)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock heeft een download van een website die bekend is omwille van malware geblokkeerd."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Opslaan"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Niet zeker?</b> Klik dan gewoon op 'Blokkeer!' hieronder."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Laatste stap: meld het probleem aan ons."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Waar precies op de pagina bevindt de advertentie zich? Hoe ziet hij eruit?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Ziet er goed uit"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Sta AdBlock toe om anoniem het gebruik van filters en gegevens te verzamelen"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Om een advertentie te rapporteren moet je verbinding hebben met het internet."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Weet je zeker dat je je wilt abonneren op de $title$ filter lijst?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"$days$ dagen geleden bijgewerkt",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"interactief object"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Welke kenmerken gelden er elke keer als je deze pagina bezoekt?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Geblokkeerde advertenties:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arabisch"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Maak mijn blokkeringen ongedaan op dit domein"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Je filters handmatig bewerken:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Stap 1: Uitzoeken wat er geblokkeerd moet worden"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Vul aub de juiste filter hieronder in en klik daarna op OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Vertaling door"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock is up-to-date!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Alleen in het Engels"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>OF</b>, klik gewoon op deze knop om alle bovenstaande dingen te doen: <a>Alle andere extensies uitschakelen</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Wat is er nieuw in de laatste versie? Bekijk de <a style='cursor:pointer;'>changelog</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (privacybescherming)"
+    "message":"Antisocial filter (verwijdert social media knoppen)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Rapporteer een advertentie op deze pagina"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Malware bescherming"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Ruim deze filter op"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Ik ben een gevorderd gebruiker, toon me de geavanceerde opties"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Duits"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Je gebruikt meer opslagruimte dan AdBlock kan gebruiken. Meldt je aub af voor enkele filterlijsten!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Let op: deze filter blokkeert alle $elementtype$ elementen op de pagina!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"hier"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Wat is je e-mailadres?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"In welke taal is de pagina geschreven?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Wil je zien hoe AdBlock werkt?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Weet je zeker dat je $count$ blokkeringen op $host$ wilt verwijderen?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"afbeelding"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Verberg een deel van een pagina"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"En maak handmatig een ticket aan. Kopieer en plak de onderstaande gegevens in de \"Fill in any details you think will help us understand your issue\" sectie."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Algemeen"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Om deze knop te verbergen, klik er met de rechtermuisknop op en kies dan voor 'Knop verbergen'. Je kan de knop opnieuw weergeven door naar de volgende pagina te gaan: chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"of AdBlock voor Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Roemeens"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video's en Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Er ging iets mis bij het controleren op updates."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"We hebben alle andere extensies uitgeschakeld. We zullen nu de pagina met de advertentie herladen. Eventjes geduld aub."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Uitgesloten bronnen"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Geweldig! Laten we nu op zoek gaan naar welke extensie de oorzaak is. Ga door elke extensie en schakel deze een voor een in. De extensie die de advertentie(s) terugbrengt is degene die je moet verwijderen om van de advertenties af te geraken."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Tsjechisch en Slowaaks"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"of Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Frame type: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formaat: ~website1.com|~website2.com|~nieuws.website3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Selecteer Taal --"
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Installeer AdBlock Plus voor Firefox $chrome$ als je dit niet hebt.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Geblokkeerde bronnen"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Verschijnt de advertentie in of voor een film of andere plugin zoals een Flash spel?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ is gelijk aan $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"De filterregel, die aangepast kan worden in de opties pagina:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"De volgende filter: <br/>$filter$<br/> heeft een fout: <br/>$message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Vink de selectievakjes van de fotosets die je wil gebruiken aan."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Sluiten"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokkeer alleen advertenties op deze websites:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Je gebruikt meer opslagruimte dan AdBlock kan gebruiken. Meldt je aub af voor enkele filterlijsten!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Sta AdBlock toe om anoniem het gebruik van filters en gegevens te verzamelen"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, je kunt deze advertentie steeds voor jezelf blokkeren. Bedankt!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Verstuur"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Fins"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Dit bestand is te groot. Zorg ervoor dat het bestand minder dan 10 MB groot is."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"De volgende informatie zal ook opgenomen worden in het advertentierapport."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Betaal wat je wil!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Dit is een probleem in de filter. Rapporteer het aub hier: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Vink bij elke extensie het selectievakje 'Ingeschakeld' uit <b>behalve</b> bij die van AdBlock. <b>Houd AdBlock geactiveerd</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Let op: dit rapport kan openbaar gemaakt worden. Dit betekent dat iedereen je rapport kan zien. Denk hieraan voor je persoonlijke informatie toevoegt."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Toon URL's van de filters"
+  "filteritalian":{
+    "description":"language",
+    "message":"Italiaans"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Alleen in het Engels"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"een Flickr fotoset ID (bv. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Help ons om dit te verspreiden!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Zie je de advertentie nog steeds?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock heeft een download van een website die bekend is omwille van malware geblokkeerd."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Zorg ervoor dat je de juiste taalfilter(s) gebruikt:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legende: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Zorg ervoor dat je filters bijgewerkt zijn:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Er ging iets mis bij het controleren op updates."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Klik op het Safari menu &rarr; Voorkeuren &rarr; Extensies."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Verstuur"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"een Flickr fotoset URL (bv. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Afgemeld."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Lets"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blokkeer een advertentie op deze pagina"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Minder advertenties blokkeren:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Fout bij het bewaren van het ge-uploade bestand."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Dat geldt voor $matchcount$ items op deze pagina.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Deze filter kon niet worden opgehaald!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Versleep de balk hieronder om aan te geven waar precies AdBlock niets moet doen."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"verborgen"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Verschijnt de advertentie in of voor een film of andere plugin zoals een Flash spel?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Russisch en Oekraïens"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spaans"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Let op: deze filter blokkeert alle $elementtype$ elementen op de pagina!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Activeer de ClickToFlash compatibiliteitsmodus"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nee"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"De filterregel, die aangepast kan worden in de opties pagina:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Verberg deze knop"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Anders"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, je kunt deze advertentie steeds voor jezelf blokkeren. Bedankt!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Russisch"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Waarom verstuur je ons geen <a>foutrapport</a>?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (privacybescherming)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ is gelijk aan $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Of voer een URL in:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"De volgende filter: <br/>$filter$<br/> heeft een fout: <br/>$message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"LADEN..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Heeft ons team gevraagd om debug info? Klik dan <a href='#' id='debug'>hier</a>!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"De lijst met filter regels overschrijft de limiet van 50 000 en is automatisch verkleind. Meld je aub af voor enkele filters of schakel de Safari Inhoud Blokkering uit!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Rapporteer een advertentie op deze pagina"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Toon debug resultaten in de Console Logs (dit vertraagt AdBlock)."
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Frame domein: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"De populairste Chrome extensie met meer dan 40 miljoen gebruikers! Blokkeert advertenties op het internet."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Heb je een fout gevonden?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Tsjechisch"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Dat is geen afbeeldingsbestand. Upload aub een .png, .gif of .jpg bestand."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Enkele foto's toevoegen</b> van Flickr! Je kan volgende zaken invoeren:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Toon URL's van de filters"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Laat sommige, niet-opdringerige advertenties toe"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Zweeds"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Uit lijst verwijderen"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Foto's toevoegen"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Selecteer Taal --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Frans"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Bewerk"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Ondersteuning"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Ga aub naar <a>onze support website</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blokkeer een advertentie via haar URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Om AdBlock te pauzeren met de Inhoud Blokkering geactiveerd, selecteer Safari (in de menubalk) > Voorkeuren > Extensies > AdBlock en schakel 'Schakel AdBlock in' uit."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versie $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Het doel van deze vraag is om na te gaan wie je melding moet ontvangen. Als je deze vraag incorrect beantwoordt zal de melding naar de verkeerde persoon gestuurd worden. Dit kan ervoor zorgen dat deze niet behandeld zal worden."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Het melden van advertenties is vrijwillig. Het helpt andere mensen doordat de onderhouders van de filters deze advertentie dan kunnen blokkeren voor iedereen. Als je niet het gevoel hebt dat je iemand wil helpen, is dat ok. Sluit deze pagina en <a>blokkeer de advertentie</a> dan gewoon voor jezelf."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Ja"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"De broncode is <a>gratis beschikbaar</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Nederlands"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"We gebruiken dit enkel indien we contact met je moeten opnemen voor als we nog meer informatie nodig hebben."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Dit geldt voor <b>1</b> item op deze pagina."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"$hours$ uur geleden bijgewerkt",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Vorige"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Klik hierop: <a>Aanvaardbare Advertenties uitschakelen</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domein van de pagina waarop dit moet worden toegepast"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock updates"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Er is iets fout gegaan. De geladen items zijn niet doorgestuurd. Deze pagina zal nu sluiten. Probeer de website opnieuw te laden."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Leer meer over malware"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Website:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Aanvaardbare Advertenties (aanbevolen)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Ziet er goed uit"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Om AdBlock te pauzeren met de Inhoud Blokkering geactiveerd, selecteer Safari (in de menubalk) > Voorkeuren > Extensies > AdBlock en schakel 'Schakel AdBlock in' uit."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Open de <a href='#'>extensies pagina</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - klik voor details"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Schakel alle extensies behalve AdBlock uit:"
   }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -1,759 +1,199 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Zgłaszanie reklam"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Listy filtrów blokujących reklamy"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Kliknij tutaj: <a>Wyłącz Akceptowane Reklamy</a>"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Domena:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Pozwól dodać do białej listy konkretne kanały YouTube"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Nie znaleziono znanego złośliwego oprogramowania."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Zapisz w tej przeglądarce tę samą listę filtrów, którą masz tutaj."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - kliknij, aby zobaczyć szczegóły"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Otwórz w niej stronę na której widzisz reklamę."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Szwedzki"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Co nowego jest w najnowszej wersji? Zobacz <a style='cursor:pointer;'>listę zmian</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Zablokować więcej reklam:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Rosyjski"
+    "message":"Duński"
   },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Rozszerzenia, które zostały poprzednio wyłączone, zostały włączone ponownie."
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Anulowano subskrypcje."
-  },
-  "filtericelandic":{
+  "filteritalian":{
     "description":"language",
-    "message":"Islandzki"
+    "message":"Włoski"
   },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grecki"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Pomóż w rozpowszechnianiu!"
   },
-  "filterchinese":{
-    "description":"language",
-    "message":"Chiński"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Hiszpański"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Ochrona przed złośliwym oprogramowaniem"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Co według ciebie będzie prawdziwe dla tej reklamy za każdym razem, gdy odwiedzasz tę stronę?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Włącz AdBlocka na tej stronie"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Wróć"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Pokaż liczbę zablokowanych reklam na przycisku AdBlock"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Ostatni krok: Co sprawia, że to reklama?"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Masz pytanie lub nowy pomysł?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Łotewski"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Listy filtrów blokują większość reklam.  Możesz również:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Kod źródłowy jest <a>swobodnie dostępny</a>!"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Dowiedz się więcej o programie Akceptowanych Reklam."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Pokazuj reklamy na stronie lub domenie"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Ilość elementów pasujących do filtru na tej stronie: <b>1</b>."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Ukryj część strony"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Dodaj kanał $name$ do białej listy",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opcje ogólne"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Twój komputer może być zainfekowany przez złośliwe oprogramowanie.  Kliknij <a>tutaj</a> aby uzyskać więcej informacji."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock nie będzie działać na żadnej stronie pasującej do:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Nie mamy domyślnej listy filtrów dla tego języka.<br/>Spróbuj znaleźć odpowiednią listę dla tego języka $link$ albo zablokuj tą reklamę dla siebie poprzez zakładkę 'Dostosuj' na stronie opcji.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Subskrybuj"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Jestem zaawansowanym użytkownikiem, pokaż mi zaawansowane opcje"
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Zablokuj reklamę poprzez jej adres URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Ukryj ten przycisk"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Aktualizacje są pobierane automatycznie; możesz również kliknąć przycisk: <a>Aktualizuj</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Kliknij: <a>Zaktualizuj filtry!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estoński"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Ilość elementów pasujących do filtru na tej stronie: $matchcount$.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Mamy <a>stronę</a>, aby pomóc Ci dowiedzieć się o ludziach pracujących nad AdBlockiem!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonezyjski"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Typ"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Jest aktualizacja dla AdBlock'a! Przejdź $here$ aby zaktualizować. <br>Uwaga: Jeśli chcesz otrzymywać aktualizacje automatycznie, po prostu kliknij na Safari > Preferencje > Rozszerzenia > Aktualizacje <br> i wybierz opcję \"Zainstaluj aktualizacje automatycznie\".",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turecki"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Co to jest?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Własne listy filtrów"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Nie subskrybuj większej ilości list niż potrzebujesz, każda trochę spowalnia przeglądarkę! Więcej list można znaleźć <a>tutaj</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"css"
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Usuń listę filtrów"
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Celem tego pytania jest ustalenie kto powinien otrzymać twój raport. Jeśli odpowiesz błędnie na to pytanie to raport zostanie wysłany do niewłaściwych osób, więc może zostać zignorowany."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polski"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dodaj pozycję do menu pod prawym przyciskiem"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Filmy i Flash"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Zablokuj tę reklamę"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"ilość godzin od aktualizacji: $hours$",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"ilość sekund od aktualizacji: $seconds$",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Czy nasz zespół poprosił o pewne informacje debugowania? Kliknij <a href='#' id='debug'>tutaj</a>, aby je uzyskać!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"obiekt interaktywny"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Węgierski"
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Zgłaszanie reklam jest dobrowolne. Pomaga ono innym użytkownikom poprzez włączanie listy filtrów, aby wszyscy mogli blokować zgłoszone reklamy. Jeśli nie masz ochoty na bezinteresowną pomoc innym - w porządku. Zamknij tę stronę i <a>zablokuj reklamę</a> tylko dla siebie."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Uwaga: Twój raport będzie dostępny publicznie. Pamiętaj, aby nie zamieszczać w nim niczego prywatnego."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Przeładuj stronę."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"strona"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Holenderski"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Nie zapomnij zapisać!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ będzie ustawiony jako $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Zamknij"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Zablokuj element:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filtr jest niepoprawny: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Ostrzeżenie: nie określono żadnego filtru!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Zezwalaj AdBlockowi na zbieranie anonimowych danych list filtrów"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Czy AdBlock ma powiadamiać Cię, gdy wykryje złośliwe oprogramowanie?"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Jeśli widzisz reklamę, nie twórz zgłoszenia błędu, stwórz <a>zgłoszenie reklamy</a>!"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Pokazuj reklamy <i>wszędzie</i> z wyjątkiem tych domen..."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Ta funkcja AdBlocka nie działa na tej stronie, ponieważ wykorzystuje starą technologię. Możesz dodać zasoby do czarnej lub białej listy ręcznie w zakładce „Dostosuj” na stronie opcji."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Pokaż liczbę zablokowanych reklam w menu AdBlock"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Opcje"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Nie włączaj AdBlock'a na..."
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Zablokowanych reklam:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Własne filtry AdBlock'a (zalecane)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Dodaj filtry dla innego języka: "
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Kłopoty fanboy'ów (usuwa kłopoty w internecie)"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Upewnij się, że używasz właściwego filtru języka:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS pasujący do"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Aby ukryć przycisk, przejdź do opera://extensions i zaznacz opcję \"Nie pokazuj na pasku narzędzi\". Możesz przywrócić ten przycisk ponownie, odznaczając tą opcję."
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Kliknij w reklamę, aby rozpocząć proces blokowania."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Zgłoś reklamę na stronie"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Świetnie! Wszystko gotowe."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Rosyjski"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Pobieram subskrypcję... proszę czekać."
   },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Uwaga: jeśli popełnisz błąd, może on zablokować inne filtry, także te oficjalne!<br/>Przeczytaj <a>poradnik tworzenia składni filtrów</a> aby nauczyć się jak dodawać zaawansowane wpisy do czarnej i białej listy filtrów.."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Ogólne"
   },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Wsparcie dla AdBlock'a"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Dostosuj AdBlock'a"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock jest aktualny!"
-  },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Dowiedz się więcej o złośliwym oprogramowaniu"
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Hebrajskim"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Przepraszamy, AdBlock jest wyłączony na tej stronie przez jedną z list filtrów."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokuj adres URL zawierający"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Cofnij moje blokady na tej domenie"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Wpisz poniżej poprawny filtr i kliknij OK."
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"zaktualizowano 1 dzień temu"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Funkcja w wersji beta"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Kłopoty fanboy'ów (usuwa kłopoty w internecie)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ na tej stronie",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Nie jesteś pewien?</b> Po prostu kliknij 'Zablokuj!'."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Nieprawidłowy adres URL listy. Zostanie skasowany."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"zaktualizowano 1 godzinę temu"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Polski"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Wersja $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opcje ogólne"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Subskrybuj listy filtrów"
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Innym"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"ukryj"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Listy filtrów"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Reklama pojawia się przed lub w trakcie filmu albo gry flash?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Inne listy filtrów"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS pasujący do"
   },
   "disableforchromeandsafaristeptwo":{
     "description":"Step 2 for disabling Chrome and Safari extensions",
     "message":"Wyłącz wszystkie rozszerzenia <b>za wyjątkiem</b> AdBlock'a odznaczając pole wyboru 'Włączone'. <b>Pozostaw AdBlock'a włączonego</b>."
   },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Zablokuj!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Zakończone!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Zablokuj reklamę na tej stronie"
-  },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Upewnij się, że twoje listy filtrów są aktualne:"
-  },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Nie chcę tego sprawdzać."
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Pokazuj reklamy <i>wszędzie</i> z wyjątkiem tych domen..."
   },
-  "lang_english":{
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Uwaga: jeśli popełnisz błąd, może on zablokować inne filtry, także te oficjalne!<br/>Przeczytaj <a>poradnik tworzenia składni filtrów</a> aby nauczyć się jak dodawać zaawansowane wpisy do czarnej i białej listy filtrów.."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Angielski"
+    "message":"Słowacki"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Dostosuj"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Wstrzymaj AdBlock'a"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Czy na pewno chcesz subskrybować listę filtrów o nazwie $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Otwórz stronę rozszerzeń, aby włączyć rozszerzenia, które zostały poprzednio wyłączone."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Zastosuj w domenie"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Koreański"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Strona:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Znalazłeś błąd?"
-  },
-  "filtereasylist_plus_arabic":{
-    "description":"language",
-    "message":"Arabski"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Czeski"
-  },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Zapłać ile zechcesz!"
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"lub AdBlock'a dla Chrome'a"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Zablokuj reklamę"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Tak"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Czy reklama wyświetla się też w tej przeglądarce?"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Wyklucz"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Zapisz"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Duński"
+    "message":"Rumuński"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Aby ukryć przycisk, kliknij prawym przyciskiem myszy na ikonie AdBlocka a następnie wybierz \"Ukryj przycisk\". Możesz ponownie włączyć pokazywanie go pod adresem chrome://extensions/."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebrajskim"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Ta funkcja AdBlocka nie działa na tej stronie, ponieważ wykorzystuje starą technologię. Możesz dodać zasoby do czarnej lub białej listy ręcznie w zakładce „Dostosuj” na stronie opcji."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Innym"
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Czeski"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Wyłączyliśmy wszystkie inne rozszerzenia. Teraz odświeżymy stronę z reklamą. Sekundę, prosimy."
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Inne listy filtrów"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Opcje"
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Twój komputer może być zainfekowany przez złośliwe oprogramowanie.  Kliknij <a>tutaj</a> aby uzyskać więcej informacji."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Aktualizacje są pobierane automatycznie; możesz również kliknąć przycisk: <a>Aktualizuj</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"ramka"
+    "message":"nieznane"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Edytuj"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Pokazuj reklamy na stronie lub domenie"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Wyszukuję reklamy...<br/><br/><i>To potrwa tylko chwilę.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turecki"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domena lub URL gdzie AdBlock nie powinien niczego blokować"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Wyszukiwanie aktualizacji (powinno to potrwać kilka sekund)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Zbyt wiele subskrybowanych list może spowolnić pracę AdBlock'a. Korzystanie ze zbyt wielu list może doprowadzić nawet do wykrzaczenia przeglądarki na niektórych stronach. Naciśnij przycisk OK, aby mimo tego zasubskrybować tą listę."
   },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skrypt"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ łącznie",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Zainstaluj Adblock Plus dla Firefoxa $chrome$, jeśli go nie posiadasz.",
     "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Odśwież stronę z reklamą."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Zainstaluj Firefoksa $chrome$ jeśli go nie masz.",
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Nie mamy domyślnej listy filtrów dla tego języka.<br/>Spróbuj znaleźć odpowiednią listę dla tego języka $link$ albo zablokuj tą reklamę dla siebie poprzez zakładkę 'Dostosuj' na stronie opcji.",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -761,246 +201,443 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Kliknij w reklamę, aby rozpocząć proces blokowania."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"css"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Aktualizacje AdBlocka"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nie"
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Dowiedz się więcej o programie Akceptowanych Reklam."
   },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Zbyt wiele subskrybowanych list może spowolnić pracę AdBlock'a. Korzystanie ze zbyt wielu list może doprowadzić nawet do wykrzaczenia przeglądarki na niektórych stronach. Naciśnij przycisk OK, aby mimo tego zasubskrybować tą listę."
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Przepraszamy, AdBlock jest wyłączony na tej stronie przez jedną z list filtrów."
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"zaktualizowano 1 dzień temu"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Nie określono żadnego filtru!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Niemiecki"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Grecki"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"ilość sekund od aktualizacji: $seconds$",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Nie jesteś pewien?</b> Po prostu kliknij 'Zablokuj!'."
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Obejście problemu niedziałających filmów na hulu.com (wymaga ponownego uruchomienia przeglądarki)"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arabski"
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Szukanie złośliwego oprogramowania, które mogłoby wprowadzać reklamy:"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokuj reklamy tylko na tych stronach:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Dostosuj"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Aby zgłosić reklamę, musisz być podłączony do internetu."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"Okej!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Zrobione! Odświeżyliśmy stronę z reklamą. Prosimy sprawdzić tę stronę, aby zobaczyć czy reklama zniknęła, a wtedy wrócić na tę stronę i odpowiedzieć na pytanie poniżej."
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Dodaj kanał $name$ do białej listy",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, możesz zablokować reklamę tylko dla siebie na stronie opcji. Dzięki!"
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Ukryj część strony"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"ramka"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estoński"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Pokaż liczbę zablokowanych reklam w menu AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Zgłaszanie reklam"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bułgarski"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Wstrzymaj blokowanie na stronach w tej domenie"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Własne listy filtrów"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Zablokować więcej reklam:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukraiński"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"ilość minut od aktualizacji: $minutes$",
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domena lub URL gdzie AdBlock nie powinien niczego blokować"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Nie włączaj AdBlock'a na..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokuj adres URL zawierający"
+  },
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Jeśli nie chcesz oglądać reklam takich jak ta, możesz wyłączyć filtr Akceptowanych Reklam."
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Zamknij"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Sprawdź w Firefoksie $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "filtereasylist_plus_french":{
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Ostatni krok: Co sprawia, że to reklama?"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Czy na pewno chcesz usunąć $count$ blokad, które stworzyłeś do $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Celem tego pytania jest ustalenie kto powinien otrzymać twój raport. Jeśli odpowiesz błędnie na to pytanie to raport zostanie wysłany do niewłaściwych osób, więc może zostać zignorowany."
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Wygląda dobrze"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Dostosuj AdBlock'a"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Nie znaleziono znanego złośliwego oprogramowania."
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Zezwalaj AdBlockowi na zbieranie anonimowych danych list filtrów"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Wstrzymaj blokowanie na tej stronie"
+  },
+  "filtereasylist_plus_finnish":{
     "description":"language",
-    "message":"Francuski"
+    "message":"Fiński"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>LUB</b>, po prostu kliknij ten przycisk, aby wykonać wszystkie z powyższych: <a>Wyłącz wszystkie inne rozszerzenia</a>"
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Ukryj ten przycisk"
   },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"Właśnie zaktualizowano"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Zapisz"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Uwaga: na wszystkich innych stronach będziesz widzieć reklamy!<br>Unieważnia to wszystkie inne filtry dla tych stron."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Zablokuj te powiadomienia"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Subskrybuję listę filtrów..."
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Listy filtrów blokujących reklamy"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"ilość dni od aktualizacji: $days$",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"ramka"
+    "message":"obiekt interaktywny"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (ochrona prywatności)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Co według ciebie będzie prawdziwe dla tej reklamy za każdym razem, gdy odwiedzasz tę stronę?"
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Czeski"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Zablokowanych reklam:"
   },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Używasz starej wersji AdBlock'a. Przejdź na <a href='#'>stronę rozszerzeń</a>, włącz \"Tryb programisty\" i kliknij \"Aktualizuj rozszerzenia\""
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Opcje AdBlocka"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Szukanie złośliwego oprogramowania, które mogłoby wprowadzać reklamy:"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Wyczyść tą liste"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Lista filtrów antyspołecznych (usuwa przyciski sieci społecznościowych)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Pokazuj komunikaty debugowania w logach konsoli (spowalnia to jednak AdBlock'a)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Przekroczyłeś limit rozmiaru Dropboksa. Proszę usunąć niektóre wpisy z własnych lub wyłączonych filtrów i spróbować ponownie."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Wznów AdBlock'a"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Zrobione! Odświeżyliśmy stronę z reklamą. Prosimy sprawdzić tę stronę, aby zobaczyć czy reklama zniknęła, a wtedy wrócić na tę stronę i odpowiedzieć na pytanie poniżej."
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Niemiecki"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Uwaga: ten filtr zablokuje wszystkie elementy $elementtype$ na tej stronie!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"tutaj"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Obejście problemu niedziałających filmów na hulu.com (wymaga ponownego uruchomienia przeglądarki)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Wyklucz"
-  },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Wyłącz wszystkie rozszerzenia z wyjątkiem AdBlocka:"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"W jakim języku jest ta strona?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Czy na pewno chcesz usunąć $count$ blokad, które stworzyłeś do $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"obraz"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Przetłumaczył:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"ŁADOWANIE..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Kliknij w reklamę prawym przyciskiem myszy by ją zablokować, lub zablokuj ją samodzielnie tutaj."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Aby ukryć przycisk, kliknij prawym przyciskiem myszy na ikonie AdBlocka a następnie wybierz \"Ukryj przycisk\". Możesz ponownie włączyć pokazywanie go pod adresem chrome://extensions/."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumuński"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Edytuj zablokowane filtry:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Akceptowane reklamy (zalecane)"
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Coś poszło nie tak podczas sprawdzania aktualizacji."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Aby ukryć przycisk, kliknij prawym przyciskiem myszy na pasek narzędzi Safari i wybierz \"Dostosuj pasek narzędzi\", a następnie przesuń przycisk AdBlocka poza pasek narzędzi. Możesz go przywrócić poprzez przeciągnięcie z powrotem na pasek."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Wyłączyliśmy wszystkie inne rozszerzenia. Teraz odświeżymy stronę z reklamą. Sekundę, prosimy."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"zaktualizowano 1 minutę temu"
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"strona"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Koreański"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Daj nam znać na naszej <a>witrynie pomocy technicznej</a>!"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Cofnij moje blokady na tej domenie"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Ręcznie edytować własne filtry:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Pokaż linki do list filtrów"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (zalecane)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Krok 1: Określ co zablokować"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Mamy <a>stronę</a>, aby pomóc Ci dowiedzieć się o ludziach pracujących nad AdBlockiem!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Domena:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"tutaj"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock jest aktualny!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Przeładuj stronę."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Tylko w języku angielskim"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Używasz starej wersji AdBlock'a. Przejdź na <a href='#'>stronę rozszerzeń</a>, włącz \"Tryb programisty\" i kliknij \"Aktualizuj rozszerzenia\""
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock jest wstrzymany."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>LUB</b>, po prostu kliknij ten przycisk, aby wykonać wszystkie z powyższych: <a>Wyłącz wszystkie inne rozszerzenia</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Co nowego jest w najnowszej wersji? Zobacz <a style='cursor:pointer;'>listę zmian</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Lista filtrów antyspołecznych (usuwa przyciski sieci społecznościowych)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Wyszukuję reklamy...<br/><br/><i>To potrwa tylko chwilę.</i>"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock nie będzie działać na żadnej stronie pasującej do:"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Zapisz w tej przeglądarce tę samą listę filtrów, którą masz tutaj."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Zablokuj reklamę"
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Przekroczyłeś limit rozmiaru Dropboksa. Proszę usunąć niektóre wpisy z własnych lub wyłączonych filtrów i spróbować ponownie."
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Lub podaj adres URL:"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Uwaga: na wszystkich innych stronach będziesz widzieć reklamy!<br>Unieważnia to wszystkie inne filtry dla tych stron."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Jest aktualizacja dla AdBlock'a! Przejdź $here$ aby zaktualizować. <br>Uwaga: Jeśli chcesz otrzymywać aktualizacje automatycznie, po prostu kliknij na Safari > Preferencje > Rozszerzenia > Aktualizacje <br> i wybierz opcję \"Zainstaluj aktualizacje automatycznie\".",
     "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"W następującym filtrze:<br/> $filter$ <br/> wystąpił błąd: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Chcesz zobaczyć, co sprawia, że AdBlock działa?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Własne filtry AdBlock'a (zalecane)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Typ"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Co to jest?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1012,319 +649,91 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Lub podaj adres URL:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"lub AdBlock'a dla Chrome'a"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Używasz starej wersji Safari. Pobierz najnowszą wersję Safari, aby móc za pomocą przycisku na pasku narzędzi wstrzymać pracę AdBlock'a, dodać stronę do białej listy i zgłosić napotkane reklamy. <a>Aktualizuj teraz</a>."
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Subskrybuj listy filtrów"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Wybierz język -- "
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Przetłumaczył:"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Kliknij w menu Safari &rarr; Ustawienia &rarr; Rozszerzenia."
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~site1.com|~site2.com|~news.site3.org"
   },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Zainstaluj Adblock Plus dla Firefoxa $chrome$, jeśli go nie posiadasz.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Zatrzymać blokowanie reklam:"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Najpopularniejsze rozszerzenie Chrome, korzysta z niego ponad 40 milionów użytkowników! Blokuje reklamy w całej sieci."
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Czy reklama nadal się wyświetla?"
-  },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Wsparcie"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bułgarski"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Chcesz zobaczyć, co sprawia, że AdBlock działa?"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Filmy i Flash"
   },
   "reenableadsonebyone":{
     "description":"Tells the user to reenable the extensions one by one",
     "message":"Świetnie! Teraz sprawdźmy, które rozszerzenie powodowało pojawianie się reklamy. Przejrzyj wszystkie rozszerzenia i włączaj je po kolei. Rozszerzenie, które przywraca reklamy należy usunąć, aby pozbyć się reklam."
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Niepowodzenie!"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Listy filtrów blokują większość reklam.  Możesz również:"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filtr który można zmienić na stronie opcji:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Aby ukryć przycisk, kliknij prawym przyciskiem myszy na pasek narzędzi Safari i wybierz \"Dostosuj pasek narzędzi\", a następnie przesuń przycisk AdBlocka poza pasek narzędzi. Możesz go przywrócić poprzez przeciągnięcie z powrotem na pasek."
   },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Ręcznie edytować własne filtry:"
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Świetnie! Wszystko gotowe."
   },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"W następującym filtrze:<br/> $filter$ <br/> wystąpił błąd: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Przeciągaj suwak dopóki reklama nie zostanie właściwie zablokowana, a inne elementy witryny pozostaną nienaruszone."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Typ"
-  },
-  "lang_slovak":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Słowacki"
+    "message":"Węgierski"
   },
   "orchrome":{
     "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
     "message":"lub Chrome'a"
   },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Czy reklama wyświetla się też w tej przeglądarce?"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Subskrybuj"
   },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Wstrzymaj blokowanie na tej stronie"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Zapłać ile zechcesz!"
   },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Litewski"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokuj reklamy tylko na tych stronach:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Daj nam znać na naszej <a>witrynie pomocy technicznej</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock jest wstrzymany."
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Przekroczono ilość pamięci z jakiej AdBlock może korzystać. Proszę anulować subskrypcje niektórych list filtrów!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Nie można jeszcze blokować reklam wewnątrz Flasha oraz innych wtyczek."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"Okej!"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Znalazłeś reklamę na jakiejś stronie? Pomożemy Ci znaleźć właściwe miejsce do zgłoszenia tego!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, możesz zablokować reklamę tylko dla siebie na stronie opcji. Dzięki!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Ogólne"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Jeśli nie chcesz oglądać reklam takich jak ta, możesz wyłączyć filtr Akceptowanych Reklam."
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"inne"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Potwierdź"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Nie określono żadnego filtru!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"nieznane"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Fiński"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock jest wyłączony na tej stronie."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/wideo"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japoński"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Zezwalaj na nienatrętne reklamy"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Edytuj zablokowane filtry:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"To jest problem list filtrów. Zgłoś go tutaj: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Wstrzymaj blokowanie na stronach w tej domenie"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Zablokuj element:"
   },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Pobieranie listy filtrów nie powiodło się!"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Uwaga: Twój raport będzie dostępny publicznie. Pamiętaj, aby nie zamieszczać w nim niczego prywatnego."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Pokaż linki do list filtrów"
-  },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Tylko w języku angielskim"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Anuluj"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Pomóż w rozpowszechnianiu!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Możesz przesunąć suwak poniżej, aby dokładnie określić na jakich stronach AdBlock ma być wyłączony."
-  },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock zablokował pobieranie z tej strony, ponieważ jest znana z posiadania złośliwego oprogramowania."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Sprawdź w Firefoksie $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Włącz tryb zgodności „ClickToFlash”"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Subskrybuj tę listę filtrów i spróbuj ponownie: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Aby zgłosić reklamę, musisz być podłączony do internetu."
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Masz pytanie lub nowy pomysł?"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Nieprawidłowy adres URL listy. Zostanie skasowany."
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Krok 1: Określ co zablokować"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Tak"
-  },
-  "filteritalian":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Włoski"
+    "message":"Litewski"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Wygląda dobrze"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (zalecane)"
+  "typepage":{
+    "description":"A resource type",
+    "message":"strona"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1334,5 +743,636 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Czy reklama nadal się wyświetla?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"inne"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Kliknij: <a>Zaktualizuj filtry!</a>"
+  },
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Upewnij się, że używasz właściwego filtru języka:"
+  },
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Upewnij się, że twoje listy filtrów są aktualne:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Aby ukryć przycisk, przejdź do opera://extensions i zaznacz opcję \"Nie pokazuj na pasku narzędzi\". Możesz przywrócić ten przycisk ponownie, odznaczając tą opcję."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Coś poszło nie tak podczas sprawdzania aktualizacji."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Kliknij w menu Safari &rarr; Ustawienia &rarr; Rozszerzenia."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Potwierdź"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Strona:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Odśwież stronę z reklamą."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Anulowano subskrypcje."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/wideo"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Łotewski"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Zablokuj reklamę na tej stronie"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Zablokuj!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Zatrzymać blokowanie reklam:"
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Kliknij tutaj: <a>Wyłącz Akceptowane Reklamy</a>"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Pozwól dodać do białej listy konkretne kanały YouTube"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"W jakim języku jest ta strona?"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Usuń listę filtrów"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Nie można jeszcze blokować reklam wewnątrz Flasha oraz innych wtyczek."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Możesz przesunąć suwak poniżej, aby dokładnie określić na jakich stronach AdBlock ma być wyłączony."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"ukryj"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock jest wyłączony na tej stronie."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Reklama pojawia się przed lub w trakcie filmu albo gry flash?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Rosyjski"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Hiszpański"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Zablokuj tę reklamę"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Uwaga: ten filtr zablokuje wszystkie elementy $elementtype$ na tej stronie!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Włącz tryb zgodności „ClickToFlash”"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nie"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Włącz AdBlocka na tej stronie"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filtr który można zmienić na stronie opcji:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Pokaż liczbę zablokowanych reklam na przycisku AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Niepowodzenie!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Wstrzymaj AdBlock'a"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Subskrybuj tę listę filtrów i spróbuj ponownie: $list_title$",
+    "placeholders":{
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Angielski"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dodaj pozycję do menu pod prawym przyciskiem"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Znalazłeś reklamę na jakiejś stronie? Pomożemy Ci znaleźć właściwe miejsce do zgłoszenia tego!"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Wyłącz wszystkie rozszerzenia z wyjątkiem AdBlocka:"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Rosyjski"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Jeśli widzisz reklamę, nie twórz zgłoszenia błędu, stwórz <a>zgłoszenie reklamy</a>!"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Używasz starej wersji Safari. Pobierz najnowszą wersję Safari, aby móc za pomocą przycisku na pasku narzędzi wstrzymać pracę AdBlock'a, dodać stronę do białej listy i zgłosić napotkane reklamy. <a>Aktualizuj teraz</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (ochrona prywatności)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ będzie ustawiony jako $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Kliknij w reklamę prawym przyciskiem myszy by ją zablokować, lub zablokuj ją samodzielnie tutaj."
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Zakończone!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Wznów AdBlock'a"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Dodaj filtry dla innego języka: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"ŁADOWANIE..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Czy nasz zespół poprosił o pewne informacje debugowania? Kliknij <a href='#' id='debug'>tutaj</a>, aby je uzyskać!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Ochrona przed złośliwym oprogramowaniem"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Zgłoś reklamę na stronie"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Pokazuj komunikaty debugowania w logach konsoli (spowalnia to jednak AdBlock'a)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Zainstaluj Firefoksa $chrome$ jeśli go nie masz.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Przeciągaj suwak dopóki reklama nie zostanie właściwie zablokowana, a inne elementy witryny pozostaną nienaruszone."
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Przekroczono ilość pamięci z jakiej AdBlock może korzystać. Proszę anulować subskrypcje niektórych list filtrów!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Najpopularniejsze rozszerzenie Chrome, korzysta z niego ponad 40 milionów użytkowników! Blokuje reklamy w całej sieci."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Znalazłeś błąd?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Dowiedz się więcej o złośliwym oprogramowaniu"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skrypt"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Listy filtrów"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Jestem zaawansowanym użytkownikiem, pokaż mi zaawansowane opcje"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Chiński"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filtr jest niepoprawny: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Subskrybuję listę filtrów..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Otwórz stronę rozszerzeń, aby włączyć rozszerzenia, które zostały poprzednio wyłączone."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Zablokuj te powiadomienia"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Ilość elementów pasujących do filtru na tej stronie: $matchcount$.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"zaktualizowano 1 godzinę temu"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Wybierz język -- "
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Czy AdBlock ma powiadamiać Cię, gdy wykryje złośliwe oprogramowanie?"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonezyjski"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"obraz"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Edytuj"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Pobieranie listy filtrów nie powiodło się!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ łącznie",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Wsparcie"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Zablokuj reklamę poprzez jej adres URL"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Anuluj"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Nie zapomnij zapisać!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Otwórz w niej stronę na której widzisz reklamę."
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Akceptowane reklamy (zalecane)"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Wersja $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Islandzki"
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Zgłaszanie reklam jest dobrowolne. Pomaga ono innym użytkownikom poprzez włączanie listy filtrów, aby wszyscy mogli blokować zgłoszone reklamy. Jeśli nie masz ochoty na bezinteresowną pomoc innym - w porządku. Zamknij tę stronę i <a>zablokuj reklamę</a> tylko dla siebie."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Czy na pewno chcesz subskrybować listę filtrów o nazwie $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Kod źródłowy jest <a>swobodnie dostępny</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holenderski"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Wpisz poniżej poprawny filtr i kliknij OK."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Rozszerzenia, które zostały poprzednio wyłączone, zostały włączone ponownie."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Ilość elementów pasujących do filtru na tej stronie: <b>1</b>."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japoński"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Wyczyść tą liste"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"ilość godzin od aktualizacji: $hours$",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Wróć"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Opcje AdBlocka"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Funkcja w wersji beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock zablokował pobieranie z tej strony, ponieważ jest znana z posiadania złośliwego oprogramowania."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Nie subskrybuj większej ilości list niż potrzebujesz, każda trochę spowalnia przeglądarkę! Więcej list można znaleźć <a>tutaj</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Wyszukiwanie aktualizacji (powinno to potrwać kilka sekund)..."
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Zastosuj w domenie"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"Właśnie zaktualizowano"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"ilość minut od aktualizacji: $minutes$",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Czeski"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Zezwalaj na nienatrętne reklamy"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Szwedzki"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Wsparcie dla AdBlock'a"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Typ"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francuski"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"zaktualizowano 1 minutę temu"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"ramka"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - kliknij, aby zobaczyć szczegóły"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Ostrzeżenie: nie określono żadnego filtru!"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Anexe uma captura de tela:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Nenhum malware conhecido foi encontrado."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Naquele navegador, aplique a mesma lista de filtros que aplicou aqui."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Nesse navegador, carregue a página com a propaganda."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Sueco"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Bloqueie mais propagandas:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Russo"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Subscrição cancelada."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Chinês"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Se você tiver criado um filtro ativo usando o assistente de \"bloquear um anúncio\", cole-o na caixa abaixo:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Lista de filtro anti-social (remove os botões de mídia social)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Encontrou um anúncio em uma página da web? Nós ajudaremos você a encontrar o lugar certo para relatar isso!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Mostrar o número de anúncios bloqueados no botão AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"O código-fonte está <a>disponível gratuitamente</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"atualizado 1 minuto atrás"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Erro ao baixar este filtro!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Por favor, reinicie o Safari para concluir a desativação do bloqueio de conteúdo."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Bloquear uma propaganda por sua URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Esconder este botão"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Eu irei baixar as atualizações automaticamente; você também pode <a>atualizar agora</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formato: ~site1.com|~site2.com|~noticias.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estoniano"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tipo"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Há uma atualização disponível para o AdBlock! Clique $here$ para atualizar. <br> Nota: Se quiser receber atualizações automáticas, clique em Safari > Preferências > Extensões > Atualizações <br> e ative a opção 'Instalar Atualizações Automaticamente'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"O que é isto?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Não subscreva-se para mais do que você precisa -- cada um deixa você um pouquinho mais devagar! Créditos e mais listas podem ser encontrados <a>aqui</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Esse recurso do AdBlock não funciona neste site poque ele usa tecnologia desatualizada. Você pode colocar na lista negra ou na lista branca os recursos manualmente pela guia 'Personalizar' da página de opções."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polonês"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Saiba mais sobre o programa de Anúncios Aceitáveis."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"atualizado $seconds$ segundos atrás",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"subrequisito de objeto"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Húngaro"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Nota: seu relatório pode se tornar disponível publicamente. Mantenha isso em mente antes de incluir qualquer coisa privada."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Por favor, desative algumas listas de filtros. Mais informações nas opções do AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Origem do Filtro: $list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Desculpe, o AdBlock está desativado nesta página por uma das suas listas de filtros."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"O filtro é inválido: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Aviso: nenhum filtro especificado!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock está desativado nesta página."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Mostrar propagandas <i>em todos os lugares</i>, exceto nesses domínios..."
+    "message":"Tem alguma pergunta ou ideia nova?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Opções"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"solicitação xmlhttp"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Propagandas bloqueadas:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Adicionar filtros para outro idioma: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Clique na propaganda, e eu irei mostrar como bloqueá-la."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Se você está vendo um anúncio, não faça um relatório de erro, faça um <a>relatório de anúncio</a>!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Ótimo! Está tudo pronto."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Outro"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Suporte AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Personalizar o AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Informações requeridas estão ausentes ou inválidas. Por favor, preencha as perguntas que têm uma borda vermelha."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Erro ao salvar o arquivo enviado."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Por favor digite o filtro correto abaixo e pressione OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Passo 1: Descubra o que bloquear"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Dinamarquês"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (recomendado)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ nesta página",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Submoldura"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"atualizado 1 hora atrás"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Coreano"
+    "message":"Polonês"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"ou Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Qual é o seu nome?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"A extensão mais popular do Chrome, com mais de 40 milhões de usuários! Bloqueia anúncios em toda a web."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Mostrar todas as solicitações"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Eu não quero ver isso"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Sim"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Desfazer os meus bloqueios neste domínio"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Personalizar"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pausar AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Você tem certeza que deseja assinar a lista de filtro $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Onde exatamente nessa página está o anúncio? Como ele parece?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"ou AdBlock para Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definição de estilo"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Limite da regra de Bloqueio de Conteúdo ultrapassado"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Encontrando propagandas...<br/><br/><i>Isso só levará um momento.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"O domínio ou url onde AdBlock não deve bloquear nada"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ no total",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Tudo pronto!  Em breve, entraremos em contato, provavelmente dentro de um dia, ou dois se for um feriado. Entretanto, aguarde um e-mail do AdBlock. Você irá encontrar um link para o seu tíquete no nosso site de ajuda. Se preferir acompanhar por e-mail, pode fazer isso também!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Não"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Algo deu errado. Nenhum recurso foi enviado. Esta página irá fechar. Tente recarregar a página."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ucraniano"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"atualizado $minutes$ minutos atrás",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Cancelamos sua subscrição em Anúncios Aceitáveis, porque você ativou o bloqueio de conteúdo do Safari. Você só pode selecionar um de cada vez. (<a>Por que?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Você não está mais inscrito na lista de filtros de Anúncios Aceitáveis."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Proteção contra malware"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Salvar"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Aviso: em todos os outros sites você verá propagandas!<br>Isso anula todas os outros filtros para esses sites."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Desativar estas notificações"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Subscrevendo-se a lista de filtros..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Você está usando uma versão antiga do AdBlock. Por favor vá para <a href='#>a página extensões</a>, habilite \"Modo do desenvolvedor' e clique \"Atualizar extensões agora'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Opções do AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Verificação de malware que poderia estar injetando anúncios:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Mostrar declarações de depuração no Log do Console (que deixa o AdBlock mais devagar)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Você excedeu o limite de tamanho do Dropbox. Por favor, remova alguns dos seus filtros personalizados ou desabilitados, e tente novamente."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Retomar o AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Solução alternativa para vídeos que não rodam em Hulu.com (requer reinicialização do navegador)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS para corresponder"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Excluir"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Desative todas as extensões, exceto o AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Créditos da tradução a:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"CARREGANDO..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Clique com o botão direito na propaganda para bloqueá-la -- ou bloqueie-a aqui manualmente."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Nota: Colocar na lista branca (permitir anúncios) uma página ou site não é aceito com o Bloqueio de Conteúdos do Safari ativado."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Só usaremos isto para entrar em contato com você se precisarmos de mais informações."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Editar os filtros desabilitados:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Ativar o bloqueio de conteúdo do Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Qual é o seu endereço de e-mail?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Para ocultar o botão, clique com o botão direito na barra de ferramentas do Safari e escolha Personalizar Barra de Ferramentas e, em seguida, arraste o botão do AdBlock para fora da Barra de Ferramentas. Você pode mostrar o botão novamente, arrastando-o para a barra de ferramentas."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Houve um erro ao processar seu pedido."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"página"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Pronto! Nós recarregamos a página com o anúncio. Por favor, verifique a página para ver se o anúncio desapareceu. Em seguida, volte a esta página e responda à pergunta abaixo."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Ou insira uma URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Você está usando uma versão antiga do Safari. Pegue a versão mais recente para usar o botão do AdBlock na barra de ferramenta para pausar o AdBlock, adicionar sites da web a lista branca, e reportar propagandas. <a>Atualize agora</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Clicar no menu Safari &rarr Preferências &rarr Extensões."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Pare de bloquear propagandas:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Bloqueie isto!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"A propaganda ainda aparece?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Búlgaro"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Ótimo. Agora vamos descobrir qual extensão é a causa. Vá ativando cada extensão uma por vez. A extensão que trazer de volta o(s) anúncio(s) é aquela que você precisa desinstalar para livrar-se dos anúncios."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Falhou!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Edite seus filtros manualmente:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italiano"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tipo"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Eslovaco"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Subscreva a listas de filtros"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Você pode ligar novamente isto e apoiar os sites que você ama, selecionando \"Permitir alguma publicidade não-intrusiva\" abaixo."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"A propaganda também aparece naquele navegador?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Não usar nesta página"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Lituano"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Conte-nos no nosso <a>site de suporte</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock está pausado."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Ainda não podemos bloquear propagandas no Flash e em outros plugins. Estamos aguardando suporte do navegador e da WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Geral"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Se você prefere não ver anúncios como este, você pode querer deixar a lista de filtros de Anúncios Aceitáveis desligada."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Seu computador pode estar infectado por malware.  Clique <a>aqui</a> para obter mais informações."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"outro"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Nenhum filtro especificado!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"desconhecido"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"áudio/vídeo"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japonês"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Permitir algumas propagandas não invasivas"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Cancelar"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Você pode deslizar abaixo para mudar exatamente em que páginas o AdBlock não atuará."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Desligamos o bloqueio de conteúdo do Safari, porque você optou por permitir anúncios publicitários não-intrusivos. Você só pode selecionar um de cada vez. (<a>Por que?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Última etapa: relatar o problema para nós."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Tente no Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Para relatar um anúncio, você deve estar conectado à internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (recomendado)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Reportando uma propaganda"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Listas de Filtro de Bloqueio de Propaganda"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Como?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permitir anúncios de canais específicos do YouTube"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Terceiros"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (remove irritações na Web)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - clique para detalhes"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"atualizado $hours$ horas atrás",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Russo e Ucraniano"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"O que há de novo na versão mais recente? Veja o <a style='cursor:pointer;'> changelog</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"As extensões que foram desabilitadas anteriormente foram reabilitadas."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grego"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Esconder uma seção de uma página da web"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Vídeos e Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"O que você acha que será verdade sobre essa propaganda toda vez que visitar esta página?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Ativar o AdBlock nesta página"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Voltar"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"As listas de filtros bloqueiam a maioria das propagandas na web. Você também pode:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Verificação dos filtros de Anúncios Aceitáveis:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Mostrar propagandas em uma página da web ou domínio"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Isso corresponde a <b>1</b> item nesta página."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Eu não quero ver isso"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Por favor, reinicie o Safari para concluir a desativação do bloqueio de conteúdo."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Seja cuidadoso: se você fizer um erro aqui muitos outros filtros, incluindo os filtros oficiais, podem quebrar também!<br/>Leia o <a>tutorial de sintaxe de filtro</a> para aprender como adicionar filtros avançados de listas negras e listas brancas."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Canal de lista branca $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"A propaganda também aparece naquele navegador?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opções gerais"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Se você prefere não ver anúncios como este, você pode querer deixar a lista de filtros de Anúncios Aceitáveis desligada."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock não irá atuar em qualquer página que corresponde a:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Não temos uma lista de filtros padrão para essa língua.<br/>Por favor tente encontrar uma lista adequada que suporte esta língua $link$ ou bloqueie essa propaganda você mesmo na aba 'Personalizar'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Subscrever"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Sou um usuário avançado, mostre-me opções avançadas"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Espanhol"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Carregado na página com domínio: $domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Clique nisto: <a>Atualize meus filtros!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Quanto mais listas de filtros você usa, mais devagar o AdBlock funciona. Usar listas demais pode até travar o seu navegador em alguns sites da web. Pressione OK para subscrever-se a esta lista mesmo assim."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Último passo: o que faz disso uma propaganda?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Isso corresponde a $matchcount$ itens nesta página.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Também temos uma <a>página</a> para ajudá-lo a descobrir as pessoas por trás do AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonésio"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turco"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Bloqueie uma propaganda"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Listas de Filtro Personalizadas"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL da moldura: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"O propósito desta pergunta é determinar quem deve receber seu relatório. Se você responder esta pergunta incorretamente, o relatório sera enviado para as pessoas erradas, logo poderá ser ignorado."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Adicionar itens ao menu de contexto"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"seletor"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Bloqueie esta propaganda"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"A nossa equipa solicitou algumas informações de depuração? Clique <a href='#' id='debug'>aqui</a> para isso!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Não use o AdBlock em..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Relatar anúncios é algo voluntário. Isto ajuda outras pessoas, permitindo que os mantenedores da lista de filtros possam bloquear o anúncio para todo mundo. Se você não está se sentido altruísta agora, sem problemas. Feche esta página e <a>bloqueie o anúncio</a> apenas para si mesmo."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Elemento oculto"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Recarregue a página."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"página"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Holandês"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Esse nome de arquivo é muito longo. Por favor, dê a seu arquivo um nome mais curto."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Não se esqueça de salvar!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Verificando se há atualizações (deve demorar apenas alguns segundos)..."
+    "message":"Lituano"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Subscreva-se a essa lista de filtros, então tente novamente: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"O AdBlock deve notificá-lo quando detectar malware?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Seu computador pode estar infectado por malware.  Clique <a>aqui</a> para obter mais informações."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Mostrar o número de anúncios bloqueador no menu AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Mostrar propagandas em uma página da web ou domínio"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Site:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Filtros personalizados do AdBlock (recomendado)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Letão"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Certifique-se que está usando o(s) filtro(s) de idioma correto(s):"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS para corresponder"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Para ocultar o botão, vá para opera://extensions e marque a opção 'Ocultar da barra de ferramentas'. Você pode mostrar o botão novamente desmarcando esta opção."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Não tem certeza?</b> Apenas pressione 'Bloqueie isto!' abaixo."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Filtro correspondente"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Baixando... por favor aguarde."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Todos os recursos"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"O AdBlock está atualizado!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Não usar em páginas neste domínio"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Hebraico"
+    "message":"Eslovaco"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Deslize o cursor até que a propaganda esteja bloqueada corretamente na página, e o elemento bloqueado pareça útil."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Bloqueie URLs contendo este texto"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"O número de regras da lista de filtros excede o limite de 50.000 e foi automaticamente reduzido. Por favor, cancele a subscrição de algumas listas de filtros ou desative o bloqueio de conteúdo do Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"atualizado 1 dia atrás"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Anúncios Aceitáveis (recomentado)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Clique aqui: <a>Desativar Anúncios Aceitáveis</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versão $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Instale o AdBlock Plus para Firefox $chrome$ se você não instalou.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Remover da lista"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Não temos uma lista de filtros padrão para essa língua.<br/>Por favor tente encontrar uma lista adequada que suporte esta língua $link$ ou bloqueie essa propaganda você mesmo na aba 'Personalizar'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Isso não é um arquivo de imagem. Por favor, faça o upload de um arquivo .png, .gif, ou .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Por que você não nos envia um <a>relatório de bug's</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"ocultando"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Listas de filtros"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Domínio da moldura: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Clique na propaganda, e eu irei mostrar como bloqueá-la."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Moldura superior"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"definição de estilo"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"desconhecido"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Desculpe, o AdBlock está desativado nesta página por uma das suas listas de filtros."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Terceiros"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Nenhum filtro especificado!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Grego"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Você está usando uma versão antiga do AdBlock. Por favor vá para <a href='#>a página extensões</a>, habilite \"Modo do desenvolvedor' e clique \"Atualizar extensões agora'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Qual é o seu nome?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Solução alternativa para vídeos que não rodam em Hulu.com (requer reinicialização do navegador)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Aviso: nenhum filtro especificado!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Personalizar"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Encontrou um anúncio em uma página da web? Nós ajudaremos você a encontrar o lugar certo para relatar isso!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estoniano"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Personalizar o AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Búlgaro"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Recurso na lista branca"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Limite da regra de Bloqueio de Conteúdo ultrapassado"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Não use o AdBlock em..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Bloqueie URLs contendo este texto"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Fechar"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Tente no Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Último passo: o que faz disso uma propaganda?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Se você está vendo um anúncio, não faça um relatório de erro, faça um <a>relatório de anúncio</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Coreano"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Você está usando uma versão antiga do Safari. Pegue a versão mais recente para usar o botão do AdBlock na barra de ferramenta para pausar o AdBlock, adicionar sites da web a lista branca, e reportar propagandas. <a>Atualize agora</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finlandês"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ucraniano"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Nenhum malware conhecido foi encontrado."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Por favor, desative algumas listas de filtros. Mais informações nas opções do AdBlock."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Cancelamos sua subscrição em Anúncios Aceitáveis, porque você ativou o bloqueio de conteúdo do Safari. Você só pode selecionar um de cada vez. (<a>Por que?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Também temos uma <a>página</a> para ajudá-lo a descobrir as pessoas por trás do AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"aqui"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"solicitação xmlhttp"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Recarregue a página."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Em qual língua a página está escrita?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock está pausado."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Retomar o AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Encontrando propagandas...<br/><br/><i>Isso só levará um momento.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock está desativado nesta página."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Naquele navegador, aplique a mesma lista de filtros que aplicou aqui."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Bloqueie uma propaganda"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Aviso: em todos os outros sites você verá propagandas!<br>Isso anula todas os outros filtros para esses sites."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Há uma atualização disponível para o AdBlock! Clique $here$ para atualizar. <br> Nota: Se quiser receber atualizações automáticas, clique em Safari > Preferências > Extensões > Atualizações <br> e ative a opção 'Instalar Atualizações Automaticamente'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Terminado!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Filtros personalizados do AdBlock (recomendado)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tipo"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"O que é isto?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japonês"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Origem do Filtro: $list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Subscreva a listas de filtros"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Tipo de moldura: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Adicionar filtros para outro idioma: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Recursos"
+    "message":"Filtro correspondente"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Bloqueie uma propaganda nesta página"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"As listas de filtros bloqueiam a maioria das propagandas na web. Você também pode:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Certifique-se que suas listas de filtros estão atualizadas:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Para ocultar o botão, clique com o botão direito na barra de ferramentas do Safari e escolha Personalizar Barra de Ferramentas e, em seguida, arraste o botão do AdBlock para fora da Barra de Ferramentas. Você pode mostrar o botão novamente, arrastando-o para a barra de ferramentas."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Inglês"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Você excedeu o limite de tamanho do Dropbox. Por favor, remova alguns dos seus filtros personalizados ou desabilitados, e tente novamente."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Islandês"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Subscrever"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Abra a página de extensões para habilitar as extensões que foram desabilitadas anteriormente."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Nota: Colocar na lista branca (permitir anúncios) uma página ou site não é aceito com o Bloqueio de Conteúdos do Safari ativado."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domínio da página para aplicar"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Elemento bloqueado:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"página"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"outro"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Clique nisto: <a>Atualize meus filtros!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Elemento oculto"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Para ocultar o botão, vá para opera://extensions e marque a opção 'Ocultar da barra de ferramentas'. Você pode mostrar o botão novamente desmarcando esta opção."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"subrequisito de objeto"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Página:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Encontrou um erro?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Bloqueie isto!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permitir anúncios de canais específicos do YouTube"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Ainda não podemos bloquear propagandas no Flash e em outros plugins. Estamos aguardando suporte do navegador e da WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Árabe"
+    "message":"Húngaro"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Bloqueie esta propaganda"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Ativar o AdBlock nesta página"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Mostrar o número de anúncios bloqueados no botão AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Falhou!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pausar AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Tcheco"
+    "message":"Inglês"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Pague o que quiser!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Adicionar itens ao menu de contexto"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Quer saber o que faz o AdBlock funcionar?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Acesso <a>nosso site de suporte</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Lista de Remoção de Avisos Adblock (remove avisos sobre uso de bloqueadores de anúncios)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"URL de lista inválida. Será deletada."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"moldura"
+    "message":"página"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Editar"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Tem certeza que deseja remover os $count$ bloqueios que criou em $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Tem alguma pergunta ou ideia nova?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legenda: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Você esqueceu de anexar uma captura de tela! Nós não podemos ajudá-lo sem ver o(s) anúncio(s) que você está relatando."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>OU</b>, simplesmente clique neste botão para que façamos tudo que está acima: <a> Desabilitar todas as outras extensões </a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"atualizado $minutes$ minutos atrás",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Saber mais sobre malware"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Anexe uma captura de tela:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Romeno"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Editar os filtros desabilitados:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Submoldura"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Recarregue a página com a propaganda."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Ativar o bloqueio de conteúdo do Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Instale o Firefox $chrome$ se você não o tem.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Listas de filtros"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Se você tiver criado um filtro ativo usando o assistente de \"bloquear um anúncio\", cole-o na caixa abaixo:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Esse arquivo é muito grande. Por favor, certifique-se de que seu arquivo tem menos de 10 MB."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock não irá atuar em qualquer página que corresponde a:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Chinês"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"O filtro é inválido: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Subscrevendo-se a lista de filtros..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Abra a página de extensões para habilitar as extensões que foram desabilitadas anteriormente."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Desativar estas notificações"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turco"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Não subscreva-se para mais do que você precisa -- cada um deixa você um pouquinho mais devagar! Créditos e mais listas podem ser encontrados <a>aqui</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"moldura"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonésio"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"imagem"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ no total",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Cancelar"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Não se esqueça de salvar!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"seletor"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Desligamos o bloqueio de conteúdo do Safari, porque você optou por permitir anúncios publicitários não-intrusivos. Você só pode selecionar um de cada vez. (<a>Por que?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Islandês"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Listas de Filtro de Bloqueio de Propaganda"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Bloqueie propagandas apenas nesses sites:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Carregado na página com domínio: $domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"As extensões que foram desabilitadas anteriormente foram reabilitadas."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Limpar esta lista"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Ajude a divulgar!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Atualizações do AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Lista de Remoção de Avisos Adblock (remove avisos sobre uso de bloqueadores de anúncios)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Opções do AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Houve um erro ao processar seu pedido."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"atualizado 1 hora atrás"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Verificando se há atualizações (deve demorar apenas alguns segundos)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"atualizado agora mesmo"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Clique com o botão direito na propaganda para bloqueá-la -- ou bloqueie-a aqui manualmente."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Verificação de malware que poderia estar injetando anúncios:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Suporte AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tipo"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Deslize o cursor até que a propaganda esteja bloqueada corretamente na página, e o elemento bloqueado pareça útil."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"atualizado 1 minuto atrás"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"moldura"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Recurso bloqueado"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"As informações a seguir também serão incluídas no relatório de anúncio."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Dinamarquês"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Verificação dos filtros de Anúncios Aceitáveis:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Você pode ligar novamente isto e apoiar os sites que você ama, selecionando \"Permitir alguma publicidade não-intrusiva\" abaixo."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Baixando... por favor aguarde."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"URL de lista inválida. Será deletada."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opções gerais"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Desmarque a opção 'ativar' próxima a todas as extensões <b>exceto</b> AdBlock.  <b>Deixe AdBlock ativado</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Nesse navegador, carregue a página com a propaganda."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Mostrar propagandas <i>em todos os lugares</i>, exceto nesses domínios..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Você esqueceu de anexar uma captura de tela! Nós não podemos ajudá-lo sem ver o(s) anúncio(s) que você está relatando."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"E crie manualmente um tíquete, copiando e colando as informações abaixo para a seção \"Fill in any details you think will help us understand your issue\"."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Para esconder o botão, clique com o botão direito e escolha Esconder Botão. Você pode mostrá-lo novamente em chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebraico"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Esse recurso do AdBlock não funciona neste site poque ele usa tecnologia desatualizada. Você pode colocar na lista negra ou na lista branca os recursos manualmente pela guia 'Personalizar' da página de opções."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Tcheco e Eslovaco"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Desativamos todas as outras extensões. Agora iremos recarregar a página com o anúncio. Um segundo, por favor."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Outras Listas de Filtro"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Francês"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Eu irei baixar as atualizações automaticamente; você também pode <a>atualizar agora</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Elemento bloqueado:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Mostrar todas as solicitações"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"objeto interativo"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Quanto mais listas de filtros você usa, mais devagar o AdBlock funciona. Usar listas demais pode até travar o seu navegador em alguns sites da web. Pressione OK para subscrever-se a esta lista mesmo assim."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Ótimo! Está tudo pronto."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Abra a <a href='#'> página de extensões</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Tudo pronto!  Em breve, entraremos em contato, provavelmente dentro de um dia, ou dois se for um feriado. Entretanto, aguarde um e-mail do AdBlock. Você irá encontrar um link para o seu tíquete no nosso site de ajuda. Se preferir acompanhar por e-mail, pode fazer isso também!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Saiba mais sobre o programa de Anúncios Aceitáveis."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"O AdBlock deve notificá-lo quando detectar malware?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"atualizado agora mesmo"
+    "message":"atualizado 1 dia atrás"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL da moldura: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Alemão"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Esse nome de arquivo é muito longo. Por favor, dê a seu arquivo um nome mais curto."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"atualizado $seconds$ segundos atrás",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Não usar nesta página"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Conte-nos no nosso <a>site de suporte</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Pronto! Nós recarregamos a página com o anúncio. Por favor, verifique a página para ver se o anúncio desapareceu. Em seguida, volte a esta página e responda à pergunta abaixo."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Todos os recursos"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Canal de lista branca $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Recursos"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Mostrar o número de anúncios bloqueador no menu AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Reportando uma propaganda"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Como?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Não usar em páginas neste domínio"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Listas de Filtro Personalizadas"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Bloqueie mais propagandas:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Informações requeridas estão ausentes ou inválidas. Por favor, preencha as perguntas que têm uma borda vermelha."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"O domínio ou url onde AdBlock não deve bloquear nada"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Você não está mais inscrito na lista de filtros de Anúncios Aceitáveis."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (remove irritações na Web)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"O AdBlock bloqueou um download de um site conhecido por conter malware."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Salvar"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Não tem certeza?</b> Apenas pressione 'Bloqueie isto!' abaixo."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Última etapa: relatar o problema para nós."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Onde exatamente nessa página está o anúncio? Como ele parece?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Parece bom"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permitir que o AdBlock colete o uso e dados da lista de filtro anônima"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Para relatar um anúncio, você deve estar conectado à internet."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Você tem certeza que deseja assinar a lista de filtro $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"atualizado $days$ dias atrás",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"moldura"
+    "message":"objeto interativo"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"O que você acha que será verdade sobre essa propaganda toda vez que visitar esta página?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Propagandas bloqueadas:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Árabe"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Desfazer os meus bloqueios neste domínio"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Edite seus filtros manualmente:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Passo 1: Descubra o que bloquear"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Por favor digite o filtro correto abaixo e pressione OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Créditos da tradução a:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"O AdBlock está atualizado!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Apenas em inglês"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>OU</b>, simplesmente clique neste botão para que façamos tudo que está acima: <a> Desabilitar todas as outras extensões </a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"O que há de novo na versão mais recente? Veja o <a style='cursor:pointer;'> changelog</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (proteção de privacidade)"
+    "message":"Lista de filtro anti-social (remove os botões de mídia social)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Reportar uma propaganda nesta página"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Proteção contra malware"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Limpar esta lista"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Sou um usuário avançado, mostre-me opções avançadas"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Alemão"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Você excedeu a quantidade de armazenamento que o AdBlock pode usar. Por favor cancele a subscrição de algumas listas de filtros!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Seja cuidadoso: este filtro bloqueia todos os elementos $elementtype$ na página!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"aqui"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Qual é o seu endereço de e-mail?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Em qual língua a página está escrita?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Quer saber o que faz o AdBlock funcionar?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Tem certeza que deseja remover os $count$ bloqueios que criou em $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"imagem"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Esconder uma seção de uma página da web"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"E crie manualmente um tíquete, copiando e colando as informações abaixo para a seção \"Fill in any details you think will help us understand your issue\"."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Geral"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Para esconder o botão, clique com o botão direito e escolha Esconder Botão. Você pode mostrá-lo novamente em chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"ou AdBlock para Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Romeno"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Vídeos e Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Algo deu errado durante a verificação de atualizações."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Desativamos todas as outras extensões. Agora iremos recarregar a página com o anúncio. Um segundo, por favor."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Recurso na lista branca"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Ótimo. Agora vamos descobrir qual extensão é a causa. Vá ativando cada extensão uma por vez. A extensão que trazer de volta o(s) anúncio(s) é aquela que você precisa desinstalar para livrar-se dos anúncios."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Tcheco e Eslovaco"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"ou Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Tipo de moldura: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formato: ~site1.com|~site2.com|~noticias.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Selecione o idioma -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Instale o AdBlock Plus para Firefox $chrome$ se você não instalou.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Recurso bloqueado"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"A propaganda aparece em ou antes de um filme ou qualquer outro plugin como um jogo em Flash?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ será $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"O filtro, que pode ser modificado na página Opções:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"O seguinte filtro: <br/> $filter$ <br/> possui um erro: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Fechar"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Bloqueie propagandas apenas nesses sites:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Você excedeu a quantidade de armazenamento que o AdBlock pode usar. Por favor cancele a subscrição de algumas listas de filtros!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permitir que o AdBlock colete o uso e dados da lista de filtro anônima"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, você ainda pode bloquear esta propaganda você mesmo na página Opções. Obrigado!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Enviar"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finlandês"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Esse arquivo é muito grande. Por favor, certifique-se de que seu arquivo tem menos de 10 MB."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"As informações a seguir também serão incluídas no relatório de anúncio."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Pague o que quiser!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Este é um problema com a lista de filtros. Reporte aqui: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Desmarque a opção 'ativar' próxima a todas as extensões <b>exceto</b> AdBlock.  <b>Deixe AdBlock ativado</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Nota: seu relatório pode se tornar disponível publicamente. Mantenha isso em mente antes de incluir qualquer coisa privada."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Mostrar links para as listas de filtros"
+  "filteritalian":{
+    "description":"language",
+    "message":"Italiano"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Apenas em inglês"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Ajude a divulgar!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"A propaganda ainda aparece?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"O AdBlock bloqueou um download de um site conhecido por conter malware."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Certifique-se que está usando o(s) filtro(s) de idioma correto(s):"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legenda: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Certifique-se que suas listas de filtros estão atualizadas:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Algo deu errado durante a verificação de atualizações."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Clicar no menu Safari &rarr Preferências &rarr Extensões."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Enviar"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Subscrição cancelada."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"áudio/vídeo"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Letão"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Bloqueie uma propaganda nesta página"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Pare de bloquear propagandas:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Erro ao salvar o arquivo enviado."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Isso corresponde a $matchcount$ itens nesta página.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Erro ao baixar este filtro!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Você pode deslizar abaixo para mudar exatamente em que páginas o AdBlock não atuará."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"ocultando"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"A propaganda aparece em ou antes de um filme ou qualquer outro plugin como um jogo em Flash?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Russo e Ucraniano"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Espanhol"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Seja cuidadoso: este filtro bloqueia todos os elementos $elementtype$ na página!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Ativar o modo de compatibilidade ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Não"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"O filtro, que pode ser modificado na página Opções:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Esconder este botão"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Outro"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, você ainda pode bloquear esta propaganda você mesmo na página Opções. Obrigado!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Russo"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Por que você não nos envia um <a>relatório de bug's</a>?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (proteção de privacidade)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ será $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Ou insira uma URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"O seguinte filtro: <br/> $filter$ <br/> possui um erro: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"CARREGANDO..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"A nossa equipa solicitou algumas informações de depuração? Clique <a href='#' id='debug'>aqui</a> para isso!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"O número de regras da lista de filtros excede o limite de 50.000 e foi automaticamente reduzido. Por favor, cancele a subscrição de algumas listas de filtros ou desative o bloqueio de conteúdo do Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Reportar uma propaganda nesta página"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Mostrar declarações de depuração no Log do Console (que deixa o AdBlock mais devagar)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Domínio da moldura: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"A extensão mais popular do Chrome, com mais de 40 milhões de usuários! Bloqueia anúncios em toda a web."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Encontrou um erro?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Tcheco"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Isso não é um arquivo de imagem. Por favor, faça o upload de um arquivo .png, .gif, ou .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Mostrar links para as listas de filtros"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Permitir algumas propagandas não invasivas"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Sueco"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Remover da lista"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Selecione o idioma -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francês"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Editar"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Suporte"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Acesso <a>nosso site de suporte</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Bloquear uma propaganda por sua URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Para pausar o AdBlock com o Bloqueio de Conteúdos ativado, por favor selecione o Safari (na barra de menu) > Preferências > Extensões > AdBlock e desmarque a opção 'Ativar AdBlock'."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versão $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"O propósito desta pergunta é determinar quem deve receber seu relatório. Se você responder esta pergunta incorretamente, o relatório sera enviado para as pessoas erradas, logo poderá ser ignorado."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Relatar anúncios é algo voluntário. Isto ajuda outras pessoas, permitindo que os mantenedores da lista de filtros possam bloquear o anúncio para todo mundo. Se você não está se sentido altruísta agora, sem problemas. Feche esta página e <a>bloqueie o anúncio</a> apenas para si mesmo."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Sim"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"O código-fonte está <a>disponível gratuitamente</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holandês"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Só usaremos isto para entrar em contato com você se precisarmos de mais informações."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Isso corresponde a <b>1</b> item nesta página."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"atualizado $hours$ horas atrás",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Voltar"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Clique aqui: <a>Desativar Anúncios Aceitáveis</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domínio da página para aplicar"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Atualizações do AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Algo deu errado. Nenhum recurso foi enviado. Esta página irá fechar. Tente recarregar a página."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Saber mais sobre malware"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Site:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Anúncios Aceitáveis (recomentado)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Parece bom"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Para pausar o AdBlock com o Bloqueio de Conteúdos ativado, por favor selecione o Safari (na barra de menu) > Preferências > Extensões > AdBlock e desmarque a opção 'Ativar AdBlock'."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Abra a <a href='#'> página de extensões</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - clique para detalhes"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Desative todas as extensões, exceto o AdBlock:"
   }
 }

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -1,1347 +1,1169 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Anexe uma captura de ecrã:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Nenhum malware encontrado."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Nesse browser, subscreva às mesmas listas de filtros que tem aqui."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Nesse browser, carregue a página com o anúncio."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Sueco"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Bloquear mais anúncios:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Russo"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Desinscrever"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Chinês"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Se criou um filtro manualmente usando o assistente de \"bloquear um anúncio\", cole-o na caixa abaixo:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Lista de filtros anti-social (remove os botões dos meios de comunicação social)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Encontrou um anúncio numa página da web? Nós vamos ajudá-lo a encontrar o lugar certo para denunciá-lo!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Mostrar o número de anúncios bloqueados no botão AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"O código-fonte está <a>disponível gratuitamente</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"actualizado há 1 minuto atrás"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Falhou a inscrição neste filtro!"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"O seu computador pode estar infectado por um malware.  Clique <a>aqui</a> para obter mais informações."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Bloquear um anúncio pelo URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Esconder este botão"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"As actualizações são automáticas; mas também pode <a>actualizar manualmente</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formato: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Estoniano"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tipo"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Está disponível uma actualização para o AdBlock! Aceda $here$ para actualizar. <br> Nota: Se quiser receber actualizações automáticas, clique em Safari > Preferências > Extensões > Actualizações <br> e active a opção 'Instalar Actualizações Automaticamente'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"O que é isto?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Não subscrever mais do que o necessário - cada lista torna-o um pouco mais lento! Créditos e mais listas podem ser encontradas <a>aqui</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Esta funcionalidade do AdBlock não funciona neste site porque apresenta tecnologia desactualizada. Pode colocar na lista negra ou nos recursos da whitelist manualmente no separador 'Personalizar' da página de opções."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polaco"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Saiba mais acerca do programa de Anúncios Aceitáveis."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"actualizado há $seconds$ segundos atrás",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Húngaro"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Nota: o seu relatório pode tornar-se público. Tenha isso em atenção antes de incluir alguma coisa privada."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Por favor, desinscreva-se de algumas listas de filtros. Mais informações nas opções do AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Origem do filtro:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Desculpe, o AdBlock foi desactivado nesta página por uma das suas listas de filtros."
-  },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Islandês"
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Aviso: nenhum filtro especificado!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock está desactivado neste site."
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Se está a ver um anúncio, não faça um relatório de erro, faça um <a>relatório de anúncio</a>!"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Mostrar anúncios <i>em todo o lado</i> excepto para estes sites..."
+    "message":"Tem alguma questão ou uma ideia nova?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Opções"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Anúncios bloqueados:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Adicione filtros para outro idioma: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Clica no anúncio e eu vou-te ajudar a bloqueá-lo."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Ótimo! Está tudo pronto."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Outro"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Suporte AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customizar AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Informação pedida está ausente ou inválida.  Por favor preencha as perguntas que têm uma borda vermelha."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Erro ao guardar o ficheiro enviado."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Por favor, corrija o tipo de filtro abaixo e clique OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Passo 1: Descobrir o que bloquear"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Dinamarquês"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (recomendado)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ nesta página",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Subframe"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"actualizado há 1 hora atrás"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Coreano"
+    "message":"Polaco"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"ou Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Qual é o seu nome?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"A extensão mais popular para o Chrome, com mais de 40 milhões de utilizadores! Bloqueia anúncios por todo o lado na Web."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Mostrar todos os pedidos"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Não quero verificar isto"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Sim"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Personalizar"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Parar AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Tem a certeza que quer subscrever à lista de filtros de $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Onde é que se encontra exactamente o anúncio nessa página? O que está a ver?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"ou AdBlock para Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"defenição de estilo"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Limite da regra de Bloqueio de Conteúdos ultrapassado"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Encontrar anúncios...<br/><br/><i>Isto vai demorar um pouco.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"O domínio ou o URL onde AdBlock não deve bloquear nada"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ ao todo",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Tudo pronto!  Em breve iremos entrar em contato, provavelmente dentro de um dia, ou dois se for um feriado. Entretanto, aguarde por um email da AdBlock. Irá encontrar um link para o seu ticket no nosso site de ajuda. Se preferir acompanhar por email, também pode fazer!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Não"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Alguma coisa aconteceu de errado. Nenhum recurso foi enviado. Esta página vai ser fechada. Tente recarregar o site."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ucraniano"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"actualizado há $minutes$ minutos atrás",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Já não se encontra inscrito na lista de filtros de Anúncios Aceitáveis."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Proteção contra malware"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Guardar"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Atenção: em todos os outros sites, vais ver anúncios!<br>Isto ultrapassa todos os outros filtros para esses sites."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Desativar estas notificações"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"A inscrever-se na lista de filtros..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Está a usar uma versão antiga do AdBlock. Por favor vá à <a href='#'>página das extensões</a>, active o 'Modo de programador' e clique 'Atualizar extensões agora'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Opções AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Verificação de malware que poderá estar a injectar anúncios:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Mostar as operações na Consola de Logs (torna o AdBlock lento)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Excedeu o limite de tamanho do Dropbox. Por favor, remova alguns dos seus filtros personalizados ou desativados e volte a tentar."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Retomar AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Solução para a não reprodução dos vídeos no site Hulu.com (necessita de reiniciar o browser)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS para corresponder"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Excluir"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Desactive todas as extensões à excepção do AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Crédito pela tradução vai para:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"A CARREGAR..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Clique com o botão direito do rato num anúncio para bloquear -- ou bloqueie manualmente aqui."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Nota: Colocar na lista branca (permitir anúncios) numa página ou num site não é compatível com o Bloqueio de Conteúdos do Safari ativado."
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Só usaremos o seu contato caso seja necessário mais informações."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Editar filtros desactivados:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Ativar o Bloqueio de Conteúdos do Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Qual é o seu endereço de e-mail?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Para ocultar o botão, faça clique com o botão da direita na barra de ferramentas do Safari e escolha Personalizar barra de ferramentas e, em seguida, arraste o botão do AdBlock para fora da barra de ferramentas. Pode visualizá-lo novamente, arrastando-o de novo para a barra de ferramentas."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Houve um erro ao processar o seu pedido."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"página"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Feito! Recarregámos a página com o anúncio. Por favor, verifique essa página para confirmar se o anúncio desapareceu. Em seguida, volte a esta página e responda à pergunta abaixo."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Ou escreva um URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Está a usar uma versão antiga do Safari. Obtenha a última versão para usar o botão AdBlock para pausar o AdBlock, colocar websites na lista de permissão e reportar anúncios. <a>Actualizar agora</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Clique no menu Safari &rarr; Preferências &rarr; Extensões."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Parar de bloquear anúncios:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Bloquear!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"O anúncio continua a aparecer?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Búlgaro"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Ótimo! Agora vamos descobrir qual é extensão que está a dar problemas. Habilite as extensões uma de cada vez. A extensão que fizer aparecer o anúncio(s) é aquela que precisa de desinstalar de maneira a livrar-se dos anúncios."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Falhou!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Editar manualmente os filtros:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italiano"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tipo"
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Não quero verificar isto"
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Tenha cuidado: se cometer um erro aqui, muitos dos outros filtros, incluindo os oficiais, vão deixar de funcionar!<br/>Leia o <a>tutorial da sintaxe de filtros</a> para aprender a adicionar avançadas listas negras e listas brancas manualmente."
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Inscrever-se para filtrar listas"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Pode ligar isto novamente e suportar os sites que ama bastando selecionar \"Permitir alguma publicidade não intrusiva\" abaixo."
-  },
   "checkinfirefox_5":{
     "description":"Instruction for how to check Firefox/Chrome for a reported ad",
     "message":"O anúncio também aparece nesse browser?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Não correr nesta página"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Lituano"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Deixe-nos saber no nosso <a>site de suporte</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock está em pausa."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Não podemos bloquear anúncios dentro do Flash e outros plugins ainda. Estamos a aguardar o apoio do navegador e do WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"O que há de novo na versão mais recente? Veja a <a style='cursor:pointer;'>lista de alterações</a>!"
   },
   "aamessageadreport":{
     "description":"Acceptable Ads message on ad report page",
     "message":"Se preferir não ver anúncios como este, pode desativar a lista de filtros de Anúncios Aceitáveis."
   },
-  "typeother":{
-    "description":"A resource type",
-    "message":"outro"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Nenhum filtro especificado!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"desconhecido"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Japonês"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Permitir alguma publicidade não intrusiva"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Cancelar"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Você pode deslizar abaixo para alterar as páginas em que o AdBlock não será executado."
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Última etapa: reportar o problema."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Verificar no Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Para denunciar um anúncio, é necessário estar conectado à internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (recomendado)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Denunciar um anúncio"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Listas de Filtros de Bloqueio de Anúncios"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Como?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permitir anúncios de canais específicos do YouTube"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Terceiros"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (remove os aborrecimentos da Web)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - clique para detalhes"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"actualizado há $hours$ horas atrás",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Russo e Ucraniano"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permitir que o AdBlock recolha lista de filtros usados e dados de forma anónima"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"As extensões que foram desactivadas anteriormente foram reactivadas."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grego"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Eslovaco"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videos e Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"O que acha que vai ser verdade sobre este anúncio cada vez que visita esta página?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Activar o AdBlock nesta página"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Voltar"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"As listas de filtros bloqueiam maior parte dos anúncios. Também pode:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Verifique os filtros de Anúncios Aceitáveis:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Mostrar anúncios numa certa página ou domínio"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Corresponde <b>1</b> item nesta página."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Esconder uma parte da página"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Whitelist canal $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opções gerais"
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock não corre nas seguintes páginas:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Nós não temos uma lista padrão de filtros para esse idioma.<br/> Por favor tente encontrar uma lista apropriada que suporte esse idioma $link$ ou bloqueie o anúncio só para si em 'Personalizar'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Inscrever-se"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Visualizar opções avançadas"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Espanhol"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Carregado na página do domínio:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Clica aqui: <a>Actualizar os meus filtros!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Quanto mais listas de filtros usar, mais lento será o funcionamento do AdBlock. Usar demasiadas listas até pode provocar um bloqueio do seu browser em alguns websites. Clique em OK para subscrever esta lista de qualquer forma."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Último passo: O que torna isto num anúncio?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Corresponde $matchcount$ items nesta página.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Também temos uma <a>página</a> para ajudá-lo a descobrir as pessoas por detrás do AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonésio"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turco"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Bloquear um anúncio"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Listas de Filtros Personalizados"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL da frame: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"O propósito desta questão é determinar quem deve receber o seu relatório. Se responder a esta pergunta incorrectamente, o relatório será enviado às pessoas erradas, por isso pode ser ignorado."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Adicionar itens ao menu do botão direito"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"selector"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Bloquear este anúncio"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"A nossa equipa solicitou algumas informações de depuração? Clique <a href='#' id='debug'>aqui</a> para isso!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Não correr o AdBlock em..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Reportar anúncios é voluntário. Ajuda outras pessoas ao permitir que os responsáveis pela lista de filtro bloqueiem o anúncio para todos. Se não te sentes altruísta agora, tudo okay. Feche esta página e <a>bloqueie o anúncio</a> apenas para si mesmo."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Elemento oculto"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Recarregar a página."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"página"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Holandês"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"O nome de ficheiro é muito longo. Por favor altere o nome para um que seja mais curto."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Não se esqueça de guardar!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"A verificar se há atualizações (só deve demorar alguns segundos)..."
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Geral"
+    "message":"Lituano"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Inscreva-se nesta lista de filtros e tente novamente: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"O AdBlock deve notificá-lo quando detecta malware?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"O seu computador pode estar infectado por um malware.  Clique <a>aqui</a> para obter mais informações."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Mostrar o número de anúncios bloqueados no menu AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Mostrar anúncios numa certa página ou domínio"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Site:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock filtros personalizados (recomendado)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Letão"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Verifique se está a usar o(s) filtro(s) de idioma correto(s):"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS para corresponder"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Para ocultar o botão, aceda a opera://extensions e active a opção 'Ocultar da barra de ferramentas'. Para visualizar outra vez desactive essa opção."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Não tem a certeza?</b> apenas pressione 'Bloquear!' em baixo."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Filtro correspondente"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Actualizando... por favor aguarde."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Todos os recursos"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock está actualizado!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Não correr nas páginas deste site"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Hebraico"
+    "message":"Eslovaco"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Arrasta o marcador até que o anúncio seja removido completamente nesta página."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Bloqueia anúncios que contêm o seguinte texto"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Desfazer os meus bloqueios neste domínio"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"actualizado há 1 dia atrás"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Anúncios aceitáveis (recomendado)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Clique aqui: <a>Desativar Anúncios Aceitáveis</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versão $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Instale o Adblock Plus no Firefox $chrome$ caso não o tenha instalado.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Remover da lista"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Nós não temos uma lista padrão de filtros para esse idioma.<br/> Por favor tente encontrar uma lista apropriada que suporte esse idioma $link$ ou bloqueie o anúncio só para si em 'Personalizar'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Esse ficheiro não é uma imagem. Por favor, fazer carregue um ficheiro do tipo .png, .gif, ou .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Porque não nos envia um <a>relatório de erro</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"Ocultado"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Lista de filtros"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Domínio de frame: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Clica no anúncio e eu vou-te ajudar a bloqueá-lo."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Frame superior"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"defenição de estilo"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"desconhecido"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Desculpe, o AdBlock foi desactivado nesta página por uma das suas listas de filtros."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Terceiros"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Nenhum filtro especificado!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Grego"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Está a usar uma versão antiga do AdBlock. Por favor vá à <a href='#'>página das extensões</a>, active o 'Modo de programador' e clique 'Atualizar extensões agora'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Qual é o seu nome?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Solução para a não reprodução dos vídeos no site Hulu.com (necessita de reiniciar o browser)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Aviso: nenhum filtro especificado!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Personalizar"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Encontrou um anúncio numa página da web? Nós vamos ajudá-lo a encontrar o lugar certo para denunciá-lo!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Estoniano"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customizar AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Búlgaro"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Recursos com permissão"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Limite da regra de Bloqueio de Conteúdos ultrapassado"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Não correr o AdBlock em..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Bloqueia anúncios que contêm o seguinte texto"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Fechar"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Verificar no Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Último passo: O que torna isto num anúncio?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Se está a ver um anúncio, não faça um relatório de erro, faça um <a>relatório de anúncio</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Coreano"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Porque não nos envia um <a>relatório de erro</a>?"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finlandês"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ucraniano"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Nenhum malware encontrado."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Por favor, desinscreva-se de algumas listas de filtros. Mais informações nas opções do AdBlock."
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Também temos uma <a>página</a> para ajudá-lo a descobrir as pessoas por detrás do AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"aqui"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Recarregar a página."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Em que idioma está a página escrita?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock está em pausa."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Retomar AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Encontrar anúncios...<br/><br/><i>Isto vai demorar um pouco.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock está desactivado neste site."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Nesse browser, subscreva às mesmas listas de filtros que tem aqui."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Bloquear um anúncio"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Atenção: em todos os outros sites, vais ver anúncios!<br>Isto ultrapassa todos os outros filtros para esses sites."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Está disponível uma actualização para o AdBlock! Aceda $here$ para actualizar. <br> Nota: Se quiser receber actualizações automáticas, clique em Safari > Preferências > Extensões > Actualizações <br> e active a opção 'Instalar Actualizações Automaticamente'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Terminado!"
   },
-  "headerresource":{
-    "description":"Resource list page: title of a column",
-    "message":"Recurso"
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock filtros personalizados (recomendado)"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Bloquear um anúncio nesta página"
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tipo"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Certifique-se que as suas listas de filtros estão actualizadas:"
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"O que é isto?"
   },
-  "lang_english":{
+  "filterjapanese":{
     "description":"language",
-    "message":"Inglês"
+    "message":"Japonês"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Abra a página de extensões para activar as extensões que foram desactivadas anteriormente."
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Origem do filtro:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domínio da página para aplicar em"
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Inscrever-se para filtrar listas"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Site:"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Adicione filtros para outro idioma: "
+  },
+  "headerfilter":{
+    "description":"Resource list page: title of a column",
+    "message":"Filtro correspondente"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"As listas de filtros bloqueiam maior parte dos anúncios. Também pode:"
+  },
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Para ocultar o botão, faça clique com o botão da direita na barra de ferramentas do Safari e escolha Personalizar barra de ferramentas e, em seguida, arraste o botão do AdBlock para fora da barra de ferramentas. Pode visualizá-lo novamente, arrastando-o de novo para a barra de ferramentas."
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Excedeu o limite de tamanho do Dropbox. Por favor, remova alguns dos seus filtros personalizados ou desativados e volte a tentar."
+  },
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Inscrever-se"
+  },
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Nota: Colocar na lista branca (permitir anúncios) numa página ou num site não é compatível com o Bloqueio de Conteúdos do Safari ativado."
+  },
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Elemento bloqueado:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"página"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"outro"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Clica aqui: <a>Actualizar os meus filtros!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Elemento oculto"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Para ocultar o botão, aceda a opera://extensions e active a opção 'Ocultar da barra de ferramentas'. Para visualizar outra vez desactive essa opção."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Página:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Encontrou um erro?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Bloquear!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permitir anúncios de canais específicos do YouTube"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Não podemos bloquear anúncios dentro do Flash e outros plugins ainda. Estamos a aguardar o apoio do navegador e do WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Árabe"
+    "message":"Húngaro"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Bloquear este anúncio"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Activar o AdBlock nesta página"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Mostrar o número de anúncios bloqueados no botão AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Falhou!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Parar AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Checo"
+    "message":"Inglês"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Pague o que quiser!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Adicionar itens ao menu do botão direito"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Quer saber o que faz o AdBlock trabalhar?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Por favor aceda ao <a>nosso site de suporte</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Lista de Remoção de Avisos Adblock (remove avisos acerca do uso de bloqueadores de anúncios)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"URL de lista inválido. Vai ser apagado."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"página"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Editar"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Tem a certeza que deseja remover os $count$ bloqueios que criou em $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Tem alguma questão ou uma ideia nova?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legenda: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Esqueceu-se de anexar a captura de ecrã! Nós não conseguimos ajudá-lo sem ver o(s) anúncio(s) que está a reportar."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>OU</b>, simplesmente clique neste botão para que façamos tudo o que precede: <a>Desactivar todas as outras extensões</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"actualizado há $minutes$ minutos atrás",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Saber mais acerca do malware"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Anexe uma captura de ecrã:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Romêno"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Editar filtros desactivados:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Subframe"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Actualizar a página com o anúncio."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Ativar o Bloqueio de Conteúdos do Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Instale o Firefox $chrome$ caso não o tenha instalado.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Lista de filtros"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Se criou um filtro manualmente usando o assistente de \"bloquear um anúncio\", cole-o na caixa abaixo:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Esse ficheiro é muito grande. Por favor, certifique-se que o seu ficheiro ocupa menos de 10 MB."
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Visualizar opções avançadas"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Chinês"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"O filtro é inválido: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"A inscrever-se na lista de filtros..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Abra a página de extensões para activar as extensões que foram desactivadas anteriormente."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Desativar estas notificações"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turco"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Não subscrever mais do que o necessário - cada lista torna-o um pouco mais lento! Créditos e mais listas podem ser encontradas <a>aqui</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonésio"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"imagem"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ ao todo",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Cancelar"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Não se esqueça de guardar!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"selector"
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Islandês"
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Tem a certeza que quer subscrever à lista de filtros de $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Bloquear anúncios apenas nestes sites:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Carregado na página do domínio:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"As extensões que foram desactivadas anteriormente foram reactivadas."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Limpar esta lista"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Ajude a espalhar a palavra!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Actualizações AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Lista de Remoção de Avisos Adblock (remove avisos acerca do uso de bloqueadores de anúncios)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Opções AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Houve um erro ao processar o seu pedido."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"actualizado há 1 hora atrás"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"A verificar se há atualizações (só deve demorar alguns segundos)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"actualizado agora mesmo"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Clique com o botão direito do rato num anúncio para bloquear -- ou bloqueie manualmente aqui."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Verificação de malware que poderá estar a injectar anúncios:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Suporte AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tipo"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Arrasta o marcador até que o anúncio seja removido completamente nesta página."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"actualizado há 1 minuto atrás"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Recurso bloqueado"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"As informações a seguir também serão incluídas no relatório de anúncio."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Dinamarquês"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Verifique os filtros de Anúncios Aceitáveis:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Pode ligar isto novamente e suportar os sites que ama bastando selecionar \"Permitir alguma publicidade não intrusiva\" abaixo."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Actualizando... por favor aguarde."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"URL de lista inválido. Vai ser apagado."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opções gerais"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Desactive a opção 'Activado' ao lado de cada extensão <b>excepto</b> para o AdBlock.  <b>Deixe o AdBlock activado</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Nesse browser, carregue a página com o anúncio."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Mostrar anúncios <i>em todo o lado</i> excepto para estes sites..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Esqueceu-se de anexar a captura de ecrã! Nós não conseguimos ajudá-lo sem ver o(s) anúncio(s) que está a reportar."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"E crie manualmente um ticket, e copie e cole as informações abaixo para a secção \"Fill in any details you think will help us understand your issue\"."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Para ocultar o botão, faça clique direito sobre ele e seleccione Ocultar botão. Pode visualizá-lo novamente em chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebraico"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Esta funcionalidade do AdBlock não funciona neste site porque apresenta tecnologia desactualizada. Pode colocar na lista negra ou nos recursos da whitelist manualmente no separador 'Personalizar' da página de opções."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Checo e Eslovaco"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Desactivámos todas as outras extensões. Vamos agora recarregar a página com o anúncio. Um segundo, por favor."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Outras Listas de Filtros"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Francês"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"As actualizações são automáticas; mas também pode <a>actualizar manualmente</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Elemento bloqueado:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Mostrar todos os pedidos"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"objecto interactivo"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Quanto mais listas de filtros usar, mais lento será o funcionamento do AdBlock. Usar demasiadas listas até pode provocar um bloqueio do seu browser em alguns websites. Clique em OK para subscrever esta lista de qualquer forma."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Ótimo! Está tudo pronto."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Abra a <a href='#'>página das extensões</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Tudo pronto!  Em breve iremos entrar em contato, provavelmente dentro de um dia, ou dois se for um feriado. Entretanto, aguarde por um email da AdBlock. Irá encontrar um link para o seu ticket no nosso site de ajuda. Se preferir acompanhar por email, também pode fazer!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Saiba mais acerca do programa de Anúncios Aceitáveis."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"O AdBlock deve notificá-lo quando detecta malware?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"actualizado agora mesmo"
+    "message":"actualizado há 1 dia atrás"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL da frame: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Alemão"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"O nome de ficheiro é muito longo. Por favor altere o nome para um que seja mais curto."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"actualizado há $seconds$ segundos atrás",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Não correr nesta página"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Deixe-nos saber no nosso <a>site de suporte</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Feito! Recarregámos a página com o anúncio. Por favor, verifique essa página para confirmar se o anúncio desapareceu. Em seguida, volte a esta página e responda à pergunta abaixo."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Todos os recursos"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Whitelist canal $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Recurso"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Mostrar o número de anúncios bloqueados no menu AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Denunciar um anúncio"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Como?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Não correr nas páginas deste site"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Listas de Filtros Personalizados"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Bloquear mais anúncios:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Informação pedida está ausente ou inválida.  Por favor preencha as perguntas que têm uma borda vermelha."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"O domínio ou o URL onde AdBlock não deve bloquear nada"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Já não se encontra inscrito na lista de filtros de Anúncios Aceitáveis."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (remove os aborrecimentos da Web)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"O AdBlock bloqueou um download de um site conhecido por alojar malware."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Guardar"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Não tem a certeza?</b> apenas pressione 'Bloquear!' em baixo."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Última etapa: reportar o problema."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"O propósito desta questão é determinar quem deve receber o seu relatório. Se responder a esta pergunta incorrectamente, o relatório será enviado às pessoas erradas, por isso pode ser ignorado."
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Parece bem"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permitir que o AdBlock recolha lista de filtros usados e dados de forma anónima"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Para denunciar um anúncio, é necessário estar conectado à internet."
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Listas de Filtros de Bloqueio de Anúncios"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"actualizado há $days$ dias atrás",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"objecto interactivo"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"O que acha que vai ser verdade sobre este anúncio cada vez que visita esta página?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Anúncios bloqueados:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Árabe"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Desfazer os meus bloqueios neste domínio"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Editar manualmente os filtros:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Passo 1: Descobrir o que bloquear"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Por favor, corrija o tipo de filtro abaixo e clique OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Crédito pela tradução vai para:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock está actualizado!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Apenas em inglês"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>OU</b>, simplesmente clique neste botão para que façamos tudo o que precede: <a>Desactivar todas as outras extensões</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"O que há de novo na versão mais recente? Veja a <a style='cursor:pointer;'>lista de alterações</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (protecção da privacidade)"
+    "message":"Lista de filtros anti-social (remove os botões dos meios de comunicação social)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Denunciar um anúncio nesta página"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Proteção contra malware"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Limpar esta lista"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock não corre nas seguintes páginas:"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Alemão"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Acabou de exceder a quantidade de armazenamento que o AdBlock pode usar. Por favor, desinscreva-se de algumas listas!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Cuidado: este filtro bloqueia todos os $elementtype$ elementos nesta página!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"aqui"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Qual é o seu endereço de e-mail?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Em que idioma está a página escrita?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Quer saber o que faz o AdBlock trabalhar?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Tem a certeza que deseja remover os $count$ bloqueios que criou em $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"imagem"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Esconder uma parte da página"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"E crie manualmente um ticket, e copie e cole as informações abaixo para a secção \"Fill in any details you think will help us understand your issue\"."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Geral"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Para ocultar o botão, faça clique direito sobre ele e seleccione Ocultar botão. Pode visualizá-lo novamente em chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"ou AdBlock para Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Romêno"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videos e Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Algo correu mal durante a verificação de actualizações."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Desactivámos todas as outras extensões. Vamos agora recarregar a página com o anúncio. Um segundo, por favor."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Recursos com permissão"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Ótimo! Agora vamos descobrir qual é extensão que está a dar problemas. Habilite as extensões uma de cada vez. A extensão que fizer aparecer o anúncio(s) é aquela que precisa de desinstalar de maneira a livrar-se dos anúncios."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1353,190 +1175,408 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Checo e Eslovaco"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"ou Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Tipo de frame: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formato: ~site1.com|~site2.com|~news.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Seleccione o Idioma --"
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Instale o Adblock Plus no Firefox $chrome$ caso não o tenha instalado.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Recurso bloqueado"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"O anúncio aparece em ou antes de um filme ou qualquer outro plugin como um jogo em Flash?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ vai ser $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"O filtro, que pode ser alterado na página das Opções:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"O seguinte filtro: <br/> $filter$ <br/> tem um erro: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Fechar"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Bloquear anúncios apenas nestes sites:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Acabou de exceder a quantidade de armazenamento que o AdBlock pode usar. Por favor, desinscreva-se de algumas listas!"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"O filtro é inválido: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, você também pode bloquear este anúncio manualmente."
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Enviar"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finlandês"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Esse ficheiro é muito grande. Por favor, certifique-se que o seu ficheiro ocupa menos de 10 MB."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"As informações a seguir também serão incluídas no relatório de anúncio."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Pague o que quiser!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Isto é um problema com a lista de filtros. Denuncie Aqui: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Desactive a opção 'Activado' ao lado de cada extensão <b>excepto</b> para o AdBlock.  <b>Deixe o AdBlock activado</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Nota: o seu relatório pode tornar-se público. Tenha isso em atenção antes de incluir alguma coisa privada."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Mostrar links para as listas de filtros"
+  "filteritalian":{
+    "description":"language",
+    "message":"Italiano"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Apenas em inglês"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Ajude a espalhar a palavra!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"O anúncio continua a aparecer?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"O AdBlock bloqueou um download de um site conhecido por alojar malware."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Verifique se está a usar o(s) filtro(s) de idioma correto(s):"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legenda: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Certifique-se que as suas listas de filtros estão actualizadas:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Algo correu mal durante a verificação de actualizações."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Clique no menu Safari &rarr; Preferências &rarr; Extensões."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Enviar"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Desinscrever"
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Letão"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Bloquear um anúncio nesta página"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Parar de bloquear anúncios:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Erro ao guardar o ficheiro enviado."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Corresponde $matchcount$ items nesta página.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Falhou a inscrição neste filtro!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Você pode deslizar abaixo para alterar as páginas em que o AdBlock não será executado."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"Ocultado"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"O anúncio aparece em ou antes de um filme ou qualquer outro plugin como um jogo em Flash?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Russo e Ucraniano"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Espanhol"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Cuidado: este filtro bloqueia todos os $elementtype$ elementos nesta página!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Ativar o modo de compatibilidade ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Não"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"O filtro, que pode ser alterado na página das Opções:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Esconder este botão"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Outro"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, você também pode bloquear este anúncio manualmente."
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Russo"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Está a usar uma versão antiga do Safari. Obtenha a última versão para usar o botão AdBlock para pausar o AdBlock, colocar websites na lista de permissão e reportar anúncios. <a>Actualizar agora</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (protecção da privacidade)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ vai ser $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Ou escreva um URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"O seguinte filtro: <br/> $filter$ <br/> tem um erro: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Tipo de frame: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"A CARREGAR..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"A nossa equipa solicitou algumas informações de depuração? Clique <a href='#' id='debug'>aqui</a> para isso!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Denunciar um anúncio nesta página"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Mostar as operações na Consola de Logs (torna o AdBlock lento)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Domínio de frame: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"A extensão mais popular para o Chrome, com mais de 40 milhões de utilizadores! Bloqueia anúncios por todo o lado na Web."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Encontrou um erro?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Checo"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Esse ficheiro não é uma imagem. Por favor, fazer carregue um ficheiro do tipo .png, .gif, ou .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Mostrar links para as listas de filtros"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Permitir alguma publicidade não intrusiva"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Sueco"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Remover da lista"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Seleccione o Idioma --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francês"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Editar"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Suporte"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Por favor aceda ao <a>nosso site de suporte</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Bloquear um anúncio pelo URL"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versão $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Onde é que se encontra exactamente o anúncio nessa página? O que está a ver?"
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Reportar anúncios é voluntário. Ajuda outras pessoas ao permitir que os responsáveis pela lista de filtro bloqueiem o anúncio para todos. Se não te sentes altruísta agora, tudo okay. Feche esta página e <a>bloqueie o anúncio</a> apenas para si mesmo."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Sim"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"O código-fonte está <a>disponível gratuitamente</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holandês"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Só usaremos o seu contato caso seja necessário mais informações."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Corresponde <b>1</b> item nesta página."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"actualizado há $hours$ horas atrás",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Voltar"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Clique aqui: <a>Desativar Anúncios Aceitáveis</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domínio da página para aplicar em"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Actualizações AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Alguma coisa aconteceu de errado. Nenhum recurso foi enviado. Esta página vai ser fechada. Tente recarregar o site."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Saber mais acerca do malware"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Anúncios aceitáveis (recomendado)"
   },
   "safaricontentblockingpausemessage":{
     "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
     "message":"Para pausar o AdBlock com Bloqueio de Conteúdos ativado, por favor selecione Safari (na barra de menus) > Preferências > Extensões > AdBlock e desmarque a opção 'Ativar AdBlock'."
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - clique para detalhes"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Parece bem"
-  },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Abra a <a href='#'>página das extensões</a>."
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Desactive todas as extensões à excepção do AdBlock:"
   }
 }

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -1,723 +1,187 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Reportare reclamă"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Filtre pentru blocare reclame"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Site:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permite whitelisting pentru canale Youtube specifice"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Nici un malware cunoscut găsit."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"În acel browser, subscrie la aceleași liste de filtrare cum ai aici."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - click pentru detalii"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"În acel browser, navighează la pagina cu reclama."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Suedeză"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Ce este nou în ultima versiune? Vezi <a style='cursor:pointer;'> changelog</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blochează mai multe reclame:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Rusă"
+    "message":"Daneză"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Plătiţi ceea ce doriţi!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Ajuta la răspândire!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Dezabonat."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blocheză o reclamă introducându-i link-ul"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Greacă"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Chineză"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video și Flash"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Protecție malware"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Ce crezi că va fi adevărat despre această reclamă de fiecare dată când accesezi această pagină?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Activează AdBlock pe această pagină"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Înapoi"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Arată numărul de reclame blocate pe butonul AdBlock"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Ai o întrebare sau o idee nouă?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Letonă"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Filtrele blochează aproape toate reclamele de pe internet. De asemenea, poți:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Codul sursă este <a>disponibil gratuit</a>!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Arată reclame pe o pagină sau un domeniu"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"S-a găsit un element pe această pagină."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Ascunde o secțiune dintr-o pagină"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Trece pe lista albă canalul $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opțiuni generale"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Computerul poate fi infectat cu malware.  Faceţi clic <a>aici</a> pentru mai multe informaţii."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock nu va rula pe vreo pagină care conține:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Nu avem un filtru predefinit pentru limba ta. <br/> Vă rugăm să căutați un filtru care suportă această limbă $link$ sau blocheză reclama în tabul 'Personalizare'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Adaugă"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Sunt un utilizator avansat, afişează-mi opţiunile avansate"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Ascunde acest buton"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Voi descărca automat actualizări; poţi, de asemenea, să <a>actualizezi acum</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Click aici: <a>Actualizează filtrele</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formatare: ~site1.com|~site2.com|~stiri.site3.org"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock este pauzat."
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"S-au găsit $matchcount$ rezultate",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Avem o <a>pagină</a> pentru a vă ajută sa gasiţi şi oamenii care au ajutat la construirea AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indoneziană"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tip"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Există un update pentru AdBlock! Mergeţi la $here$ pentru actualizare.<br>Notă: Daca doriţi să primiţi automat update-uri, faceţi click pe opţiunea 'Install updates automatically' in Safari > Preferences > Extensions > Updates",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turcă"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Ce-i asta?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Filtre personalizate"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Nu adăuga mai multe filtre decât sunt necesare -- fiecare încetinește navigarea puțin! Credite și alte liste pot fi găsite <a>aici</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definire de stil"
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Această caracteristică AdBlock nu funcţionează pe acest site deoarece nu foloseşte tehnologie de actualitate. Puteţi pune manual resurse pe lista neagră sau albă în tab-ul 'Personalizare' din pagina de opţiuni."
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Scopul acestei întrebări este de a determina cine primește raportul tău."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Poloneză"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Adaugă elemente la meniul clic dreapta"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blochează acest anunț"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"Actualizat în urmă cu $hours$ ore",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"Actualizat în urmă cu $seconds$ secunde",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Echipa noastră a solicitat unele informaţii de depanare? Faceţi clic <a href='#' id='debug'> aici</a> pentru asta!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"obiect interactiv"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Maghiară"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Link invalid. Va fi șters."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Notă: raportul tău poate deveni accesibil publicului. Gândește-te la aceasta înainte de a include ceva privat."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Reîncărcaţi pagina."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"pagină"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Olandeză"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Nu uita să salvezi!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ va fi $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Închide"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Element blocat:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filtrul este invalid: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Atenție: nici un filtru specificat!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Permite AdBlock să colecteze anonim lista de utilizare a filtrului şi datele"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Ar trebui să vă notifice AdBlock atunci când detectează malware?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Arată reclame <i>peste tot</i> cu excepția acestor domenii..."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Arată numărul de reclame blocate în meniul AdBlock"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Opțiuni"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Nu rula AdBlock pe..."
-  },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"XMLHttpRequest"
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Reclame blocate:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Filtre AdBlock personalizate (recomandat)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Adaugă filtru pentru altă limbă: "
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (înlătură deranjurile pe Web)"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Extensiile care au fost dezactivate anterior acum au fost re-activate."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blochează link-urile care contine acest text"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS care se potrivește"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Pentru a ascunde butonul, du-te la opera://extensions şi bifează opţiunea  'Hide from toolbar'. Poate fi afișat din nou prin debifarea acestei opţiuni."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Click pe o reclamă și te voi ajuta să o blochezi."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Raportează o reclamă de pe această pagină"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Rusă și ucraineană"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Preluare... vă rugăm așteptați."
   },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Ai girjă: dacă greșești aici, toate filtrele, inclusiv cele oficiale, pot funcționa greșit! \n<br/>Citește <a>sintaxa filtrelor</a> pentru a învăța cum să adaugi filtre avansate."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"General"
   },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Suport AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Personalizează AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock este actualizat!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ în total",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Ebraică"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Scuze, AdBlock este dezactivat pe această pagină din cauza unui filtru."
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Anulare blocajele mele pe acest domeniu"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Introdu filtrul corect dedesubt și apasă OK"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"Actualizat în urmă cu o zi"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (înlătură deranjurile pe Web)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ pe această pagină",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Nesigur?</b> Doar apasă 'Blocheză-l'."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Link invalid. Va fi șters."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"Actualizat în urmă cu o oră"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Poloneză"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Versiunea $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opțiuni generale"
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Șterge din listă"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Alte"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS care se potrivește"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"ascuns"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Filtre"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Reclama apare înainte sau înăuntru unui film sau plugin (Flash)?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Alte filtre"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"sau Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blocheză-l!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Terminat!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blocheză o reclamă de pe această pagină"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Închide"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Nu doresc să încerc asta"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Arată reclame <i>peste tot</i> cu excepția acestor domenii..."
   },
-  "lang_english":{
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Ai girjă: dacă greșești aici, toate filtrele, inclusiv cele oficiale, pot funcționa greșit! \n<br/>Citește <a>sintaxa filtrelor</a> pentru a învăța cum să adaugi filtre avansate."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Engleză"
+    "message":"Slovacă"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Personalizează"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pauzează AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Sunteţi sigur că doriţi să vă abonaţi la lista de filtrare $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Deschideţi pagina de extensii pentru a activa extensiile care au fost dezactivate anterior."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domeniul paginii pe care se va aplica:"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Coreeană"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Pagina:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Ai găsit un bug?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Pasul 1: Găsește ce vrei să blochezi"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Cehă"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Cu cât ai mai multe filtre, cu atât mai încet funcționează AdBlock. Folosind prea multe filtre poate duce la oprirea navigatorului pe unele site-uri. Apasă OK pentru a adăuga filtrul oricum."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"sau AdBlock pentru Chrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blochează un anunț"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Da"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Reclama apare şi în celălalt browser?"
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Ultimul pas: Ce caracterizează aceasta ca fiind o reclamă?"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Nu rula pe această pagină"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Daneză"
+    "message":"Română"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Pentru a ascunde butonul, click dreapta, iar apoi alege 'Ascundeți butonul'. Pentru a-l arăta trebuie să accesați managerul de extensii."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Ebraică"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Această caracteristică AdBlock nu funcţionează pe acest site deoarece nu foloseşte tehnologie de actualitate. Puteţi pune manual resurse pe lista neagră sau albă în tab-ul 'Personalizare' din pagina de opţiuni."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Cehă și Slovacă"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Alte filtre"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Opțiuni"
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Computerul poate fi infectat cu malware.  Faceţi clic <a>aici</a> pentru mai multe informaţii."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Voi descărca automat actualizări; poţi, de asemenea, să <a>actualizezi acum</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"necunoscut"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Editează"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Arată reclame pe o pagină sau un domeniu"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Căutare reclame... <br/><br/><i>Va rugăm așteptați.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turcă"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domeniul sau link-ul unde AdBlock nu va bloca reclame"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Verificare actualizări (ar trebui să ia doar câteva secunde)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Cu cât ai mai multe filtre, cu atât mai încet funcționează AdBlock. Folosind prea multe filtre poate duce la oprirea navigatorului pe unele site-uri. Apasă OK pentru a adăuga filtrul oricum."
   },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Nu rula pe paginiile din acest domeniu"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Reîncarcă pagina cu reclama."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Instalează Firefox $chrome$ dacă nu le ai.",
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Adaugă acest filtru, iar apoi încearcă din nou: $list_title$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Nu avem un filtru predefinit pentru limba ta. <br/> Vă rugăm să căutați un filtru care suportă această limbă $link$ sau blocheză reclama în tabul 'Personalizare'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -725,234 +189,381 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Click pe o reclamă și te voi ajuta să o blochezi."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"definire de stil"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Actualizări AdBlock"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nu"
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Click dreapta pe o reclamă într-o pagină pentru a o bloca -- sau blocheaz-o aici manual"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Scuze, AdBlock este dezactivat pe această pagină din cauza unui filtru."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Ar trebui să vă notifice AdBlock atunci când detectează malware?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"Actualizat în urmă cu o zi"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Niciun filtru specificat!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Germană"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Adaugă alte filtre"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Greacă"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"Actualizat în urmă cu $seconds$ secunde",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Nesigur?</b> Doar apasă 'Blocheză-l'."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"În acel browser, navighează la pagina cu reclama."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Aduceţi-ne la cunoştinţă pe <a>siteul de suport</a>!"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blocheză reclame doar pe aceste site-uri:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Personalizează"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Pentru a raporta o reclamă, trebuie să fiţi conectat la internet."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Trece pe lista albă canalul $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Ascunde o secțiune dintr-o pagină"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Arată numărul de reclame blocate în meniul AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Reportare reclamă"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgară"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Nu rula pe paginiile din acest domeniu"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Filtre personalizate"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blochează mai multe reclame:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ucraineană"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"Actualizat în urmă cu $minutes$ minute",
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tip"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domeniul sau link-ul unde AdBlock nu va bloca reclame"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Nu rula AdBlock pe..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blochează link-urile care contine acest text"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Exclude"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Verifica în Firefox $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Franceză"
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>Sau</b>, doar faceţi click pe acest buton pentru ca noi să facem toate cele de mai sus: <a>Dezactivaţi toate celelalte extensii</a>"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"Actualizare finalizată acum"
   },
   "savebutton":{
     "description":"Save button",
     "message":"Salvează"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Atenție: pe toate celălalte site-uri vei vedea reclame!<br>Aceasta respinge celălalte filtre pentru acele site-uri."
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
   },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Dezactivaţi aceste notificări"
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Se adaugă filtrul..."
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Arată bine"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Personalizează AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Nici un malware cunoscut găsit."
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permite AdBlock să colecteze anonim lista de utilizare a filtrului şi datele"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Bifează pentru a putea folosi pe Hulu.com în cazul în care nu merge. Este necesară repornirea navigatorului."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finlandeză"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Ascunde acest buton"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Filtre pentru blocare reclame"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"Actualizat în urmă cu $days$ zile",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"obiect interactiv"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (protecție a vieții private)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Ce crezi că va fi adevărat despre această reclamă de fiecare dată când accesezi această pagină?"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Aflaţi mai multe despre malware"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Cehă și Slovacă"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Folosești o versiune veche AdBlock. Vă rugăm să accesați <a href='#'>managerul de extensii</a>, să activați 'Mod dezvoltator' și să faceți click pe 'Actualizați extensiile imediat'."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Opțiuni AdBlock"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Curăţă această listă"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Filtru rețele sociale (elimină butoanele sociale)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Arată declarații de depanare în Consolă (încetinește AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Ai depăşit limita de spaţiu Dropbox. Te rugăm îndepărtează câteva intrări din filtrele proprii sau cele dezactivate şi încearcă din nou."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Activaţi AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Germană"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Fii atent! Acest filtru blochează toate elementele de tip $elementtype$ de pe pagină.",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"aici"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Da"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Bifează pentru a putea folosi pe Hulu.com în cazul în care nu merge. Este necesară repornirea navigatorului."
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Exclude"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"În ce limbă este scrisă pagina?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Sigur doriţi să eliminaţi $count$ blocaje pe care le-aţi creat pe $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"imagine"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Mulțumiri:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"Încărcare..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Click dreapta pe o reclamă într-o pagină pentru a o bloca -- sau blocheaz-o aici manual"
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Pentru a ascunde butonul, click dreapta, iar apoi alege 'Ascundeți butonul'. Pentru a-l arăta trebuie să accesați managerul de extensii."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Română"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Editare filtre dezactivate:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Ceva a mers prost în timp ce se verificau actualizările."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Pentru a ascunde butonul, faceţi clic dreapta pe bara de instrumente din Safari şi alegeţi Customize Toolbar, apoi glisaţi butonul AdBlock afară din bara de instrumente. Îl puteţi afișa din nou trăgându-l înapoi în bara de instrumente."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"Actualizat în urmă cu un minut"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Reclame blocate:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"pagină"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Coreeană"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Anulare blocajele mele pe acest domeniu"
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Editează manual filtrele:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Arată link-urile către listele de filtre"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (recomandat)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Pasul 1: Găsește ce vrei să blochezi"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Avem o <a>pagină</a> pentru a vă ajută sa gasiţi şi oamenii care au ajutat la construirea AdBlock!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Site:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"aici"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"pop-up"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Dacă vedeţi un anunţ, nu faceţi un raport de problemă, faceţi un <a>raport de reclamă</a>!"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock este actualizat!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Reîncărcaţi pagina."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Doar engleză"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Folosești o versiune veche AdBlock. Vă rugăm să accesați <a href='#'>managerul de extensii</a>, să activați 'Mod dezvoltator' și să faceți click pe 'Actualizați extensiile imediat'."
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock este pauzat."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>Sau</b>, doar faceţi click pe acest buton pentru ca noi să facem toate cele de mai sus: <a>Dezactivaţi toate celelalte extensii</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Ce este nou în ultima versiune? Vezi <a style='cursor:pointer;'> changelog</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Filtru rețele sociale (elimină butoanele sociale)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Căutare reclame... <br/><br/><i>Va rugăm așteptați.</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Sunt un utilizator avansat, afişează-mi opţiunile avansate"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"În acel browser, subscrie la aceleași liste de filtrare cum ai aici."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blochează un anunț"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Atenție: pe toate celălalte site-uri vei vedea reclame!<br>Aceasta respinge celălalte filtre pentru acele site-uri."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Extensiile care au fost dezactivate anterior acum au fost re-activate."
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Vreţi să vedeţi cum a fost construit AdBlock?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Filtre AdBlock personalizate (recomandat)"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Ce-i asta?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -964,281 +575,83 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Sau introdu URL-ul:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"sau AdBlock pentru Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Folosești o versiune veche Safari. Instalează ultima versiune pentru a putea folosi butonul din bara de instrumente AdBlock, pentru a permite reclame pe anumite site-uri și pentru a raporta reclame. <a>Actualizează acum</a>."
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Alege Limba --"
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Mulțumiri:"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formatare: ~site1.com|~site2.com|~stiri.site3.org"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Click pe meniul Safari &rarr; Preferințe &rarr; Extensii."
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Oprește blocarea reclamelor:"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video și Flash"
   },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Cea mai populară extensie pentru Chrome, cu peste 40 de milioane de utilizatori! Blochează orice reclamă pe web."
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Filtrele blochează aproape toate reclamele de pe internet. De asemenea, poți:"
   },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Reclama încă apare?"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Pentru a ascunde butonul, faceţi clic dreapta pe bara de instrumente din Safari şi alegeţi Customize Toolbar, apoi glisaţi butonul AdBlock afară din bara de instrumente. Îl puteţi afișa din nou trăgându-l înapoi în bara de instrumente."
   },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Suport"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Ai depăşit limita de spaţiu Dropbox. Te rugăm îndepărtează câteva intrări din filtrele proprii sau cele dezactivate şi încearcă din nou."
   },
-  "filtereasylist_plus_bulgarian":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Bulgară"
+    "message":"Maghiară"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Vreţi să vedeţi cum a fost construit AdBlock?"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"sau Chrome"
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Eșec!"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Adaugă"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filtrul, care poate fi schimbat în Opțiuni:"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Plătiţi ceea ce doriţi!"
   },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"Editează manual filtrele:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Următorul filtru:<br/> $filter$ <br/> are o eroare: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"pop-up"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Glisează cursorul până când reclama este blocată corect și arată bine."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tip"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovacă"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Adaugă alte filtre"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Reclama apare şi în celălalt browser?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Nu rula pe această pagină"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blocheză reclame doar pe aceste site-uri:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Aduceţi-ne la cunoştinţă pe <a>siteul de suport</a>!"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Ultimul pas: Ce caracterizează aceasta ca fiind o reclamă?"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Ai depășit spațiul de stocare pe care AdBlock îl poate folosi. Vă rugăm ștergeți câteva filtre!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Nu putem bloca reclame din plugin-uri (Flash). Avem nevoie de suport de la navigator și de la motorul WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"Poți bloca această reclamă pentru tine în Opțiuni. Mulțumesc!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"General"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"altul"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Submit"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Niciun filtru specificat!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"necunoscut"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finlandeză"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock este dezactivat pe această pagină."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japoneză"
+    "message":"Editare filtre dezactivate:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Aceasta este o problemă de filtru. Reporteaz-o aici: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Debizează caseta de selectare 'Activată' de lângă fiecare extensie, <b>cu excepția</b> AdBlock. <b>Lasă AdBlock activat</b>."
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Element blocat:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Arată link-urile către listele de filtre"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Notă: raportul tău poate deveni accesibil publicului. Gândește-te la aceasta înainte de a include ceva privat."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Doar engleză"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Anulează"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Ajuta la răspândire!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Poți glisa dedesubt pentru a alege exact pe ce pagini AdBlock nu va rula."
-  },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock a blocat descărcarea de pe un site cunoscut că găzduiește malware."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Verifica în Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Activați modul de compatibilitate ClickToFlash"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Adaugă acest filtru, iar apoi încearcă din nou: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Pentru a raporta o reclamă, trebuie să fiţi conectat la internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (recomandat)"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Eșec la preluarea filtrului!"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italiană"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Spaniolă"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Arată bine"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Dacă vedeţi un anunţ, nu faceţi un raport de problemă, faceţi un <a>raport de reclamă</a>!"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Ai o întrebare sau o idee nouă?"
+  "typepage":{
+    "description":"A resource type",
+    "message":"pagină"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1248,5 +661,632 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Reclama încă apare?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"altul"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Click aici: <a>Actualizează filtrele</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Italiană"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Pentru a ascunde butonul, du-te la opera://extensions şi bifează opţiunea  'Hide from toolbar'. Poate fi afișat din nou prin debifarea acestei opţiuni."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Ceva a mers prost în timp ce se verificau actualizările."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Click pe meniul Safari &rarr; Preferințe &rarr; Extensii."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Submit"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Pagina:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Reîncarcă pagina cu reclama."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Dezabonat."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Letonă"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blocheză o reclamă de pe această pagină"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blocheză-l!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Oprește blocarea reclamelor:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Permite whitelisting pentru canale Youtube specifice"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"În ce limbă este scrisă pagina?"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Debizează caseta de selectare 'Activată' de lângă fiecare extensie, <b>cu excepția</b> AdBlock. <b>Lasă AdBlock activat</b>."
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Șterge din listă"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Nu putem bloca reclame din plugin-uri (Flash). Avem nevoie de suport de la navigator și de la motorul WebKit."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Poți glisa dedesubt pentru a alege exact pe ce pagini AdBlock nu va rula."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"ascuns"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock este dezactivat pe această pagină."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Reclama apare înainte sau înăuntru unui film sau plugin (Flash)?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Rusă și ucraineană"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spaniolă"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blochează acest anunț"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Fii atent! Acest filtru blochează toate elementele de tip $elementtype$ de pe pagină.",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Activați modul de compatibilitate ClickToFlash"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nu"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Activează AdBlock pe această pagină"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filtrul, care poate fi schimbat în Opțiuni:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Arată numărul de reclame blocate pe butonul AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Eșec!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pauzează AdBlock"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Următorul filtru:<br/> $filter$ <br/> are o eroare: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Engleză"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Adaugă elemente la meniul clic dreapta"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"Poți bloca această reclamă pentru tine în Opțiuni. Mulțumesc!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Rusă"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Sigur doriţi să eliminaţi $count$ blocaje pe care le-aţi creat pe $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Folosești o versiune veche Safari. Instalează ultima versiune pentru a putea folosi butonul din bara de instrumente AdBlock, pentru a permite reclame pe anumite site-uri și pentru a raporta reclame. <a>Actualizează acum</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (protecție a vieții private)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"XMLHttpRequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ va fi $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Sau introdu URL-ul:"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Terminat!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Activaţi AdBlock"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Adaugă filtru pentru altă limbă: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"Încărcare..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Echipa noastră a solicitat unele informaţii de depanare? Faceţi clic <a href='#' id='debug'> aici</a> pentru asta!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Protecție malware"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Raportează o reclamă de pe această pagină"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Arată declarații de depanare în Consolă (încetinește AdBlock)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Instalează Firefox $chrome$ dacă nu le ai.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Glisează cursorul până când reclama este blocată corect și arată bine."
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Ai depășit spațiul de stocare pe care AdBlock îl poate folosi. Vă rugăm ștergeți câteva filtre!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Cea mai populară extensie pentru Chrome, cu peste 40 de milioane de utilizatori! Blochează orice reclamă pe web."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Ai găsit un bug?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Aflaţi mai multe despre malware"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Filtre"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock nu va rula pe vreo pagină care conține:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Chineză"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filtrul este invalid: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Se adaugă filtrul..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Deschideţi pagina de extensii pentru a activa extensiile care au fost dezactivate anterior."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Dezactivaţi aceste notificări"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"S-au găsit $matchcount$ rezultate",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"Actualizat în urmă cu o oră"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Alege Limba --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Franceză"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indoneziană"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"imagine"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Editează"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Eșec la preluarea filtrului!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ în total",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Suport"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blocheză o reclamă introducându-i link-ul"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Anulează"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Nu uita să salvezi!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Versiunea $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Scopul acestei întrebări este de a determina cine primește raportul tău."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Sunteţi sigur că doriţi să vă abonaţi la lista de filtrare $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Codul sursă este <a>disponibil gratuit</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Olandeză"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Introdu filtrul corect dedesubt și apasă OK"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Există un update pentru AdBlock! Mergeţi la $here$ pentru actualizare.<br>Notă: Daca doriţi să primiţi automat update-uri, faceţi click pe opţiunea 'Install updates automatically' in Safari > Preferences > Extensions > Updates",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"S-a găsit un element pe această pagină."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japoneză"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Curăţă această listă"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"Actualizat în urmă cu $hours$ ore",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Înapoi"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Opțiuni AdBlock"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock a blocat descărcarea de pe un site cunoscut că găzduiește malware."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Nu adăuga mai multe filtre decât sunt necesare -- fiecare încetinește navigarea puțin! Credite și alte liste pot fi găsite <a>aici</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Verificare actualizări (ar trebui să ia doar câteva secunde)..."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Alte"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domeniul paginii pe care se va aplica:"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"Actualizare finalizată acum"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"Actualizat în urmă cu $minutes$ minute",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Cehă"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Suedeză"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Suport AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tip"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"Actualizat în urmă cu un minut"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - click pentru detalii"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Atenție: nici un filtru specificat!"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Приложите скриншот:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Известных вредоносных программ не обнаружено."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"В этом браузере подпишитесь на те же списки фильтров, как у Вас здесь."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock актуальный!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"В этом браузере, загрузите страницу с рекламой."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Шведский"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Блокировать больше рекламы:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Русский"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Отказ от подписки."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Китайский"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Если Вы создали рабочий фильтр с помощью мастера «блокировка рекламы», вставьте его в поле ниже:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Список антисоциальных фильтров (удаляет кнопки социальных средств массовой информации)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Нашли рекламу на странице? Мы поможем вам найти правильное место, чтобы сообщить о ней!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Показать количество заблокированной рекламы на кнопке AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Исходный код <a>в свободном доступе</a> !"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"обновлено 1 минуту назад"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Не удалось извлечь этот фильтр!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Пожалуйста, перезапустите Safari для завершения отключения блокировки содержимого."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Блокировать рекламу по её URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Скрыть эту кнопку"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Я буду вносить обновления автоматически; Вы можете также <a>обновить сейчас</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Формат: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Эстонский"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Тип"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Есть обновление для AdBlock! Перейдите на $here$ для обновления. <br>Примечание: Если Вы хотите получать обновления автоматически, просто нажмите на Safari > Настройки...> Расширения> Обновления<br>и отметьте опцию «Устанавлить обновления автоматически».",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Что это?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Остановить CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Не подписывайтесь на больше чем нужно – каждый из них замедляет чуть-чуть работу! Первоисточники и дополнительные списки Вы можете найти <a>здесь</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Эта функция AdBlock не работает на этом сайте, потому что он использует устаревшие технологии. Вы можете внести её в черный или белый список ресурсов вручную на вкладке «Настроить» страницы параметров."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Польский"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Узнайте больше о программе Приемлемой Рекламы."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"обновлено $seconds$ сек. назад",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Венгерский"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Примечание: отчет может стать общедоступным. Имейте это в виду, прежде чем включать в него что-то личное."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Пожалуйста, отключите некоторые списки фильтров. Больше информации см. в Параметры AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Происхождение фильтра:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Извените, AdBlock отключен на этой странице одним из списков фильтров."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Недопустимый фильтр: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Внимание: фильтр не задан!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock отключен на этой странице."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Показывать рекламу <i>везде</i>, кроме этих доменов..."
+    "message":"Есть вопрос или новая идея?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Параметры"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Извините, CatBlock отключен на этой странице одним из списков фильтров."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Заблокированная реклама:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Добавьте фильтры для другого языка: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Щелкните по рекламе, и я доведу Вас до ее блокировки."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"Поиск фотографий (например: <i>парусная гонка</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Если Вы видите рекламу, не отправляйте отчет об ошибках, отправьте  <a>отчет о рекламе</a>!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Настроить CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Прекрасно! Все настроено."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Другой"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Поддержка AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Настройка AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Необходимая информация отсутствует или недопустима.  Ответьте, пожалуйста, на вопросы в красных рамках."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Ошибка при сохранении загружаемого файла."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Введите правильный фильтр и нажмите OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Шаг 1: Определить, что нужно заблокировать"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Датский"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (рекомендуется)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ на этой странице",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Субфрейм"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"обновлено 1 час назад"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Корейский"
+    "message":"Польский"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"или Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Как Вас зовут?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Наиболее популярное расширение Chrome с более чем 40 миллионами пользователей! Блокирует рекламу по всему Интернету."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Показать все запросы"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Я не хочу проверять это"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Параметры"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Да"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Отменить мои блокировки на этом домене"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Настройка"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Приостановить AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Вы уверены, что хотите подписаться на список фильтров $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Где именно на этой странице появляется реклама? Как это выглядит?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Отключите все расширения, кроме CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"или AdBlock для Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"задание стиля"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Показывать сообщения отладки в Журнале Консоли (замедляет CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Бета"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Превышено ограничение правил Блокировки Содержимого"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Поиск рекламы...<br/><br/><i>Это займет секунды</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"Flickr фотосет URL-адрес (например: $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Домен или URL, где AdBlock не должен ничего блокировать"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"сценарий"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ всего",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Все готово!  Мы скоро свяжемся с Вами, наиболее вероятно в течение одного-двух дней, если это не праздники. Также, найдите в электронной почте письмо от AdBlock. Вы найдете там ссылку на Ваш запрос на нашем сайте помощи. Если Вы предпочитаете следить за результатами по электронной почте, Вы можете делать это тоже!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Нет"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Что-то пошло не так. Ресурсы не были отправлены. Эта страница будет закрыта. Попробуйте перезагрузить сайт."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Украинский"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"обновлено $minutes$ мин. назад",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Мы отписался Вас от Приемлемой Рекламы, потому что Вы включили Блокировку Содержимого в Safari. Одновременно можно выбрать только одно. (<a>Почему?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Вы не подписались на список фильтров приемлемой рекламы."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Защита от вредоносных программ"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Сохранить"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Внимание: на всех других сайтах Вы увидите рекламу!<br>Будут отменены все другие фильтры для этих сайтов."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Отключить эти уведомления"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Подписка на список фильтров..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Вы используете старую версию AdBlock. Пожалуйста, перейдите на <a href='#'>страницу Расширения</a>, включите 'Режим разработчика' и нажмите кнопку 'Обновить расширения'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Параметры AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Проверка наличия вредоносных программ, которые могут добавлять рекламу:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Показывать сообщения отладки в Журнале Консоли (замедляет AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Превышен предельный размер Dropbox. Пожалуйста, удалите некоторые записи из Ваших действующих или отключенных фильтров и повторите попытку."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Возобновить работу AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Решение проблемы Видео на Hulu.com не воспроизводится (требуется перезапуск браузера)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"Соответствующий CSS"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Исключить"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Отключите все расширения, кроме AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Не запускать CatBlock на..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Благодарите за перевод:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"ЗАГРУЗКА..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Щелкните правой кнопкой мыши рекламу на странице, чтобы заблокировать её - или заблокируйте здесь вручную."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Примечание: Белый список (разрешает рекламу) на странице или сайте не поддерживается в Safari блокирование содержимого включена."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Домен или URL, где CatBlock не должен ничего блокировать"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Мы будем использовать его только для связи с Вами, если нам нужно будет больше информации."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Редактировать отключенные фильтры:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Включить Блокировку Содержимого в Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Ваш адрес электронной почты?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Чтобы скрыть кнопку, щелкните правой кнопкой мыши по панели инструментов Safari и выберите Настроить панель инструментов, а затем перетащите кнопку AdBlock с панели инструментов. Вы можете показать её снова, перетащив обратно на панель инструментов."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Произошла ошибка при обработке вашего запроса."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"страница"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Добавить Фотографии"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Готово! Мы перезагрузили страницу с рекламой. Пожалуйста, проверьте пропала реклама на ней или нет. Потом вернитесь на эту страницу и дайте ответы на следующие вопросы."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Или введите URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Вы используете старую версию Safari. Установите последнюю версию, чтобы использовать кнопки панели инструментов AdBlock для приостановки работы AdBlock, использования белого списка веб-сайтов и сообщений о рекламе. <a>Обновить сейчас</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Откройте меню Safari &rarr; Параметры &rarr; Расширения."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Остановить блокировку рекламы:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Блокировать!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Реклама все еще появляется?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Болгарский"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Прекрасно! Теперь давайте выясним, какое расширение является причиной. Попробуйте включать каждое расширение одно за другим. Расширение, которое вернет рекламные объявления необходимо удалить, чтобы избавится от рекламы."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Ошибка!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Редактирование фильтров вручную:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Итальянский"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Тип"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"словацкий"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Подписка на списки фильтров"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Вы можете снова включить это и поддерживать веб-сайты, которые Вы любите, выбрав «Разрешить некоторую ненавязчивую рекламу» ниже."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Реклама появляется в этом браузере тоже?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Не запускать на этой странице"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Литовский"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Дайте нам знать на нашем <a>сайте поддержки</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock приостановлен."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Мы еще не можем блокировать рекламу внутри Флэш и других плагинах. Мы ждем поддержки от браузера и WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Общая"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Если Вы не хотите видеть рекламу вроде этой - вам нужно оставить фильтр Приемлемой Рекламы выключенным."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Ваш компьютер может быть заражен вредоносными программами.  Нажмите <a>здесь</a> для получения дополнительной информации."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"другое"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Фильтр не задан!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"неизвестно"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"аудио/видео"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Японский"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Разрешить некоторую ненавязчивую рекламу"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Отмена"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Вы можете переместиться ниже, чтобы изменить именно те страницы, на которых AdBlock не будет работать."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Мы отключить Блокировку Содержимого в Safari потому, что Вы решили разрешить ненавязчивую рекламу. Одновременно можно выбрать только одно. (<a>Почему?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Последний шаг: сообщите нам о проблеме."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Проверить в Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Чтобы сообщить о рекламе, необходимо подключение к Интернету."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (рекомендуется)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"Flickr фотосет ID (например: $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - отчет о рекламе"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Списки фильтров блокировки рекламы"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Как?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Разрешить заносить определенные каналы YouTube в белый список"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Сторонний"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (удаляет отвлекающее содержимое в интернете)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - нажмите, чтобы увидеть подробности"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"обновлено $hours$ час. назад",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Русский и украинский"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Что нового в последней версии? См. <a style='cursor:pointer;'>changelog</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Расширения, которые были отключены ранее, снова включены."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Греческий"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Скрыть секцию веб-страницы"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Видео и Флэш"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Как Вы думаете, будет правильно видеть эту рекламу каждый раз при посещении этой страницы?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Включить AdBlock на этой странице"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Назад"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Списки фильтров блокируют большинство рекламы в Интернете. Вы также можете:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock приостановлен."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Проверяем фильтры Приемлемой Рекламы:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Показывать рекламу на веб-странице или домене"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Соответствует <b>1</b> элементу на этой странице."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Я не хочу проверять это"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Пожалуйста, перезапустите Safari для завершения отключения блокировки содержимого."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Осторожно: Если Вы сделаете здесь ошибку, много других фильтров, включая официальные фильтры, могут оказаться сломанными тоже! <br/> Прочитайте <a>Учебник по синтаксису фильтров</a>, чтобы научиться дополнять черный и белый списки фильтров."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Канал $name$ белого списка",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Реклама появляется в этом браузере тоже?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Общие параметры"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Если Вы не хотите видеть рекламу вроде этой - вам нужно оставить фильтр Приемлемой Рекламы выключенным."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock не будет работать на соответствующих страницах:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"У нас нет списка фильтров по умолчанию для этого языка.<br/>Пожалуйста, попробуйте найти подходящий список, который поддерживает этот язык $link$, или заблокируйте эту рекламу для себя на вкладке 'Настройка'",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Подписаться"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Я продвинутый пользователь, покажите мне дополнительные опции"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Испанский"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Загружено на страницу с доменом:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Щелкните: <a>Обновить фильтры!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Чем больше списков фильтров Вы используете, тем медленнее работает AdBlock. Использование слишком большого количества списков может привести даже к сбою браузера на некоторых веб-сайтах. Нажмите OK, чтобы подписаться на этот список в любом случае."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Последний шаг: Что делать с этой рекламой?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Соответствует $matchcount$ элементам на этой странице.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"А также у нас есть <a>страница</a>, которая поможет Вам узнать людей, стоящих за AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Индонезийский"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Турецкий"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Заблокировать рекламу"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Пользовательские списки фильтров"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL фрейма: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Цель этого вопроса определить, кто должен получить Ваш отчет. Если Вы ответите на этот вопрос неправильно, то отчет будет направлен не тем людям и может быть проигнорирован."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Добавить элементы в меню правой кнопки мыши"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"селектор"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Блокировать эту рекламу"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Наша команда запросила некоторую отладочную информацию? Нажмите <a href='#' id='debug'>здесь</a>!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Не запускать AdBlock на..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Сообщения о рекламе является добровольным. Это поможет каждому пользователю, благодаря добавлению в список фильтров реклама будет блокироваться у всех пользователей. Если Вы не чувствуете себя альтруистом прямо сейчас - ничего страшного. Просто закройте эту страничку и <a>заблокируйте рекламу</a> только для себя."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Скрытый элемент"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Перезагрузить страницу."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"страница"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Голландский"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Это имя файла слишком длинное. Пожалуйста, дайте Вашему файлу более короткое имя."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Не забудьте сохранить!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Проверка обновлений (займет всего несколько секунд)..."
+    "message":"Литовский"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Подпишитесь на этот список, а затем попробуйте снова: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Следует ли AdBlock уведомляет Вас, когда он обнаруживает вредоносные программы?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Снимите флажок 'Включен' рядом с каждым расширением <b>кроме</b> CatBlock. <b>Оставьте CatBlock включенным</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Ваш компьютер может быть заражен вредоносными программами.  Нажмите <a>здесь</a> для получения дополнительной информации."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Показать количество заблокированной рекламы в меню AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Показывать рекламу на веб-странице или домене"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Сайт:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"пользовательские фильтры AdBlock (рекомендуется)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Латышский"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Убедитесь, что вы используете правильный язык фильтра(ов):"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"Соответствующий CSS"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Чтобы скрыть кнопку, перейдите в  opera://extensions и включите опцию \"Скрыть из панели инструментов\". Вы можете отобразить её снова, сняв эту опцию."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Не уверены?</b> Просто нажмите кнопку 'Блокировать!'."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Соответствующий фильтр"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Получение... подождите."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Все ресурсы"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock актуальный!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Не запускать на страницах этого домена"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Иврит"
+    "message":"словацкий"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Сдвигайте ползунок до тех пор, пока реклама не будет заблокирована правильно, а заблокированный элемент выглядит пригодным."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Блокировать URL, содержащие этот текст"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Добавить несколько фотографий</b> с Flickr!  Вы можете выбрать:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Количество правил списка фильтров превышает ограничение в 50 000 и автоматически уменьшено. Пожалуйста, отпишитесь от некоторых списков фильтров или отключите блокирование содержимого Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"обновлено 1 день назад"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Ненавязчивая реклама (рекомендуется)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Нажмите кнопку: <a>Отключить Приемлемую Рекламу</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Версия $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Установите Adblock Plus для Firefox $chrome$, если у вас его нет.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Удалить из списка"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"У нас нет списка фильтров по умолчанию для этого языка.<br/>Пожалуйста, попробуйте найти подходящий список, который поддерживает этот язык $link$, или заблокируйте эту рекламу для себя на вкладке 'Настройка'",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Это не файл изображения. Пожалуйста, загрузите файл .png, .gif или .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Почему бы Вам не отправить нам <a>сообщение об ошибке</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"скрытие"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Списки фильтров"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Домен фрейма:"
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Щелкните по рекламе, и я доведу Вас до ее блокировки."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Топ фрейм"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"задание стиля"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"неизвестно"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Извените, AdBlock отключен на этой странице одним из списков фильтров."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Сторонний"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Фильтр не задан!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Греческий"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Вы используете старую версию AdBlock. Пожалуйста, перейдите на <a href='#'>страницу Расширения</a>, включите 'Режим разработчика' и нажмите кнопку 'Обновить расширения'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Как Вас зовут?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Решение проблемы Видео на Hulu.com не воспроизводится (требуется перезапуск браузера)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Внимание: фильтр не задан!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Настройка"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Нашли рекламу на странице? Мы поможем вам найти правильное место, чтобы сообщить о ней!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Эстонский"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Настройка AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Болгарский"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Ресурс из белого списка"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Превышено ограничение правил Блокировки Содержимого"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Установите флажок на наборы картинок, которые вы хотите использовать."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Не запускать AdBlock на..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Блокировать URL, содержащие этот текст"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Закрыть"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Проверить в Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Последний шаг: Что делать с этой рекламой?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Если Вы видите рекламу, не отправляйте отчет об ошибках, отправьте  <a>отчет о рекламе</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Корейский"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Вы используете старую версию Safari. Установите последнюю версию, чтобы использовать кнопки панели инструментов AdBlock для приостановки работы AdBlock, использования белого списка веб-сайтов и сообщений о рекламе. <a>Обновить сейчас</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Финский"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"сценарий"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Украинский"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Известных вредоносных программ не обнаружено."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Пожалуйста, отключите некоторые списки фильтров. Больше информации см. в Параметры AdBlock."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Мы отписался Вас от Приемлемой Рекламы, потому что Вы включили Блокировку Содержимого в Safari. Одновременно можно выбрать только одно. (<a>Почему?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"А также у нас есть <a>страница</a>, которая поможет Вам узнать людей, стоящих за AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"здесь"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Перезагрузить страницу."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"На каком языке эта страница?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock приостановлен."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Параметры"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Возобновить работу AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Поиск рекламы...<br/><br/><i>Это займет секунды</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock отключен на этой странице."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"В этом браузере подпишитесь на те же списки фильтров, как у Вас здесь."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Заблокировать рекламу"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Внимание: на всех других сайтах Вы увидите рекламу!<br>Будут отменены все другие фильтры для этих сайтов."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Есть обновление для AdBlock! Перейдите на $here$ для обновления. <br>Примечание: Если Вы хотите получать обновления автоматически, просто нажмите на Safari > Настройки...> Расширения> Обновления<br>и отметьте опцию «Устанавлить обновления автоматически».",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Завершено!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"пользовательские фильтры AdBlock (рекомендуется)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Тип"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Что это?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Японский"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Происхождение фильтра:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Подписка на списки фильтров"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Тип фрейма: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Добавьте фильтры для другого языка: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Ресурс"
+    "message":"Соответствующий фильтр"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Блокировать рекламу на этой странице"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Списки фильтров блокируют большинство рекламы в Интернете. Вы также можете:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Убедитесь, что списки фильтров актуальны:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Чтобы скрыть кнопку, щелкните правой кнопкой мыши по панели инструментов Safari и выберите Настроить панель инструментов, а затем перетащите кнопку AdBlock с панели инструментов. Вы можете показать её снова, перетащив обратно на панель инструментов."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Английский"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Превышен предельный размер Dropbox. Пожалуйста, удалите некоторые записи из Ваших действующих или отключенных фильтров и повторите попытку."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Исландский"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Подписаться"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Откройте страницу расширений, чтобы включить расширения, которые ранее были отключены."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Примечание: Белый список (разрешает рекламу) на странице или сайте не поддерживается в Safari блокирование содержимого включена."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Домен страницы"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Блокируемый элемент:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"страница"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"другое"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Щелкните: <a>Обновить фильтры!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Скрытый элемент"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Чтобы скрыть кнопку, перейдите в  opera://extensions и включите опцию \"Скрыть из панели инструментов\". Вы можете отобразить её снова, сняв эту опцию."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Стр.:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Нашли ошибку?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Блокировать!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Разрешить заносить определенные каналы YouTube в белый список"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Настроить CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"Поиск фотографий (например: <i>парусная гонка</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Мы еще не можем блокировать рекламу внутри Флэш и других плагинах. Мы ждем поддержки от браузера и WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Арабский"
+    "message":"Венгерский"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Блокировать эту рекламу"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Включить AdBlock на этой странице"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Показать количество заблокированной рекламы на кнопке AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Ошибка!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Приостановить AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Чешский"
+    "message":"Английский"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Заплати сколько хочешь!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Добавить элементы в меню правой кнопки мыши"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Хотите увидеть кто продвигает AdBlock?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Пожалуйста, перейдите на <a>наш сайт поддержки</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Список Предупреждений об удалении AdBlock (удаляет предупреждения об использовании блокировщика рекламы)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Недопустимый список URL. Будет удален."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"фрейм"
+    "message":"страница"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Изменить"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Вы уверены, что хотите удалить $count$ блокировок, которые Вы создали на $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Есть вопрос или новая идея?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Условные обозначения: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Вы забыли приложить скриншот! Мы не можем помочь Вам не видя рекламу, о которой Вы сообщаете."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ИЛИ</b>, просто нажмите эту кнопку для нас, чтобы сделать все вышеперечисленное: <a>Отключить все другие расширения</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"обновлено $minutes$ мин. назад",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Подробнее о вредоносных программах"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Приложите скриншот:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Румынский"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Редактировать отключенные фильтры:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Субфрейм"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Перезагрузите страницу с рекламой."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Включить Блокировку Содержимого в Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Установите Firefox $chrome$, если у Вас их нет.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Списки фильтров"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Если Вы создали рабочий фильтр с помощью мастера «блокировка рекламы», вставьте его в поле ниже:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Этот файл слишком большой. Пожалуйста, убедитесь, что ваш файл менее 10 МБ."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock не будет работать на соответствующих страницах:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Китайский"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Недопустимый фильтр: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Подписка на список фильтров..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Откройте страницу расширений, чтобы включить расширения, которые ранее были отключены."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Отключить эти уведомления"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Турецкий"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Не подписывайтесь на больше чем нужно – каждый из них замедляет чуть-чуть работу! Первоисточники и дополнительные списки Вы можете найти <a>здесь</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"фрейм"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Индонезийский"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"изображение"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ всего",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Отмена"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Не забудьте сохранить!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"селектор"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Мы отключить Блокировку Содержимого в Safari потому, что Вы решили разрешить ненавязчивую рекламу. Одновременно можно выбрать только одно. (<a>Почему?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Исландский"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Списки фильтров блокировки рекламы"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Блокировать рекламу только на этих сайтах:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Загружено на страницу с доменом:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Расширения, которые были отключены ранее, снова включены."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Извините, CatBlock отключен на этой странице одним из списков фильтров."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Очистить этот список"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Помогите распространить информацию!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Включить CatBlock на этой странице"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Обновления AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Список Предупреждений об удалении AdBlock (удаляет предупреждения об использовании блокировщика рекламы)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Параметры AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock актуальный!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Произошла ошибка при обработке вашего запроса."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"обновлено 1 час назад"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Проверка обновлений (займет всего несколько секунд)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"обновлено прямо сейчас"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Щелкните правой кнопкой мыши рекламу на странице, чтобы заблокировать её - или заблокируйте здесь вручную."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Проверка наличия вредоносных программ, которые могут добавлять рекламу:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Поддержка AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Тип"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Сдвигайте ползунок до тех пор, пока реклама не будет заблокирована правильно, а заблокированный элемент выглядит пригодным."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"обновлено 1 минуту назад"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"фрейм"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Заблокированный ресурс"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Следующие сведения будут также включены в отчет о рекламе."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Датский"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Проверяем фильтры Приемлемой Рекламы:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Вы можете снова включить это и поддерживать веб-сайты, которые Вы любите, выбрав «Разрешить некоторую ненавязчивую рекламу» ниже."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Получение... подождите."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Недопустимый список URL. Будет удален."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Общие параметры"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock не может работать на этом домене."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Снимите флажок 'Включен' рядом с каждым расширением <b>кроме</b> AdBlock. <b>Оставьте AdBlock включенным</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"В этом браузере, загрузите страницу с рекламой."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Показывать рекламу <i>везде</i>, кроме этих доменов..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Вы забыли приложить скриншот! Мы не можем помочь Вам не видя рекламу, о которой Вы сообщаете."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Показывать сообщения отладки в Журнале Консоли (замедляет CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"И вручную создать карточку, и копировать и вставить информацию ниже в раздел «Fill in any details you think will help us understand your issue»."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Не запускать CatBlock на..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Чтобы скрыть кнопку, нажмите правую кнопку мыши и выберите Скрыть. Вы можете показать её снова в chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Иврит"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Эта функция AdBlock не работает на этом сайте, потому что он использует устаревшие технологии. Вы можете внести её в черный или белый список ресурсов вручную на вкладке «Настроить» страницы параметров."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Чешский и словацкий"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Мы отключили все остальные расширения. Сейчас мы перезагрузим страницу с рекламой. Одну секундочку, пожалуйста."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Другие списки фильтров"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Французский"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Я буду вносить обновления автоматически; Вы можете также <a>обновить сейчас</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Блокируемый элемент:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Показать все запросы"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"интерактивный объект"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Чем больше списков фильтров Вы используете, тем медленнее работает AdBlock. Использование слишком большого количества списков может привести даже к сбою браузера на некоторых веб-сайтах. Нажмите OK, чтобы подписаться на этот список в любом случае."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Прекрасно! Все настроено."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Бета"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Откройте <a href='#'>страницу расширений</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Все готово!  Мы скоро свяжемся с Вами, наиболее вероятно в течение одного-двух дней, если это не праздники. Также, найдите в электронной почте письмо от AdBlock. Вы найдете там ссылку на Ваш запрос на нашем сайте помощи. Если Вы предпочитаете следить за результатами по электронной почте, Вы можете делать это тоже!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Узнайте больше о программе Приемлемой Рекламы."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Следует ли AdBlock уведомляет Вас, когда он обнаруживает вредоносные программы?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"обновлено прямо сейчас"
+    "message":"обновлено 1 день назад"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL фрейма: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Немецкий"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Это имя файла слишком длинное. Пожалуйста, дайте Вашему файлу более короткое имя."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"обновлено $seconds$ сек. назад",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Не запускать на этой странице"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Дайте нам знать на нашем <a>сайте поддержки</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Готово! Мы перезагрузили страницу с рекламой. Пожалуйста, проверьте пропала реклама на ней или нет. Потом вернитесь на эту страницу и дайте ответы на следующие вопросы."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Все ресурсы"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Канал $name$ белого списка",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Ресурс"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Показать количество заблокированной рекламы в меню AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - отчет о рекламе"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Как?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Не запускать на страницах этого домена"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Пользовательские списки фильтров"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Блокировать больше рекламы:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Необходимая информация отсутствует или недопустима.  Ответьте, пожалуйста, на вопросы в красных рамках."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Домен или URL, где AdBlock не должен ничего блокировать"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Вы не подписались на список фильтров приемлемой рекламы."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (удаляет отвлекающее содержимое в интернете)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock заблокировал загрузку с сайта, известного как место размещения вредоносного ПО."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Сохранить"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Не уверены?</b> Просто нажмите кнопку 'Блокировать!'."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Последний шаг: сообщите нам о проблеме."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Остановить CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Где именно на этой странице появляется реклама? Как это выглядит?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Выглядит хорошо"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Разрешить AdBlock сбирать анонимное использование списка фильтров и данные"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Чтобы сообщить о рекламе, необходимо подключение к Интернету."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Вы уверены, что хотите подписаться на список фильтров $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"обновлено $days$ дн. назад",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"фрейм"
+    "message":"интерактивный объект"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Как Вы думаете, будет правильно видеть эту рекламу каждый раз при посещении этой страницы?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Заблокированная реклама:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Арабский"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Отменить мои блокировки на этом домене"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Редактирование фильтров вручную:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Шаг 1: Определить, что нужно заблокировать"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Введите правильный фильтр и нажмите OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Благодарите за перевод:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock актуальный!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Только на английском языке"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ИЛИ</b>, просто нажмите эту кнопку для нас, чтобы сделать все вышеперечисленное: <a>Отключить все другие расширения</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Что нового в последней версии? См. <a style='cursor:pointer;'>changelog</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (конфиденциальность)"
+    "message":"Список антисоциальных фильтров (удаляет кнопки социальных средств массовой информации)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Сообщить о рекламе на этой странице"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Защита от вредоносных программ"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Очистить этот список"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Я продвинутый пользователь, покажите мне дополнительные опции"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Немецкий"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Вы превысили объем памяти, который может использовать AdBlock. Пожалуйста, отключите некоторые списки фильтров!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Осторожно: этот фильтр блокирует все элементы $elementtype$ на странице!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"здесь"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Ваш адрес электронной почты?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"На каком языке эта страница?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Хотите увидеть кто продвигает AdBlock?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Вы уверены, что хотите удалить $count$ блокировок, которые Вы создали на $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Отключите все расширения, кроме CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"изображение"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Скрыть секцию веб-страницы"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"И вручную создать карточку, и копировать и вставить информацию ниже в раздел «Fill in any details you think will help us understand your issue»."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Общая"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Чтобы скрыть кнопку, нажмите правую кнопку мыши и выберите Скрыть. Вы можете показать её снова в chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"или AdBlock для Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Румынский"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Видео и Флэш"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Что-то пошло не так во время проверки обновлений."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Мы отключили все остальные расширения. Сейчас мы перезагрузим страницу с рекламой. Одну секундочку, пожалуйста."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Ресурс из белого списка"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Прекрасно! Теперь давайте выясним, какое расширение является причиной. Попробуйте включать каждое расширение одно за другим. Расширение, которое вернет рекламные объявления необходимо удалить, чтобы избавится от рекламы."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Чешский и словацкий"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"или Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Тип фрейма: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Формат: ~site1.com|~site2.com|~news.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Выберите язык --"
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Установите Adblock Plus для Firefox $chrome$, если у вас его нет.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Заблокированный ресурс"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Отображается ли реклама перед фильмом или любым другим плагином как Flash-игра?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ будет $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Фильтры, которые могут быть изменены на странице Параметры:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Следующий фильтр: <br/> $filter$ <br/> содержит ошибку: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Установите флажок на наборы картинок, которые вы хотите использовать."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Закрыть"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Блокировать рекламу только на этих сайтах:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Вы превысили объем памяти, который может использовать AdBlock. Пожалуйста, отключите некоторые списки фильтров!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Разрешить AdBlock сбирать анонимное использование списка фильтров и данные"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, Вы все равно можете заблокировать эту рекламу для себя на странице Параметры. Спасибо!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock не может работать на этом домене."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Отправить"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Финский"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Этот файл слишком большой. Пожалуйста, убедитесь, что ваш файл менее 10 МБ."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Следующие сведения будут также включены в отчет о рекламе."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Заплати сколько хочешь!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Это проблема со списком фильтров. Сообщите сюда: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Снимите флажок 'Включен' рядом с каждым расширением <b>кроме</b> AdBlock. <b>Оставьте AdBlock включенным</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Примечание: отчет может стать общедоступным. Имейте это в виду, прежде чем включать в него что-то личное."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Показать ссылки на списки фильтров"
+  "filteritalian":{
+    "description":"language",
+    "message":"Итальянский"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Только на английском языке"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"Flickr фотосет ID (например: $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Помогите распространить информацию!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Реклама все еще появляется?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock заблокировал загрузку с сайта, известного как место размещения вредоносного ПО."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Убедитесь, что вы используете правильный язык фильтра(ов):"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Условные обозначения: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Убедитесь, что списки фильтров актуальны:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Что-то пошло не так во время проверки обновлений."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Откройте меню Safari &rarr; Параметры &rarr; Расширения."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Отправить"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"Flickr фотосет URL-адрес (например: $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Отказ от подписки."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"аудио/видео"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Латышский"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Блокировать рекламу на этой странице"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Остановить блокировку рекламы:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Ошибка при сохранении загружаемого файла."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Соответствует $matchcount$ элементам на этой странице.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Не удалось извлечь этот фильтр!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Вы можете переместиться ниже, чтобы изменить именно те страницы, на которых AdBlock не будет работать."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"скрытие"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Отображается ли реклама перед фильмом или любым другим плагином как Flash-игра?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Русский и украинский"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Испанский"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Осторожно: этот фильтр блокирует все элементы $elementtype$ на странице!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Включить режим совместимости ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Нет"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Фильтры, которые могут быть изменены на странице Параметры:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Скрыть эту кнопку"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Другой"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, Вы все равно можете заблокировать эту рекламу для себя на странице Параметры. Спасибо!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Русский"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Почему бы Вам не отправить нам <a>сообщение об ошибке</a>?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (конфиденциальность)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ будет $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Или введите URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Следующий фильтр: <br/> $filter$ <br/> содержит ошибку: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"ЗАГРУЗКА..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Наша команда запросила некоторую отладочную информацию? Нажмите <a href='#' id='debug'>здесь</a>!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Снимите флажок 'Включен' рядом с каждым расширением <b>кроме</b> CatBlock. <b>Оставьте CatBlock включенным</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Количество правил списка фильтров превышает ограничение в 50 000 и автоматически уменьшено. Пожалуйста, отпишитесь от некоторых списков фильтров или отключите блокирование содержимого Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Сообщить о рекламе на этой странице"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Показывать сообщения отладки в Журнале Консоли (замедляет AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Домен фрейма:"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Наиболее популярное расширение Chrome с более чем 40 миллионами пользователей! Блокирует рекламу по всему Интернету."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Нашли ошибку?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Чешский"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Домен или URL, где CatBlock не должен ничего блокировать"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Это не файл изображения. Пожалуйста, загрузите файл .png, .gif или .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Добавить несколько фотографий</b> с Flickr!  Вы можете выбрать:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Показать ссылки на списки фильтров"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Разрешить некоторую ненавязчивую рекламу"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Шведский"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Удалить из списка"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Добавить Фотографии"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Выберите язык --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Французский"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Изменить"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Поддержка"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Пожалуйста, перейдите на <a>наш сайт поддержки</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Блокировать рекламу по её URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Чтобы приостановить AdBlock с включенной Блокировкой Содержимого, пожалуйста, выберите Safari (в строке меню) > Предпочтения > Расширения > AdBlock и снимите флажок 'Включить AdBlock'."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Версия $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Цель этого вопроса определить, кто должен получить Ваш отчет. Если Вы ответите на этот вопрос неправильно, то отчет будет направлен не тем людям и может быть проигнорирован."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Сообщения о рекламе является добровольным. Это поможет каждому пользователю, благодаря добавлению в список фильтров реклама будет блокироваться у всех пользователей. Если Вы не чувствуете себя альтруистом прямо сейчас - ничего страшного. Просто закройте эту страничку и <a>заблокируйте рекламу</a> только для себя."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Да"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Исходный код <a>в свободном доступе</a> !"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Голландский"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Мы будем использовать его только для связи с Вами, если нам нужно будет больше информации."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Соответствует <b>1</b> элементу на этой странице."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"обновлено $hours$ час. назад",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Назад"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Нажмите кнопку: <a>Отключить Приемлемую Рекламу</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Домен страницы"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Обновления AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock приостановлен."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Что-то пошло не так. Ресурсы не были отправлены. Эта страница будет закрыта. Попробуйте перезагрузить сайт."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Подробнее о вредоносных программах"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Сайт:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Ненавязчивая реклама (рекомендуется)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Выглядит хорошо"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Чтобы приостановить AdBlock с включенной Блокировкой Содержимого, пожалуйста, выберите Safari (в строке меню) > Предпочтения > Расширения > AdBlock и снимите флажок 'Включить AdBlock'."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Откройте <a href='#'>страницу расширений</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - нажмите, чтобы увидеть подробности"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Отключите все расширения, кроме AdBlock:"
   }
 }

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -1,723 +1,187 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Nahlásenie reklamy"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Zoznamy filtrov pre blokovanie reklám"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Doména:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Povoliť odblokovanie reklám na konkrétnych YouTube kanáloch"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Zaškrtnite políčko pri súboroch obrázkov, ktoré chcete použiť."
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Malvér nebol nájdený."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Skontrolujte či máte ten istý zoznam filtrov v prehliadači ako aj tu."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - kliknite pre viac informácií"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Prepáčte, ale CatBlock je na tejto stránke zakázaný jedným z vašich filtrov."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Načítajte v prehliadači stránku s reklamou."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Švédčina"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Čo je nové v najnovšej verzii? Pozri <a style='cursor:pointer;'> zoznam zmien</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blokovať viac reklám:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Ruština"
+    "message":"Dánčina"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Zaplaťte, koľko chcete!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Zdieľajte nás!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Odhlásené."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blokovať reklamu podľa jej URL"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Gréčtina"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Čínština"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videá a Flash"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Ochrana pred malvérom"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Myslíte si, že sa budete pozerať na túto reklamu zakaždým, keď navštívite túto stránku?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Zapnúť AdBlock na tejto stránke"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Späť"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Má Vás CatBlock upozorniť, keď zistí malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Zobraziť počet zablokovaných reklám na AdBlock tlačidle"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Máte otázku alebo nový nápad?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Chcete vidieť, kto a čo stojí za CatBlockom?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Lotyština"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Zoznamy filtrov blokujú väčšinu reklám na webe. Môžete tiež:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Zdrojový kód je <a>voľne k dispozícii</a>!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"CatBlock používa príliš veľa pamäte. Prosím, odznačte niekoľko filtrov zo zoznamu!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock je pozastavený."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Zobrazovať reklamy na webovej stránke alebo doméne"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Toto zodpovedá <b>1</b> položke na tejto stránke."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Skryť časť webovej stránky"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Odblokuj kanál $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Hlavné nastavenia"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Váš počítač môže byť napadnutý malwarom.  Kliknite <a>tu</a> pre viac informácií."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock sa nespustí na týchto stránkach:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Nemáme zoznam filtrov pre daný jazyk.<br/>Prosím, skúste nájsť vhodný zoznam pre tento jazyk $link$ alebo si túto reklamu zablokujte len pre seba na záložke 'Prispôsobenie'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Pridať"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Som skúsený používateľ, ukáž mi pokročilé nastavenia"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Vypnite všetky rozšírenia okrem CatBlocku."
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Skryť toto tlačidlo"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Aktualizácie filtrov sa sťahujú automaticky; ale môžete ich aj <a>stiahnuť teraz</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Kliknite tu: <a>Aktualizovať filtre!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Formát: ~stránka1.sk|~stránka2.sk|~správy.site3.sk"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock je pozastavený."
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Toto zodpovedá $matchcount$ položkám na tejto stránke.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Máme pre vás <a>stránku</a>, ktorá vám pomôže nájsť ľudí, ktorí pracujú na AdBlocku!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonézština"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Typ"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"K dispozícii je aktualizácia pre AdBlock! Choďte $here$ pre aktualizáciu AdBlocku. <br>Poznámka: Ak chcete dostávať aktualizácie automaticky, stačí ísť do Safari > Nastavenia... > Rozšírenia > Aktualizácie <br>a začiarknite možnosť \"Automaticky inštalovať aktualizácie\".",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turečtina"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Čo je to?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pozastaviť CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Vlastné zoznamy filtrov"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Neprihlasujte k odberu viac filtrov ako potrebujete -- každý filter naviac spôsobí drobné spomalenie! Poďakovanie a ďalšie zoznamy nájdete <a>tu</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"CSS"
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Táto funkcia AdBlocku nefunguje na tejto stránke, pretože využíva zastarané technológie. Avšak stále môžete zablokovať alebo odblokovať zdroje manuálne v tabe 'Prispôsobenie' na stránke s nastaveniami."
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Účelom tejto otázky je určiť, komu má byť vaše hlásenie odoslané. Ak odpoviete na túto otázku nesprávne, hlásenie môže byť odoslané nesprávnej osobe, ktoré toto hlásenie môže ignorovať."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polština"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Pridať položky do ponuky po kliknutí pravým tlačidlom myši"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokovať túto reklamu"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"aktualizované pred $hours$ hodinami",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"aktualizované pred $seconds$ sekundami",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Vyžiadal si náš tím niektoré ladiace informácie? Kliknite <a href='#' id='debug'>sem</a> pre to!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktívny objekt"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Maďarčina"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Neplatný zoznam URL. Zoznam bude vymazaný."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Poznámka: vaše nahlásenie môže byť verejne dostupné. Majte to na pamäti predtým ako tam vložíte niečo súkromné."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Obnoviť stránku"
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"stránka"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Holandčina"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Nezabudnite uložiť!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ bude $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Zavrieť"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blokovaný prvok:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Tento filter je neplatný: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Upozornenie: nie je vybraný filter!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Povoliť AdBlock zbierať anonymné údaje o používaní filtrov"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Má Vás AdBlock upozorniť, keď zistí malware?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Odčiarknite všetky 'Povolené' políčka <b>okrem</b> CatBlocku.  <b>Nechajte CatBlock zapnutý</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Zobrazovať reklamy <i>všade</i> okrem týchto domén..."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Zobraziť počet zablokovaných reklám v AdBlock menu"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Nastavenia"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Nespúšťať AdBlock na..."
-  },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xml-http žiadosť"
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock je aktuálny!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Počet blokovaných reklám:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock filter (odporúčané)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Pridať filtre pre iný jazyk: "
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (odstraňuje rušivé elementy na webe)"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Rozšírenia ktoré sú zakázané boli znovu povolené."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokovať URL obsahujúce tento text"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS obsahuje"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Ak chcete skryť tlačidlo, navštívte stránku opera://extensions a začiarknite voľbu \"Skryť z panela s nástrojmi\". Tlačidlo môžete zobraziť neskôr zrušením začiarknutia tejto možnosti."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Kliknite na reklamu a ja vám ju pomôžem zablokovať."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"vyhľadať fotky (napríklad <i>závod plachetníc</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Nahlásiť reklamu na tejto stránke"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Doména alebo Url, na ktorej CatBlock nesmie nič blokovať"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Prispôsobenie CatBlocku"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock je na tejto stránke zakázaný."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Ruština a Ukrajinčina"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Načítavam... prosím čakajte."
   },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Buďte opatrní: pokiaľ tu urobíte chybu, veľa iných filtrov, vrátane oficiálnych, môžu byť tiež poškodené!<br/>Prečítajte si <a>filter syntax tutorial (anglicky)</a> kde sa dozviete, ako pridávať pokročilé vlastné filtre a výnimky."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Všeobecné"
   },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Podpora"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Prispôsobenie AdBlocku"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock je aktuálny!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ celkovo",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Hebrejčina"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Prepáčte, ale AdBlock je na tejto stránke zakázaný jedným z vašich filtrov."
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Používate starú verziu prehiadača Safari. Získajte najnovšiu verziu prehliadača Safari, ktorá umožňuje pozastaviť CatBlock stlačením tlačidla na paneli nástrojov, nahlásiť reklamy a poskytuje ďalšie nové funkcie. <a>Aktualizovať prehliadač</a>."
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Pridať nejaké fotky</b> z Flickr!  Môžete:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Vrátiť blokovanie na tejto doméne"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Nižšie zadajte správny filter a stlačte OK"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"aktualizované pred dňom"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta verzia"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (odstraňuje rušivé elementy na webe)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ na tejto stránke",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Nie ste si istí?</b> Tak len stlačte tlačidlo 'Blokovať!' nižšie."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Neplatný zoznam URL. Zoznam bude vymazaný."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"aktualizované pred hodinou"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Polština"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Verzia $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Hlavné nastavenia"
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Odstrániť zo zoznamu"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock sa nedá spustiť na tejto doméne."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Iný"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS obsahuje"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"skrytý"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Zoznam filtrov"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Objavuje sa reklama vo filme alebo pred ním, alebo v akomkoľvek inom doplnku, napr. vo Flash hre?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Ostatné zoznamy filtrov"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"alebo Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokovať!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Dokončené!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blokovať reklamu na tejto stránke"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Zavrieť"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Nechcem to takto kontrolovať"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"Možnosti CatBlocku"
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Zobrazovať reklamy <i>všade</i> okrem týchto domén..."
   },
-  "lang_english":{
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Buďte opatrní: pokiaľ tu urobíte chybu, veľa iných filtrov, vrátane oficiálnych, môžu byť tiež poškodené!<br/>Prečítajte si <a>filter syntax tutorial (anglicky)</a> kde sa dozviete, ako pridávať pokročilé vlastné filtre a výnimky."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Angličtina"
+    "message":"Slovenčina"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Prispôsobenie"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pozastaviť AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Chcete naozaj používať tento zoznam filtrov $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Otvorte stránku s rozšíreniami aby ste ich mohli znovu povoliť."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Používať na stránkach domény"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Kórejčina"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Podstránka:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Našli ste chybu?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Krok 1: Určte, čo sa bude blokovať"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Čeština"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Čím viac filtrov prihlásite, tým bude AdBlock pomalší. Použitie príliš veľa filtrov môže dokonca spôsobiť pád prehliadača na niektorých stránkach. Pre potvrdenie prihlásenia stlačte tlačidlo OK."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"alebo AdBlock pre Chrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokovanie reklamy"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Máme pre vás <a>stránku</a>, ktorá vám pomôže nájsť ľudí, ktorí pracujú na CatBlocku!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Áno"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Zobrazovať chybové hlásenia v konzole (spomaluje CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Tiež sa zobrazuje reklama v tomto prehliadači?"
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Posledný krok: Podľa čoho rozpoznám reklamu?"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Nepoužívať na tejto stránke"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Nespúšťať CatBlock na..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Dánčina"
+    "message":"Rumunčina"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Ak chcete skryť tlačidlo, kliknite naň pravým tlačidlom myši a vyberte Skryť tlačidlo. Tlačidlo môžete zobraziť znovu v chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Čím viac filtrov prihlásite, tým bude CatBlock pomalší. Použitie príliš veľa filtrov môže dokonca spôsobiť pád prehliadača na niektorých stránkach. Pre potvrdenie prihlásenia stlačte tlačidlo OK."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebrejčina"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Táto funkcia AdBlocku nefunguje na tejto stránke, pretože využíva zastarané technológie. Avšak stále môžete zablokovať alebo odblokovať zdroje manuálne v tabe 'Prispôsobenie' na stránke s nastaveniami."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Čeština a Slovenčina"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Táto funkcia CatBlocku nefunguje na tejto stránke, pretože využíva zastarané technológie. Avšak stále môžete zablokovať alebo odblokovať zdroje manuálne v tabe 'Prispôsobenie' na stránke s nastaveniami."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Ostatné zoznamy filtrov"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Nastavenia"
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Váš počítač môže byť napadnutý malwarom.  Kliknite <a>tu</a> pre viac informácií."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Aktualizácie filtrov sa sťahujú automaticky; ale môžete ich aj <a>stiahnuť teraz</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"sub-dokument"
+    "message":"neznámy"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Upraviť"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Zobrazovať reklamy na webovej stránke alebo doméne"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Hľadanie reklám...<br/><br/><i>Môže to chvíľu trvať.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turečtina"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Doména alebo URL, na ktorej AdBlock nesmie nič blokovať"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Kontrola aktualizácií (mala by trvať iba pár sekúnd)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Čím viac filtrov prihlásite, tým bude AdBlock pomalší. Použitie príliš veľa filtrov môže dokonca spôsobiť pád prehliadača na niektorých stránkach. Pre potvrdenie prihlásenia stlačte tlačidlo OK."
   },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skript"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Nespúšťať na podstránkach tejto domény"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Načítajte znovu stránku s reklamou."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Nainštalujte FireFox $chrome$ ak ho nemáte.",
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Prihláste sa k odberu tohoto zoznamu filtrov a skúste to znovu: $list_title$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Nemáme zoznam filtrov pre daný jazyk.<br/>Prosím, skúste nájsť vhodný zoznam pre tento jazyk $link$ alebo si túto reklamu zablokujte len pre seba na záložke 'Prispôsobenie'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -725,234 +189,381 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Zapnúť CatBlock na tejto stránke"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Kliknite na reklamu a ja vám ju pomôžem zablokovať."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"CSS"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Aktualizácie AdBlocku"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nie"
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Kliknite pravým tlačidlom myši na reklamu pre jej zablokovanie -- alebo ju zablokujte ručne tu."
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Prepáčte, ale AdBlock je na tejto stránke zakázaný jedným z vašich filtrov."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Má Vás AdBlock upozorniť, keď zistí malware?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"aktualizované pred dňom"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Zobraziť počet zablokovaných reklám v CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Nebol vybraný filter!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Nemčina"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Zoznam filtrov"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Gréčtina"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Používate starú verziu prehiadača Safari. Získajte najnovšiu verziu prehliadača Safari, ktorá umožňuje pozastaviť CatBlock stlačením tlačidla na paneli nástrojov, nahlásiť reklamy a poskytuje ďalšie nové funkcie. <a>Aktualizovať prehliadač</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"aktualizované pred $seconds$ sekundami",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Nie ste si istí?</b> Tak len stlačte tlačidlo 'Blokovať!' nižšie."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Načítajte v prehliadači stránku s reklamou."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Dajte nám vedieť na našej <a>stránke podpory</a>!"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokovať reklamy len na týchto stránkach:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Nastavením posuvníku nižšie vyberte tie stránky, pri ktorých sa CatBlock nebude spúšťať."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Prispôsobenie"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Ak chcete nahlásiť reklamu, musíte byť pripojený na internet."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Odblokuj kanál $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Skryť časť webovej stránky"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Zobraziť počet zablokovaných reklám v AdBlock menu"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Nahlásenie reklamy"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulharčina"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Nespúšťať na podstránkach tejto domény"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Vlastné zoznamy filtrov"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blokovať viac reklám:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukrainčina"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"aktualizované pred $minutes$ minútami",
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Typ"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Zaškrtnite políčko pri súboroch obrázkov, ktoré chcete použiť."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Doména alebo URL, na ktorej AdBlock nesmie nič blokovať"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Nespúšťať AdBlock na..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokovať URL obsahujúce tento text"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Vylúčiť"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Skontrolujte vo Firefoxe $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Francúzština"
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>alebo</b>, kliknite na toto tlačidlo a my urobíme všetky veci uvedené vyššie: <a>Zakázať všetky ostatné rožšírenia</a>"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"žiadosť objektu"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"aktualizované práve teraz"
   },
   "savebutton":{
     "description":"Save button",
     "message":"Uložiť"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Upozornenie: na všetkých ostatných stránkach uvidíte reklamy!<br>Toto má prednosť pred všetkými ostatnými filtrami pre tieto stránky."
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pozastaviť CatBlock"
   },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Vypnúť tieto notifikácie"
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Prihlasovanie k odberu zoznamu filtrov..."
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Pokračovať"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Zobraz na CatBlock tlačidle"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Prispôsobenie AdBlocku"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Malvér nebol nájdený."
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Povoliť AdBlock zbierať anonymné údaje o používaní filtrov"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Ak máte problémy s prehrávaním videa na Hulu.com, zapnite túto funkciu (vyžaduje reštartovanie prehliadača)"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Fínčina"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Skryť toto tlačidlo"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Zoznamy filtrov pre blokovanie reklám"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"aktualizované pred $days$ dňami",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"sub-dokument"
+    "message":"interaktívny objekt"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (ochrana súkromia)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Myslíte si, že sa budete pozerať na túto reklamu zakaždým, keď navštívite túto stránku?"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Dozvedieť sa viac o malware"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Čeština a Slovenčina"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Používate starú verziu AdBlocku. Prosím choďte na <a href='#'>stránku s rozšíreniami</a>, zapnite 'Režim pre vývojárov' a kliknite na 'Aktualizovať rozšírenia'."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Nastavenia"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Vyčistiť tento zoznam"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisociálny zoznam filtrov (odstraňuje tlačidlá sociálnych sietí)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Zobrazovať chybové hlásenia v konzole (spomaluje AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Prekročili ste limit veľkosti súboru v Dropboxe. Odstráňte niektoré položky z vlastných alebo vypnutých filtrov a skúste to znova."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Spustiť AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Spustiť CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Nemčina"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Buďte opatrní: tento filter blokuje všetky $elementtype$ prvky na stránke!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"tu"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Áno"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Ak máte problémy s prehrávaním videa na Hulu.com, zapnite túto funkciu (vyžaduje reštartovanie prehliadača)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Vylúčiť"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"V akom jazyku je stránka napísaná?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Nespúšťať CatBlock na..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Naozaj chcete odstrániť $count$ blokovania/í, ktoré ste vytvorili na $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"obrázok"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Autorom prekladu je:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"NAČÍTAVAM..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Kliknite pravým tlačidlom myši na reklamu pre jej zablokovanie -- alebo ju zablokujte ručne tu."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Ak chcete skryť tlačidlo, kliknite naň pravým tlačidlom myši a vyberte Skryť tlačidlo. Tlačidlo môžete zobraziť znovu v chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumunčina"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Upraviť vypnuté filtre:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Nastavením posuvníku nižšie vyberte tie stránky, pri ktorých sa CatBlock nebude spúšťať."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Niečo sa pokazilo pri kontrole aktualizácií."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Aby ste skryli tlačidlo, kliknite pravým tlačidlom myši na Safari toolbar, zvoľte 'Prispôsobiť panel s nástrojmi' a odtiahnite AdBlock tlačidlo preč z toolbaru. Ak ho budete znovu chcieť zobraziť, stačí ho presunúť do toolbaru."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"aktualizované pred minútou"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Počet blokovaných reklám:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"stránka"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Pridať fotografie"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Kórejčina"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"zadať adresu FIickr galérie (napr. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Vrátiť blokovanie na tejto doméne"
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Čím viac filtrov prihlásite, tým bude CatBlock pomalší. Použitie príliš veľa filtrov môže dokonca spôsobiť pád prehliadača na niektorých stránkach. Pre potvrdenie prihlásenia stlačte tlačidlo OK."
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Ručne upraviť vlastné filtre:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Odkazy pre zobrazenie zoznamov filtrov"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (odporúčané)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Krok 1: Určte, čo sa bude blokovať"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Máme pre vás <a>stránku</a>, ktorá vám pomôže nájsť ľudí, ktorí pracujú na AdBlocku!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Doména:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"tu"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"vyskakovacie okno"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Ak ste videli reklamu, neposielajte nám hlásenie o chybe ale <a>hlásenie o reklame</a>!"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock je aktuálny!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Obnoviť stránku"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Iba v angličtine"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Používate starú verziu AdBlocku. Prosím choďte na <a href='#'>stránku s rozšíreniami</a>, zapnite 'Režim pre vývojárov' a kliknite na 'Aktualizovať rozšírenia'."
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock je pozastavený."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>alebo</b>, kliknite na toto tlačidlo a my urobíme všetky veci uvedené vyššie: <a>Zakázať všetky ostatné rožšírenia</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Čo je nové v najnovšej verzii? Pozri <a style='cursor:pointer;'> zoznam zmien</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antisociálny zoznam filtrov (odstraňuje tlačidlá sociálnych sietí)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Hľadanie reklám...<br/><br/><i>Môže to chvíľu trvať.</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Som skúsený používateľ, ukáž mi pokročilé nastavenia"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Skontrolujte či máte ten istý zoznam filtrov v prehliadači ako aj tu."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokovanie reklamy"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Upozornenie: na všetkých ostatných stránkach uvidíte reklamy!<br>Toto má prednosť pred všetkými ostatnými filtrami pre tieto stránky."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Rozšírenia ktoré sú zakázané boli znovu povolené."
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Nahradiť reklamy obrázkami mačiek"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Chcete vidieť, kto a čo stojí za AdBlockom?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock filter (odporúčané)"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Vypnite všetky rozšírenia okrem CatBlocku."
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Čo je to?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -964,281 +575,83 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Alebo zadajte URL:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"alebo AdBlock pre Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Používate starú verziu prehiadača Safari. Získajte najnovšiu verziu prehliadača Safari, ktorá umožňuje pozastaviť AdBlock stlačením tlačidla na paneli nástrojov, nahlásiť reklamy a poskytuje ďalšie nové funkcie. <a>Aktualizovať prehliadač</a>."
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"Možnosti CatBlocku"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Zvoľte jazyk --"
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Autorom prekladu je:"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Nahradiť reklamy obrázkami mačiek"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Formát: ~stránka1.sk|~stránka2.sk|~správy.site3.sk"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Kliknite v Safari menu -> Predvoľby -> Rozšírenia."
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Zrušiť blokovanie reklám:"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videá a Flash"
   },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Najobľúbenejšie rozšírenie pre Chrome s viac ako 40 miliónmi používateľov! Blokuje reklamy na celom webe."
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Zoznamy filtrov blokujú väčšinu reklám na webe. Môžete tiež:"
   },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Zobrazuje sa táto reklama stále?"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Aby ste skryli tlačidlo, kliknite pravým tlačidlom myši na Safari toolbar, zvoľte 'Prispôsobiť panel s nástrojmi' a odtiahnite AdBlock tlačidlo preč z toolbaru. Ak ho budete znovu chcieť zobraziť, stačí ho presunúť do toolbaru."
   },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Podpora"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Prekročili ste limit veľkosti súboru v Dropboxe. Odstráňte niektoré položky z vlastných alebo vypnutých filtrov a skúste to znova."
   },
-  "filtereasylist_plus_bulgarian":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Bulharčina"
+    "message":"Maďarčina"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Chcete vidieť, kto a čo stojí za AdBlockom?"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"alebo Chrome"
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Neúspešné!"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Pridať"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filter, ktorý sa dá neskôr zmeniť v nastaveniach:"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Zaplaťte, koľko chcete!"
   },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"Ručne upraviť vlastné filtre:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Následujúci filter:<br/> $filter$ <br/> je chybný: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"vyskakovacie okno"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Nastavte posuvník tak, aby reklama na stránke bola blokovaná a zbytok stránky stále vyzeral uspokojivo."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Typ"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovenčina"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Zoznam filtrov"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Tiež sa zobrazuje reklama v tomto prehliadači?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Nepoužívať na tejto stránke"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokovať reklamy len na týchto stránkach:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Dajte nám vedieť na našej <a>stránke podpory</a>!"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Posledný krok: Podľa čoho rozpoznám reklamu?"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"AdBlock používa príliš veľa pamäte. Prosím, odznačte niekoľko filtrov zo zoznamu!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Zatiaľ nemôžeme blokovať reklamy vo vnútri objektov Flash alebo v iných doplnkoch. Čakáme na podporu prehliadača a WebKitu."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, môžete si zablokovať túto reklamu len pre seba v nastaveniach. Ďakujem!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Všeobecné"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock sa nedá spustiť na tejto doméne."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Táto funkcia CatBlocku nefunguje na tejto stránke, pretože využíva zastarané technológie. Avšak stále môžete zablokovať alebo odblokovať zdroje manuálne v tabe 'Prispôsobenie' na stránke s nastaveniami."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"ostatné"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Potvrdiť"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Nebol vybraný filter!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Zobraz na CatBlock tlačidle"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"neznámy"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Fínčina"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Zobraziť počet zablokovaných reklám v CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock je na tejto stránke zakázaný"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japončina"
+    "message":"Upraviť vypnuté filtre:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Toto je chyba zoznamu filtrov. Nahláste ju tu: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Odčiarknite všetky 'Povolené' políčka <b>okrem</b> AdBlocku.  <b>Nechajte AdBlock zapnutý</b>."
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blokovaný prvok:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Odkazy pre zobrazenie zoznamov filtrov"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Poznámka: vaše nahlásenie môže byť verejne dostupné. Majte to na pamäti predtým ako tam vložíte niečo súkromné."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Iba v angličtine"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Zrušiť"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Zdieľajte nás!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Nastavením posuvníku nižšie vyberte tie stránky, pri ktorých sa AdBlock nebude spúšťať."
-  },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock zablokoval sťahovanie zo stránky na ktorej sa vyskytuje malware."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Skontrolujte vo Firefoxe $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Povoliť spätnú kompatibilitu s doplnkom ClickToFlash"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Prihláste sa k odberu tohoto zoznamu filtrov a skúste to znovu: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Ak chcete nahlásiť reklamu, musíte byť pripojený na internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (odporúčané)"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Aktualizácie CatBlocku"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Nepodarilo sa načítať tento filter!"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Taliančina"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Španielčina"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Pokračovať"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Ak ste videli reklamu, neposielajte nám hlásenie o chybe ale <a>hlásenie o reklame</a>!"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Máte otázku alebo nový nápad?"
+  "typepage":{
+    "description":"A resource type",
+    "message":"stránka"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1248,5 +661,632 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Zobrazuje sa táto reklama stále?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"ostatné"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Kliknite tu: <a>Aktualizovať filtre!</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Taliančina"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Ak chcete skryť tlačidlo, navštívte stránku opera://extensions a začiarknite voľbu \"Skryť z panela s nástrojmi\". Tlačidlo môžete zobraziť neskôr zrušením začiarknutia tejto možnosti."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Niečo sa pokazilo pri kontrole aktualizácií."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Kliknite v Safari menu -> Predvoľby -> Rozšírenia."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"žiadosť objektu"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Potvrdiť"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Podstránka:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Má Vás CatBlock upozorniť, keď zistí malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Načítajte znovu stránku s reklamou."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Odhlásené."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"zadať adresu FIickr galérie (napr. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Lotyština"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blokovať reklamu na tejto stránke"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokovať!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Zrušiť blokovanie reklám:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Povoliť odblokovanie reklám na konkrétnych YouTube kanáloch"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"V akom jazyku je stránka napísaná?"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Odčiarknite všetky 'Povolené' políčka <b>okrem</b> AdBlocku.  <b>Nechajte AdBlock zapnutý</b>."
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Prispôsobenie CatBlocku"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Odstrániť zo zoznamu"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"vyhľadať fotky (napríklad <i>závod plachetníc</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Zatiaľ nemôžeme blokovať reklamy vo vnútri objektov Flash alebo v iných doplnkoch. Čakáme na podporu prehliadača a WebKitu."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Aktualizácie CatBlocku"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Nastavením posuvníku nižšie vyberte tie stránky, pri ktorých sa AdBlock nebude spúšťať."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"skrytý"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock je na tejto stránke zakázaný"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Objavuje sa reklama vo filme alebo pred ním, alebo v akomkoľvek inom doplnku, napr. vo Flash hre?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Ruština a Ukrajinčina"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Španielčina"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokovať túto reklamu"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock je na tejto stránke zakázaný."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Buďte opatrní: tento filter blokuje všetky $elementtype$ prvky na stránke!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Povoliť spätnú kompatibilitu s doplnkom ClickToFlash"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nie"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Zapnúť AdBlock na tejto stránke"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filter, ktorý sa dá neskôr zmeniť v nastaveniach:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Zobraziť počet zablokovaných reklám na AdBlock tlačidle"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Neúspešné!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pozastaviť AdBlock"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Následujúci filter:<br/> $filter$ <br/> je chybný: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Angličtina"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Pridať položky do ponuky po kliknutí pravým tlačidlom myši"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, môžete si zablokovať túto reklamu len pre seba v nastaveniach. Ďakujem!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Ruština"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Naozaj chcete odstrániť $count$ blokovania/í, ktoré ste vytvorili na $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Používate starú verziu prehiadača Safari. Získajte najnovšiu verziu prehliadača Safari, ktorá umožňuje pozastaviť AdBlock stlačením tlačidla na paneli nástrojov, nahlásiť reklamy a poskytuje ďalšie nové funkcie. <a>Aktualizovať prehliadač</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (ochrana súkromia)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"CatBlock používa príliš veľa pamäte. Prosím, odznačte niekoľko filtrov zo zoznamu!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xml-http žiadosť"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ bude $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Alebo zadajte URL:"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Dokončené!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Spustiť AdBlock"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Pridať filtre pre iný jazyk: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"NAČÍTAVAM..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Vyžiadal si náš tím niektoré ladiace informácie? Kliknite <a href='#' id='debug'>sem</a> pre to!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Odčiarknite všetky 'Povolené' políčka <b>okrem</b> CatBlocku.  <b>Nechajte CatBlock zapnutý</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Ochrana pred malvérom"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Nahlásiť reklamu na tejto stránke"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Zobrazovať chybové hlásenia v konzole (spomaluje AdBlock)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Nainštalujte FireFox $chrome$ ak ho nemáte.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Nastavte posuvník tak, aby reklama na stránke bola blokovaná a zbytok stránky stále vyzeral uspokojivo."
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"AdBlock používa príliš veľa pamäte. Prosím, odznačte niekoľko filtrov zo zoznamu!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Najobľúbenejšie rozšírenie pre Chrome s viac ako 40 miliónmi používateľov! Blokuje reklamy na celom webe."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Našli ste chybu?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Dozvedieť sa viac o malware"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Doména alebo Url, na ktorej CatBlock nesmie nič blokovať"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skript"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Pridať nejaké fotky</b> z Flickr!  Môžete:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Zoznam filtrov"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock sa nespustí na týchto stránkach:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Čínština"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Tento filter je neplatný: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Prihlasovanie k odberu zoznamu filtrov..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Otvorte stránku s rozšíreniami aby ste ich mohli znovu povoliť."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Vypnúť tieto notifikácie"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Toto zodpovedá $matchcount$ položkám na tejto stránke.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"aktualizované pred hodinou"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Pridať fotografie"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Zvoľte jazyk --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francúzština"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonézština"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"obrázok"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Upraviť"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Nepodarilo sa načítať tento filter!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ celkovo",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Podpora"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blokovať reklamu podľa jej URL"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Zrušiť"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Nezabudnite uložiť!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Spustiť CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Máme pre vás <a>stránku</a>, ktorá vám pomôže nájsť ľudí, ktorí pracujú na CatBlocku!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Verzia $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Účelom tejto otázky je určiť, komu má byť vaše hlásenie odoslané. Ak odpoviete na túto otázku nesprávne, hlásenie môže byť odoslané nesprávnej osobe, ktoré toto hlásenie môže ignorovať."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Chcete naozaj používať tento zoznam filtrov $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Zdrojový kód je <a>voľne k dispozícii</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holandčina"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Nižšie zadajte správny filter a stlačte OK"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"K dispozícii je aktualizácia pre AdBlock! Choďte $here$ pre aktualizáciu AdBlocku. <br>Poznámka: Ak chcete dostávať aktualizácie automaticky, stačí ísť do Safari > Nastavenia... > Rozšírenia > Aktualizácie <br>a začiarknite možnosť \"Automaticky inštalovať aktualizácie\".",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Toto zodpovedá <b>1</b> položke na tejto stránke."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Prepáčte, ale CatBlock je na tejto stránke zakázaný jedným z vašich filtrov."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japončina"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Vyčistiť tento zoznam"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"aktualizované pred $hours$ hodinami",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Späť"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Nastavenia"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta verzia"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock je aktuálny!"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock zablokoval sťahovanie zo stránky na ktorej sa vyskytuje malware."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Neprihlasujte k odberu viac filtrov ako potrebujete -- každý filter naviac spôsobí drobné spomalenie! Poďakovanie a ďalšie zoznamy nájdete <a>tu</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Kontrola aktualizácií (mala by trvať iba pár sekúnd)..."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Iný"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Používať na stránkach domény"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"aktualizované práve teraz"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock je pozastavený."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"aktualizované pred $minutes$ minútami",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Čeština"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Švédčina"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Podpora"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Typ"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"sub-dokument"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"aktualizované pred minútou"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"sub-dokument"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - kliknite pre viac informácií"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Upozornenie: nie je vybraný filter!"
   }
 }

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -1,1291 +1,1099 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Priložite posnetek zaslona:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Zlonamerna programska oprema ni bila najdena."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"V tistem brskalniku se naročite na iste sezname filtrov kot v tem."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"V tistem brskalniku pojdite na stran z oglasom."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"švedščina"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blokiraj več oglasov:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"ruščina"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Odjavljeno."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"kitajščina"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Seznam antisocialnih filtrov (odstrani gumbe za deljenje vsebine preko socialnih omrežij)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Ste našli oglas na spletni strani? Pomagali vam bomo najti pravi kraj za prijavo!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Prikaži št. blokiranih oglasov na AdBlockovem gumbu"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Naročite se na ta seznam filtrov, nato pa poskusite znova: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Izvorna koda je <a>na voljo brezplačno</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"posodobljeno pred 1 minuto"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Filter ni bil uspešno pridobljen!"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Vaš računalnik je morda okužen z zlonamerno programsko opremo. Kliknite <a>sem</a> za dodatne informacije."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blokiraj oglas z URL naslovom"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Skrij ta gumb"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Posodobitve se bodo izvajale samodejno; vseeno pa lahko <a>posodobite zdaj</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Oblika: ~stran1.com|~stran2.com|~novice.stran3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"estonščina"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Vrsta"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Na voljo je posodobitev za AdBlock! Za posodobitev pojdite $here$. <br> Vedite: Če želite prejemati posodobitve samodejno, kliknite na Safari > Nastavitve > Razširitve > Posodobitve <br> in izberite možnost 'Samodejno namesti posodobitve'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Kaj je to?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Ne naročite se na več kot potrebujete -- vsak filter malce upočasni brskanje. Zasluge in drugi seznami se nahajajo <a>tukaj</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Ta funkcija AdBlocka tukaj ne deluje, ker stran uporablja zastarelo tehnologijo. Vire lahko ročno blokirate ali dovolite v zavihku Prilagodi na strani z nastavitvami."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"poljščina"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Izvedite več o Sprejemljivih oglasih."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"posodobljeno pred naslednjim številom sekund: $seconds$",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"madžarščina"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Opomba: poročilo lahko postane javno dostopno. To imejte v mislih, preden vključite karkoli zasebnega."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"drugo"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ bo $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Oprostite, AdBlock je na tej strani onemogočen s strani enega izmed vaših filtrov."
-  },
-  "filtericelandic":{
-    "description":"language",
-    "message":"islandščina"
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Opozorilo: filter ni določen!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock je onemogočen na tej strani."
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"V kolikor se vam prikazuje oglas, ne prijavite hrošča, temveč pošljite poročilo o <a>oglasu</a>!"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Prikaži oglase <i>povsod</i>, razen na teh domenah..."
+    "message":"Imate vprašanje ali novo idejo?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Možnosti"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Blokirani oglasi:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Filtri za druge jezike: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Kliknite na oglas in vodili vas bomo skozi postopek blokiranja."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Super! Vse je urejeno."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock podpora"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Prilagodite AdBlock"
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Napaka pri shranjevanju priložene datoteke."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Prosimo, vnesite pravilen filter v spodnje polje in izberite 'V redu'"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"1. korak: Kaj želite blokirati?"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"danščina"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (priporočeno)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ na tej strani",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Podokvir"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"posodobljeno pred 1 uro"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"korejščina"
+    "message":"poljščina"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"ali Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Kako vam je ime?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Najbolj priljubljena razširitev za brskalnik Chrome z več kot 40 milijoni uporabnikov!  Blokira oglase po vsem spletu."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Prikaži vse zahteve"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Tega ne želim preveriti"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Da"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Prilagodi"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Začasno ustavi AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Ali ste prepričani, da se želite naročiti na filter $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Kje točno na strani se nahaja oglas? Kako izgleda?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"ali AdBlock za Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definicija stila"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Iskanje oglasov...<br/><br/><i>To bo trajalo le trenutek.</i>"
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domena ali spletni naslov, kjer AdBlock naj ne blokira ničesar"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skripta"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ skupno",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Ne"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Nekaj je šlo narobe. Viri niso bili poslani. Ta stran se bo zdaj zaprla. Poskusite ponovno naložiti spletno stran."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"ukrajinščina"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"posodobljeno pred naslednjim številom minut $minutes$",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Zaščita pred zlonamerno programsko opremo"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Shrani"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Opozorilo: na vseh drugih spletnih mestih boste videli oglase!<br>To povozi vse druge filtre za tista mesta."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Izključi ta sporočila"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Poteka naročanje na seznam filtrov..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Uporabljate staro različico AdBlocka. Prosimo, pojdite na <a href='#'>stran z razširitvami</a>, omogočite 'Način za razvijalce' in kliknite 'Posodobi razširitve'."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock - možnosti"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Preverjanje za zlonamerno programsko opremo, ki lahko vsiljuje oglase:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Pokaži izjave za odpravljanje napak v dnevniku konzole (upočasni AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Presegli ste največjo velikost za storitev Dropbox. Odstranite nekaj vnosov filtrov po meri oz. onemogočenih filtrov in poskusite znova."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Ponovno aktiviraj AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Obidi težavo z nedelovanjem videov na Hulu.com (zahteva ponovni zagon brskalnika)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS, ki mu mora ustrezati"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Izvzemi"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Onemogočite vse razširitve, razen AdBlocka:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Prevod:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"NALAGANJE..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Če želite blokirati oglas, kliknite nanj z desno miškino tipko -- isto pa tudi lahko ročno storite tukaj."
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Kontaktirali vas bomo le v primeru, v kolikor bomo potrebovali dodatne informacije."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Uredi izklopljene filtre:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Omogoči Safari Content Blocking"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Kakšen je vaš e-poštni naslov?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Če želite skriti gumb, z desno miškino tipko kliknite na orodno vrstico, izberite 'Prilagodi orodno vrstico' in povlecite AdBlockov gumb iz orodne vrstice. Znova ga omogočite tako, da ga povlečete nazaj v orodno vrstico."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Prišlo je do napake pri obdelavi vaše zahteve."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"stran"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Končano! Osvežili smo stran z oglasom. Prosimo preverite, ali je oglas izginil. Potem se vrnite na to stran in odgovorite na spodnje vprašanje."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Ali vnesite URL:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Uporabljate staro različico brskalnika Safari. V kolikor želite uporabljati AdBlockov gumb v opravilni vrstici, ga onemogočiti na nekaterih spletnih straneh ter prijavljati oglase, <a>nadgradite zdaj</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Izberite Safari meni &rarr; Nastavitve &rarr; Razširitve."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Ustavi blokiranje oglasov:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokiraj!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Ali se oglas še vedno prikazuje?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"bolgarščina"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Super! Zdaj pa preverimo katera razširitev povzroča težave. Pojdite skozi seznam razširitev in omogočite eno po eno. Razširitev, ki prinese oglas(e) nazaj je tista, ki jo morate odstraniti, da se znebite oglasov."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Ni uspelo!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Ročno uredite vaše filtre:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"italijanščina"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"pojavno okno"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Vrsta"
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Tega ne želim preveriti"
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Bodite previdni: v kolikor tu storite napako, večina filtrov, vključno z uradnimi, ne bo delovala!<br/>Preberite si <a>vodič po sintaksi filtrov</a> in se naučite pravilno dodajati napredne možnosti."
   },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Naročite se na sezname filtrov"
-  },
   "checkinfirefox_5":{
     "description":"Instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Ali se oglas prikaže tudi v tistem v brskalniku?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Ne izvajaj se na tej strani"
   },
   "filtereasylist_plus_lithuania":{
     "description":"language",
     "message":"litovščina"
   },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Sporočite nam na naši <a>strani s podporo</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock je začasno ustavljen."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Trenutno ni možno blokirati oglasov znotraj Flasha in drugih vtičnikov. Čakamo na podporo brskalnika in WebKita."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"V redu!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Splošno"
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"drugo"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Filter ni določen!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"neznano"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"avdio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"japonščina"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Dovoli nekatere nevsiljive oglase"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Prekliči"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Če želite spremeniti strani, na katerih se AdBlock ne bo izvajal, premaknite spodnji drsnik."
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Zadnji korak: prijavite nam oglas"
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Preverite v brskalniku Firefox $chrome$",
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Naročite se na ta seznam filtrov, nato pa poskusite znova: $list_title$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Za prijavo oglasa morate biti povezani na internet."
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (priporočeno)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Prijava oglasa"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Seznami filtrov za blokiranje oglasov"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Kako?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Omogoči dodajanje nekaterih YouTube kanalov na seznam dovoljenih"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Tretja oseba"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (s spleta odstrani nadloge)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - kliknite za podrobnosti"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"posodobljeno pred naslednjim številom ur: $hours$",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"ruski in ukrajinski"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Kaj je novega v zadnji izdaji? Oglejte si <a style='cursor:pointer;'>dnevnik sprememb</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Predhodno onemogočene razširitve so zdaj ponovno omogočene."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"grščina"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"slovaščina"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video posnetki in Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Kaj menite, da bo veljalo za ta oglas pri vsakem obisku te spletne strani?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Omogoči AdBlock na tej strani"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Nazaj"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Seznami filtrov blokirajo večino oglasov na spletu. Lahko pa tudi:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Preverite filtre Sprejemljivih oglasov:"
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Vaš računalnik je morda okužen z zlonamerno programsko opremo. Kliknite <a>sem</a> za dodatne informacije."
   },
   "linkunblock":{
     "description":"Link on the 'Customize' tab",
     "message":"Prikaži oglase na spletni strani ali domeni"
   },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"To ustreza <b>1</b> elementu na tej strani."
+  "lang_slovak":{
+    "description":"language",
+    "message":"slovaščina"
   },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Skrij odsek spletne strani"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Dovoli oglase na kanalu $name$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Namestite Adblock Plus za Firefox $chrome$, v kolikor ga še nimate.",
     "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Splošne možnosti"
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock ne bo deloval na straneh, ki ustrezajo:"
   },
   "nodefaultfilter1":{
     "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
     "message":"Trenutno nimamo privzetega seznama filtrov za ta jezik.<br/>Prosimo, poskusite najti seznam, ki podpira vaš jezik $link$, ali pa blokirajte ta oglas le zase s klikom na zavihek 'Prilagodi'.",
     "placeholders":{
       "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Naroči se"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Sem izkušen uporabnik; prikaži dodatne možnosti"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"španščina"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Naloženo na strani z domeno:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Kliknite to: <a>Posodobi moje filtre!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Tem več seznamov filtrov uporabljate, tem počasneje deluje AdBlock. Uporaba prevelike količine seznamov lahko celo privede do zrušitve vašega brskalnika. Izberite 'V redu', da se vseeno naročite na ta seznam."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Zadnji korak: kaj velja za ta oglas?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"To ustreza $matchcount$ elementom na tej strani.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Imamo tudi <a>stran</a> kjer lahko najdete ljudi, ki so naredili AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"indonezijščina"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"turščina"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokiraj oglas"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Seznami filtrov po meri"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL okvirja: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Namen tega vprašanja je ugotoviti kdo naj prejme vaše poročilo. V kolikor na to vprašanje odgovorite nepravilno, bo bilo poročilo poslano napačni skupini in zaradi tega ne bo obravnavano."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dodaj elemente na meni desnega miškinega klika"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"selektor"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokiraj ta oglas"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Ali naša ekipa potrebuje nekaj informacij za odpravljanje napak? Kliknite <a href='#' id='debug'>sem</a> za pridobitev le-teh."
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Ne izvajaj AdBlocka na..."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Skrit element"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Ponovno naložite stran."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"stran"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"nizozemščina"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Ime datoteke je predolgo. Prosimo, preimenujte datoteko."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Ne pozabite shraniti!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Preverjanje posodobitev (moralo bi trajati le nekaj sekund)..."
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dovoli AdBlocku, da zbira anonimne podatke o uporabi filtrov"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Ali vas naj AdBlock obvesti, kadar zazna zlonamerno programsko opremo?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Prikaži št. blokiranih oglasov v AdBlockovem meniju"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Domena:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock filtri po meri (priporočeno)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"latvijščina"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Prepričajte se, da uporabljate pravilne jezikovne filtre:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS, ki mu mora ustrezati"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Če želite skriti gumb, pojdite na opera://extensions in potrdite potrditveno polje pri možnosti \"Skrij z orodne vrstice\". Ponovno ga prikažete tako, da opustite izbor pri isti možnosti."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Niste prepričani?</b> preprosto izberite 'Blokiraj!' spodaj."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Ujemajoči se filter"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"pridobivam... prosimo počakajte."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Vsi viri"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock je posodobljen!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Ne izvajaj se na straneh na tej domeni"
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"hebrejščina"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Premikajte drsnik dokler oglas ni pravilno blokiran in blokirani elementi izgledajo uporabno."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokiraj URL naslove, ki vsebujejo to besedilo"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Razveljavi moje blokade na tej domeni"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"posodobljeno pred 1 dnevom"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Sprejemljivi oglasi (priporočeno)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Kliknite to: <a>Onemogoči Sprejemljive oglase</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Različica $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Odstrani s seznama"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"skrivanje"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Seznami filtrov"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Domena okvirja: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Kliknite na oglas in vodili vas bomo skozi postopek blokiranja."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Zgornji okvir"
   },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Končano!"
-  },
-  "headerresource":{
-    "description":"Resource list page: title of a column",
-    "message":"Vir"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blokiraj oglas na tej strani"
-  },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Poskrbite, da bodo vaši seznami filtrov posodobljeni:"
-  },
-  "lang_english":{
-    "description":"language",
-    "message":"angleščina"
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Odprite stran z razširitvami in omogočite tiste, ki so bile prej onemogočene."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domena strani na kateri želite to uveljaviti"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Stran:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Ste našli hrošča?"
-  },
-  "filtereasylist_plus_arabic":{
-    "description":"language",
-    "message":"arabščina"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"češčina"
-  },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Plačajte kolikor želite!"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Ali želite videti, kako deluje AdBlock?"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Neveljaven seznam URL-jev. Izbrisan bo."
-  },
-  "typesub_frame":{
+  "typestylesheet":{
     "description":"A resource type",
-    "message":"okvir"
+    "message":"definicija stila"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Uredi"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Imate vprašanje ali novo idejo?"
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ALI</b> pa preprosto kliknite na ta gumb, da se vse zgoraj napisano stori samodejno: <a>Onemogoči vse druge razširitve</a>"
-  },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Izvedite več o zlonamerni programski opremi"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Ponovno naložite stran z oglasom."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Če ga nimate, namestite Firefox $chrome$.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
-      }
-    }
-  },
-  "catblock_enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
-    "message":"Enable CatBlock on this page"
-  },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Posodobitve AdBlocka"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Drugi seznami filtrov"
-  },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"francoščina"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blokirani element:"
-  },
-  "typeobject":{
+  "typeunknown":{
     "description":"A resource type",
-    "message":"Interaktivni objekt"
+    "message":"neznano"
   },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"ravnokar posodobljeno"
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Oprostite, AdBlock je na tej strani onemogočen s strani enega izmed vaših filtrov."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Tretja oseba"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Filter ni določen!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"grščina"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Uporabljate staro različico AdBlocka. Prosimo, pojdite na <a href='#'>stran z razširitvami</a>, omogočite 'Način za razvijalce' in kliknite 'Posodobi razširitve'."
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Kako vam je ime?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Obidi težavo z nedelovanjem videov na Hulu.com (zahteva ponovni zagon brskalnika)"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Prilagodi"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Ste našli oglas na spletni strani? Pomagali vam bomo najti pravi kraj za prijavo!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"estonščina"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"posodobljeno pred naslednjim številom dni: $days$",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
-  },
-  "typesubdocument":{
-    "description":"A resource type",
-    "message":"okvir"
-  },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (zaščita zasebnosti)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Prijavi oglas na tej strani"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Počisti ta seznam"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"nemščina"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Bodite previdni: filter blokira vse $elementtype$ elemente na strani!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"tukaj"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"V katerem jeziku je napisana stran?"
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Ali ste prepričani, da želite odstraniti naslednje število blokad, ki ste jih ustvarili na $host$? Št. blokad: $count$",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"slika"
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Če želite skriti gumb, kliknite nanj z desno miškino tipko in izberite Skrij gumb. Ponovno ga lahko prikažete v razširitvahi: chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"romunščina"
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Nekaj je šlo narobe pri preverjanju posodobitev."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Onemogočili smo vse druge razširitve. Zdaj bomo osvežili stran z oglasom. Sekundo, prosim."
   },
   "whitelistedresource":{
     "description":"Resource list page: resource status",
     "message":"Dovoljen vir"
   },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Ne izvajaj AdBlocka na..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokiraj URL naslove, ki vsebujejo to besedilo"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Zapri"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Preverite v brskalniku Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Zadnji korak: kaj velja za ta oglas?"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Prilagodite AdBlock"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"korejščina"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"finščina"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skripta"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"ukrajinščina"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Zlonamerna programska oprema ni bila najdena."
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Imamo tudi <a>stran</a> kjer lahko najdete ljudi, ki so naredili AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"tukaj"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"pojavno okno"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"V kolikor se vam prikazuje oglas, ne prijavite hrošča, temveč pošljite poročilo o <a>oglasu</a>!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Ponovno naložite stran."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"V katerem jeziku je napisana stran?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock je začasno ustavljen."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Ponovno aktiviraj AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Iskanje oglasov...<br/><br/><i>To bo trajalo le trenutek.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock je onemogočen na tej strani."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"V tistem brskalniku se naročite na iste sezname filtrov kot v tem."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokiraj oglas"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Opozorilo: na vseh drugih spletnih mestih boste videli oglase!<br>To povozi vse druge filtre za tista mesta."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Na voljo je posodobitev za AdBlock! Za posodobitev pojdite $here$. <br> Vedite: Če želite prejemati posodobitve samodejno, kliknite na Safari > Nastavitve > Razširitve > Posodobitve <br> in izberite možnost 'Samodejno namesti posodobitve'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Končano!"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock filtri po meri (priporočeno)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Vrsta"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Kaj je to?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"japonščina"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Izvor filtra:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Naročite se na sezname filtrov"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Domena:"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Filtri za druge jezike: "
+  },
+  "headerfilter":{
+    "description":"Resource list page: title of a column",
+    "message":"Ujemajoči se filter"
+  },
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Seznami filtrov blokirajo večino oglasov na spletu. Lahko pa tudi:"
+  },
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Če želite skriti gumb, z desno miškino tipko kliknite na orodno vrstico, izberite 'Prilagodi orodno vrstico' in povlecite AdBlockov gumb iz orodne vrstice. Znova ga omogočite tako, da ga povlečete nazaj v orodno vrstico."
+  },
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Presegli ste največjo velikost za storitev Dropbox. Odstranite nekaj vnosov filtrov po meri oz. onemogočenih filtrov in poskusite znova."
+  },
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Naroči se"
+  },
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blokirani element:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"stran"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"drugo"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Kliknite to: <a>Posodobi moje filtre!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Skrit element"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Če želite skriti gumb, pojdite na opera://extensions in potrdite potrditveno polje pri možnosti \"Skrij z orodne vrstice\". Ponovno ga prikažete tako, da opustite izbor pri isti možnosti."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Stran:"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokiraj!"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Omogoči dodajanje nekaterih YouTube kanalov na seznam dovoljenih"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Trenutno ni možno blokirati oglasov znotraj Flasha in drugih vtičnikov. Čakamo na podporo brskalnika in WebKita."
+  },
+  "filterhungarian":{
+    "description":"language",
+    "message":"madžarščina"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokiraj ta oglas"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Omogoči AdBlock na tej strani"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Prikaži št. blokiranih oglasov na AdBlockovem gumbu"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Ni uspelo!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Začasno ustavi AdBlock"
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"angleščina"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dodaj elemente na meni desnega miškinega klika"
+  },
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Prosimo, pojdite na <a>našo spletno mesto za podporo</a>."
+  },
+  "typemain_frame":{
+    "description":"A resource type",
+    "message":"stran"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Ali ste prepričani, da želite odstraniti naslednje število blokad, ki ste jih ustvarili na $host$? Št. blokad: $count$",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legenda: "
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Priložite posnetek zaslona:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"romunščina"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Uredi izklopljene filtre:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Podokvir"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Omogoči Safari Content Blocking"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Če ga nimate, namestite Firefox $chrome$.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Seznami filtrov"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Sem izkušen uporabnik; prikaži dodatne možnosti"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"kitajščina"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filter ni veljaven: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Poteka naročanje na seznam filtrov..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Odprite stran z razširitvami in omogočite tiste, ki so bile prej onemogočene."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Izključi ta sporočila"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"turščina"
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"posodobljeno pred 1 uro"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"okvir"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"indonezijščina"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"slika"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ skupno",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Prekliči"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Ne pozabite shraniti!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"selektor"
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"islandščina"
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Ali ste prepričani, da se želite naročiti na filter $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokiraj oglase samo na teh straneh:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Naloženo na strani z domeno:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Napaka pri shranjevanju priložene datoteke."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Počisti ta seznam"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Pomagajte nam širiti idejo!"
+  },
+  "catblock_enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
+    "message":"Enable CatBlock on this page"
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock - možnosti"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Prišlo je do napake pri obdelavi vaše zahteve."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Ne naročite se na več kot potrebujete -- vsak filter malce upočasni brskanje. Zasluge in drugi seznami se nahajajo <a>tukaj</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Preverjanje posodobitev (moralo bi trajati le nekaj sekund)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"ravnokar posodobljeno"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Če želite blokirati oglas, kliknite nanj z desno miškino tipko -- isto pa tudi lahko ročno storite tukaj."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Preverjanje za zlonamerno programsko opremo, ki lahko vsiljuje oglase:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock podpora"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Vrsta"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Premikajte drsnik dokler oglas ni pravilno blokiran in blokirani elementi izgledajo uporabno."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"posodobljeno pred 1 minuto"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"okvir"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Blokiran vir"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Spodnje informacije bodo vključene v poročilo:"
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"danščina"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Preverite filtre Sprejemljivih oglasov:"
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"pridobivam... prosimo počakajte."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Neveljaven seznam URL-jev. Izbrisan bo."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Splošne možnosti"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Odznačite potrditveno polje 'Omogočeno' pri vsaki razširitvi, <b>razen</b> AdBlocku. <b>AdBlock pustite omogočen</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"V tistem brskalniku pojdite na stran z oglasom."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Prikaži oglase <i>povsod</i>, razen na teh domenah..."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Če želite skriti gumb, kliknite nanj z desno miškino tipko in izberite Skrij gumb. Ponovno ga lahko prikažete v razširitvahi: chrome://chrome/extensions."
+  },
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"hebrejščina"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Ta funkcija AdBlocka tukaj ne deluje, ker stran uporablja zastarelo tehnologijo. Vire lahko ročno blokirate ali dovolite v zavihku Prilagodi na strani z nastavitvami."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"češki in slovaški"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Onemogočili smo vse druge razširitve. Zdaj bomo osvežili stran z oglasom. Sekundo, prosim."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Drugi seznami filtrov"
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Posodobitve se bodo izvajale samodejno; vseeno pa lahko <a>posodobite zdaj</a>"
+  },
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Prikaži vse zahteve"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Tem več seznamov filtrov uporabljate, tem počasneje deluje AdBlock. Uporaba prevelike količine seznamov lahko celo privede do zrušitve vašega brskalnika. Izberite 'V redu', da se vseeno naročite na ta seznam."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Super! Vse je urejeno."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Posodobitve AdBlocka"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Izvedite več o Sprejemljivih oglasih."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Ali vas naj AdBlock obvesti, kadar zazna zlonamerno programsko opremo?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"posodobljeno pred 1 dnevom"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL okvirja: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"nemščina"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Ime datoteke je predolgo. Prosimo, preimenujte datoteko."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"posodobljeno pred naslednjim številom sekund: $seconds$",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Ne izvajaj se na tej strani"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Sporočite nam na naši <a>strani s podporo</a>!"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"ruski in ukrajinski"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"V redu!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Končano! Osvežili smo stran z oglasom. Prosimo preverite, ali je oglas izginil. Potem se vrnite na to stran in odgovorite na spodnje vprašanje."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Vsi viri"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Dovoli oglase na kanalu $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Vir"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Prikaži št. blokiranih oglasov v AdBlockovem meniju"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Prijava oglasa"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Kako?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Ne izvajaj se na straneh na tej domeni"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Seznami filtrov po meri"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blokiraj več oglasov:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domena ali spletni naslov, kjer AdBlock naj ne blokira ničesar"
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (s spleta odstrani nadloge)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock je blokiral prenos s strani, ki je znana po tem, da se na njej nahaja zlonamerna programska oprema."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Shrani"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Niste prepričani?</b> preprosto izberite 'Blokiraj!' spodaj."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Zadnji korak: prijavite nam oglas"
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Namen tega vprašanja je ugotoviti kdo naj prejme vaše poročilo. V kolikor na to vprašanje odgovorite nepravilno, bo bilo poročilo poslano napačni skupini in zaradi tega ne bo obravnavano."
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Izgleda dobro"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dovoli AdBlocku, da zbira anonimne podatke o uporabi filtrov"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Za prijavo oglasa morate biti povezani na internet."
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Seznami filtrov za blokiranje oglasov"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"bolgarščina"
+  },
+  "typeobject":{
+    "description":"A resource type",
+    "message":"Interaktivni objekt"
+  },
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Kaj menite, da bo veljalo za ta oglas pri vsakem obisku te spletne strani?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Blokirani oglasi:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"arabščina"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Razveljavi moje blokade na tej domeni"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Ročno uredite vaše filtre:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"1. korak: Kaj želite blokirati?"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Prosimo, vnesite pravilen filter v spodnje polje in izberite 'V redu'"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Prevod:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock je posodobljen!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Na voljo le v angleščini"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ALI</b> pa preprosto kliknite na ta gumb, da se vse zgoraj napisano stori samodejno: <a>Onemogoči vse druge razširitve</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Kaj je novega v zadnji izdaji? Oglejte si <a style='cursor:pointer;'>dnevnik sprememb</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Seznam antisocialnih filtrov (odstrani gumbe za deljenje vsebine preko socialnih omrežij)"
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Zaščita pred zlonamerno programsko opremo"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock ne bo deloval na straneh, ki ustrezajo:"
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Presegli ste količino prostora, ki jo AdBlock lahko uporabi za shranjevanje. Prosimo, odjavite se od nekaterih seznamov filtriranja!"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Kakšen je vaš e-poštni naslov?"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Ali želite videti, kako deluje AdBlock?"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Skrij odsek spletne strani"
+  },
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Splošno"
+  },
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"ali AdBlock za Chrome"
+  },
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video posnetki in Flash"
+  },
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Super! Zdaj pa preverimo katera razširitev povzroča težave. Pojdite skozi seznam razširitev in omogočite eno po eno. Razširitev, ki prinese oglas(e) nazaj je tista, ki jo morate odstraniti, da se znebite oglasov."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1297,174 +1105,406 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"češki in slovaški"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"ali Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Tip okvira: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Oblika: ~stran1.com|~stran2.com|~novice.stran3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Izberite jezik -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Namestite Adblock Plus za Firefox $chrome$, v kolikor ga še nimate.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Blokiran vir"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Ali se oglas pojavi v ali pred videoposnetkom oz. katerimkoli drugim vtičnikom, kot npr. Flash igri?"
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Izvor filtra:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filter, ki se ga lahko spremeni na strani 'Možnosti':"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Filter:<br/> $filter$ <br/> ima napako: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Zapri"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokiraj oglase samo na teh straneh:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Presegli ste količino prostora, ki jo AdBlock lahko uporabi za shranjevanje. Prosimo, odjavite se od nekaterih seznamov filtriranja!"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filter ni veljaven: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"V redu, še vedno lahko ta oglas blokirate le zase na strani 'Možnosti'. Hvala!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Pošlji"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"finščina"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Spodnje informacije bodo vključene v poročilo:"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Plačajte kolikor želite!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"To je problem seznama filtrov. Tu lahko prijavite napako: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Odznačite potrditveno polje 'Omogočeno' pri vsaki razširitvi, <b>razen</b> AdBlocku. <b>AdBlock pustite omogočen</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Opomba: poročilo lahko postane javno dostopno. To imejte v mislih, preden vključite karkoli zasebnega."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Pokaži povezave do seznamov filtrov"
+  "filteritalian":{
+    "description":"language",
+    "message":"italijanščina"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Na voljo le v angleščini"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Pomagajte nam širiti idejo!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Ali se oglas še vedno prikazuje?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock je blokiral prenos s strani, ki je znana po tem, da se na njej nahaja zlonamerna programska oprema."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Prepričajte se, da uporabljate pravilne jezikovne filtre:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legenda: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Poskrbite, da bodo vaši seznami filtrov posodobljeni:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Nekaj je šlo narobe pri preverjanju posodobitev."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Izberite Safari meni &rarr; Nastavitve &rarr; Razširitve."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Pošlji"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Odjavljeno."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"avdio/video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"latvijščina"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blokiraj oglas na tej strani"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Ustavi blokiranje oglasov:"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Odstrani s seznama"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Filter ni bil uspešno pridobljen!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Če želite spremeniti strani, na katerih se AdBlock ne bo izvajal, premaknite spodnji drsnik."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"skrivanje"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Ali se oglas pojavi v ali pred videoposnetkom oz. katerimkoli drugim vtičnikom, kot npr. Flash igri?"
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Nekaj je šlo narobe. Viri niso bili poslani. Ta stran se bo zdaj zaprla. Poskusite ponovno naložiti spletno stran."
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"španščina"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Bodite previdni: filter blokira vse $elementtype$ elemente na strani!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Omogoči združljivost s ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Ne"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filter, ki se ga lahko spremeni na strani 'Možnosti':"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Skrij ta gumb"
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Predhodno onemogočene razširitve so zdaj ponovno omogočene."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"drugo"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"V redu, še vedno lahko ta oglas blokirate le zase na strani 'Možnosti'. Hvala!"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Onemogočite vse razširitve, razen AdBlocka:"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"ruščina"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Uporabljate staro različico brskalnika Safari. V kolikor želite uporabljati AdBlockov gumb v opravilni vrstici, ga onemogočiti na nekaterih spletnih straneh ter prijavljati oglase, <a>nadgradite zdaj</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (zaščita zasebnosti)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ bo $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Ali vnesite URL:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Filter:<br/> $filter$ <br/> ima napako: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Tip okvira: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"NALAGANJE..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Ali naša ekipa potrebuje nekaj informacij za odpravljanje napak? Kliknite <a href='#' id='debug'>sem</a> za pridobitev le-teh."
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Prijavi oglas na tej strani"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Pokaži izjave za odpravljanje napak v dnevniku konzole (upočasni AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Domena okvirja: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Najbolj priljubljena razširitev za brskalnik Chrome z več kot 40 milijoni uporabnikov!  Blokira oglase po vsem spletu."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Ste našli hrošča?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"češčina"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Ponovno naložite stran z oglasom."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Pokaži povezave do seznamov filtrov"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Dovoli nekatere nevsiljive oglase"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"švedščina"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"To ustreza $matchcount$ elementom na tej strani.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Izberite jezik -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"francoščina"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Uredi"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Podpora"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Prosimo, pojdite na <a>našo spletno mesto za podporo</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blokiraj oglas z URL naslovom"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Izgleda dobro"
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Različica $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Kje točno na strani se nahaja oglas? Kako izgleda?"
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Da"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Izvorna koda je <a>na voljo brezplačno</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"nizozemščina"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Kontaktirali vas bomo le v primeru, v kolikor bomo potrebovali dodatne informacije."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"To ustreza <b>1</b> elementu na tej strani."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"posodobljeno pred naslednjim številom ur: $hours$",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Nazaj"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Kliknite to: <a>Onemogoči Sprejemljive oglase</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domena strani na kateri želite to uveljaviti"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"posodobljeno pred naslednjim številom minut $minutes$",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Izvedite več o zlonamerni programski opremi"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Sprejemljivi oglasi (priporočeno)"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - kliknite za podrobnosti"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Opozorilo: filter ni določen!"
   }
 }

--- a/_locales/sr/messages.json
+++ b/_locales/sr/messages.json
@@ -1,471 +1,1083 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Prijavljivanje reklame"
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Nešto se pokvarilo. Resursi nisu poslati. Stranica će se sada zatvoriti. Pokušajte ponovno pokrenuti vebsajt."
   },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Filter Liste za Blokiranje Reklama"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Kliknite ovo: <a>Onemogući Prihvatljive reklame</a>"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Sajt:"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Prilagodi"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dopusti postavljanje specifičnih YouTube kanala na listu dopuštenih"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Od treće strane"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Nije pronađen nijedan poznati maliciozni softver."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"U tom pregledaču, pretplatite se na iste liste filtera koje imate na ovom."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - kliknite za detalje"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"U tom pretraživaču, učitajte stranu sa reklamom."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Švedski"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Šta je novo u poslednjem izdanju? Pogledajte <a style='cursor:pointer;'>spisak promena</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blokiraj još reklama:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Ruski"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Dodaci koji su pre bili onemogućeni sada su omogućeni."
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Prekini pratnju."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blokiraj reklamu preko njenog URL-a"
-  },
-  "topframe":{
-    "description":"Resource list page: frame type",
-    "message":"Gornji okvir"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grčki"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock prilagodljivi filteri (preporučeno)"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Sakrij odeljak veb strane"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Španski"
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Takođe, imamo i <a>stranicu</a> o ljudima koji su napravili AdBlock!"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blokirani element:"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Šta mislite da će biti tačno što se tiče ove reklame svaki put kad posetite stranicu?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Omogući AdBlock na ovoj stranici"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Nazad"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Pokaži broj blokiranih reklama na AdBlock dugmetu"
-  },
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
+    "message":"Imate pitanje ili novu ideju?"
   },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Liste filtera blokiraju većinu reklama na internetu. Možete takođe:"
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Opcije"
   },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Izvorni kod je <a>otvoren i besplatan</a>!"
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Pazite: ovaj filter blokira sve $elementtype$ elemente na strani!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Naučite više o programu Prihvatljivih reklama."
+  "blocked_n_on_this_page":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
+    "message":"$count$ na ovoj stranici",
+    "placeholders":{
+      "count":{
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
   },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Poljski"
   },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS za traženje"
   },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Prikazuje reklame na veb strani ili domenu"
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Isključi"
   },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"To odgovara <b>jednoj</b> stavci na ovoj strani."
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"slika"
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Ne želim ovo da proverim"
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Budite pažljivi: ukoliko napravite grešku ovde mnogo drugih filtera, uključujući i oficijalne filtere, mogu da prestanu da rade kako treba!<br/>Pročitajte <a>sintaksni vodič za filtere<a> kako bi naučili da dodajete napredne filtere zabranjujućih i dopuštajućih lista."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Dopusti $name$ kanal",
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Da li se reklama takođe pojavljuje u tom pretraživaču?"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Zapamti"
+  },
+  "filtereasylist_plus_lithuania":{
+    "description":"language",
+    "message":"Litvanski"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Prijavite se na ovu listu filtera, onda pokušajte ponovo: $list_title$",
     "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Opšte opcije"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
   "malwarewarning":{
     "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
     "message":"Vaš računar je možda zaražen sa malicioznim softverom. Kliknite <a>ovde</a> za više informacija."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock neće raditi na stranama:"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Prikazuje reklame na veb strani ili domenu"
   },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"ažurirano pre jedan dan"
+  "lang_slovak":{
+    "description":"language",
+    "message":"Slovenski"
+  },
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Instalirajte Adblock Plus za Firefox/$chrome$ ukoliko ga nemate.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
   },
   "nodefaultfilter1":{
     "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
     "message":"Mi nemamo standardnu listu filtera za taj jezik.<br/>Molimo pokušajte da pronađete odgovarajuću listu koja podržava ovaj jezik $link$ ili blokirajte ovu reklamu sami u 'Modifikuj' tab-u.",
     "placeholders":{
       "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Prijavi se"
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Pritisnite na reklamu, i ja ću vam objasniti kako da je blokirate."
   },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Ja sam napredni korisnik, pokaži mi dodatne opcije"
+  "topframe":{
+    "description":"Resource list page: frame type",
+    "message":"Gornji okvir"
   },
-  "lang_czech":{
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"definicija stila"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Izvinite, AdBlock je onesposobljen na ovoj strani zbog jedne od vaših lista filtera."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Od treće strane"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Filter nije specifikovan!"
+  },
+  "filtereasylist_plus_greek":{
     "description":"language",
-    "message":"Češki"
+    "message":"Grčki"
   },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Sakrij ovo dugme"
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
   },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Ažuriranja će se preuzimati automatski; takođe možete <a>ažurirati sada</a>"
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Niste sigurni?</b> samo kliknite 'Blokiraj!' ispod."
   },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Pokrenuto na stranici s domenom:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Zaobiđite videe sa Hulu.com koji ne rade (zahteva restartovanje pretraživača)"
   },
-  "reportfilterlistproblem":{
-    "description":"Telling the user to report an ad to a filter list maintainer",
-    "message":"Ovo je problem liste filtera. Prijavi ga ovde: $link$",
-    "placeholders":{
-      "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
-      }
-    }
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Upozorenje: nijedan filter nije specifikovan!"
   },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~sajt1.com|~sajt2.com|~novosti.sajt3.org"
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Prilagodi"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Pronašli ste reklamu na web-stranici? Pomoći ćemo Vam da pronađete pravo mesto da je prijavite!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
   },
   "filtereasylist_plus_estonian":{
     "description":"language",
     "message":"Estonski"
   },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Ima $matchcount$ takve stavke na ovoj strani.",
+  "updateddaysago":{
+    "description":"Label for subscription",
+    "message":"ažurirano pre $days$ dana",
     "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
+      "days":{
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (uklanja dosadne smetnje sa Weba)"
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Dopušteni resurs"
   },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonezijski"
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
   },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Kucaj"
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Ne pokreći AdBlock na..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blokiraj URL-ove koji sadže ovaj tekst"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Zatvori"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Proveri u Firefox-u $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Poslednji korak: Sta čini ovo reklamom?"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Prilago AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Nije pronađen nijedan poznati maliciozni softver."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finski"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"skripta"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Ukrajinski"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Korejski"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Takođe, imamo i <a>stranicu</a> o ljudima koji su napravili AdBlock!"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popap"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Ako vidite reklamu, nemojte napraviti prijavu baga, napravite prijavu <a>reklame</a>!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Ponovo učitajte stranicu."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Koristite staru verziju AdBlock-a. Molimo idite do <a href='#'>strane za prijključke</a>, uključite 'Režim razvojnika' i kliknite na 'Ažuriraj priključke sada'"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock je pauziran."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Ponovo aktivirati AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Pronalaženje reklama...<br/><br/><i>Ovo će potrajati samo malo.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock je onesposobljen na ovoj strani."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"U tom pregledaču, pretplatite se na iste liste filtera koje imate na ovom."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blokiraj reklamu"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Upozorenje: na svim ostalim sajtovima ćete videti reklame!<br>Ovo poništava sve ostale filtere za te sajtove."
   },
   "update_available":{
     "description":"On the Options > Support page, shows when there are updates available for AdBlock",
     "message":"Postoji nova verzija AdBlock-a! Idite $here$ kako biste je preuzeli. <br> Ako želite preuzimati ažuriranja automatski, samo kliknite u Safari > Postavke > Ekstenzije > Ažuriranja <br> i označite opciju 'Instaliraj ažuriranja automatski'.",
     "placeholders":{
       "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
-  "filterturkish":{
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Filter:<br/> $filter$ <br/> ima grešku: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "filteradblock_custom":{
     "description":"A filter list",
-    "message":"Turski"
+    "message":"AdBlock prilagodljivi filteri (preporučeno)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Kucaj"
   },
   "whats_this":{
     "description":"Text of a link pointing to the explanation of a new feature",
     "message":"Šta je ovo?"
   },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Prilagođene Filter Liste"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Nemojte se prijavljivati na više nego vam je potrebno -- svaki filter dodatno usporava AdBlock! Zasluge i druge liste možete pronaći <a>ovde</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"definicija stila"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL okvira: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Svrha ovog pitanja je da se odredi ko bi trebao da primi vaš izveštaj. Ukoliko odgovorite na ovo pitanje pogrešno, izveštaj će biti poslat pogrešnim ljudima, pa može biti ignorisan."
-  },
-  "filtereasylist_plus_polish":{
+  "filterjapanese":{
     "description":"language",
-    "message":"Poljski"
+    "message":"Japanski"
   },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dodaj stavke na meni desnog klika"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Videi i Flash"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"selektor"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blokiraj ovu reklamu"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"ažurirano pre $hours$ sati",
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Poreklo filtera:\n$list$",
     "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
       }
     }
   },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"ažurirano pre $seconds$ sekundi",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Prijavite se na liste filtera"
   },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Da li je naš tim zatražio dodatne informacije o bagu? Kliknite <a href='#' id='debug'>ovde</a> za to!"
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Zaslužan za prevodjenje:"
   },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"objekat_podpotražnja"
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Dodaj filtere za drugi jezik: "
   },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Mađarski"
+  "headerfilter":{
+    "description":"Resource list page: title of a column",
+    "message":"Odgovarajući filter"
   },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Prijavljivanje reklama je dobrovoljno. Pomaže drugima da takođe ne vide reklame tako što održavatelji lista filtera blokiraju reklamu za sve. Ako se ne osećate altruistički, to je isto u redu. Zatvorite ovu stranicu i <a>blokirajte reklamu</a> samo sebi."
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Liste filtera blokiraju većinu reklama na internetu. Možete takođe:"
   },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Ne zaboravi: tvoj izveštaj može postati javno dostupan. Imaj to na umu pre uključivanja nečeg privatnog."
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Da biste sklonili dugme, desnim klikom na alatnu traku Safari-ja odaberite Customize toolbar (Prilogođivanje alatne trake), a zatim povucite dugme AdBlock iz alatne trake. Možete ga ponovo prikazati vraćanjem ga nazad u alatnoj traku."
   },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Skriveni element"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Premašili ste Dropbox ograničenje veličine. Molimo uklonite neke unose iz vaših prilagođenih ili onemogućenih filtera pa pokušajte ponovo."
   },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Ponovo učitajte stranicu."
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Prijavi se"
+  },
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blokirani element:"
   },
   "typepage":{
     "description":"A resource type",
     "message":"stranica"
   },
-  "filterdutch":{
+  "typeother":{
+    "description":"A resource type",
+    "message":"ostalo"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Kliknite na ovo: <a>Ažuriraj moje filtere!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Skriveni element"
+  },
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Videi i Flash"
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"objekat_podpotražnja"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Strana:"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blokiraj!"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dopusti postavljanje specifičnih YouTube kanala na listu dopuštenih"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Na kom jeziku je stranica napisana?"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Nemojte se prijavljivati na više nego vam je potrebno -- svaki filter dodatno usporava AdBlock! Zasluge i druge liste možete pronaći <a>ovde</a>."
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Ne možemo još da blokiramo reklame unutar Flash-a i ostalih priključaka. Čekamo podršku pretraživača i WebKit-a."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Holandski"
+    "message":"Mađarski"
   },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Ne zaboravite da zapamtite!"
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blokiraj ovu reklamu"
   },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ će biti $value$",
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Omogući AdBlock na ovoj stranici"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Pokaži broj blokiranih reklama na AdBlock dugmetu"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Nije uspelo!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pauziraj AdBlock"
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Engleski"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dodaj stavke na meni desnog klika"
+  },
+  "typemain_frame":{
+    "description":"A resource type",
+    "message":"stranica"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Jeste li sigurni da želite ukloniti $count$ blokiranja koje ste napravili na $host$?",
     "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
       },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
       }
     }
   },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Zatvori"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Legenda: "
   },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Odgovarajući filter"
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Rumunski"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Uredi onemogućene filtere:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Podokvir"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Instalirajte Firefox $chrome$ ukoliko ga nemate.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Liste filtera"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Ja sam napredni korisnik, pokaži mi dodatne opcije"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Kineski"
   },
   "blacklistereditinvalid1":{
     "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
     "message":"Ovaj filter je pogrešan: $exception$",
     "placeholders":{
       "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
+        "content":"$1",
+        "example":"This filter is not supported"
       }
     }
   },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Upozorenje: nijedan filter nije specifikovan!"
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Prijavljivanje na listu filtera..."
   },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Dopusti AdBlock-u anonimno prikupljanje podatka i korišćenja liste filtera"
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Otvori stranicu dodataka kako bi omogućili dodatke koji su bili onemogućeni."
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Da li AdBlock treba da Vas obavesti kada pronađe maliciozni softver?"
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Onemogući ova obaveštenja"
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Prikaži sve zahteve"
   },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Prikaži reklame <i>svuda</i> osim na ovim domenima..."
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"ažurirano pre jedan sat"
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Pokaži broj blokiranih reklama na AdBlock meniju"
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"okvir"
   },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Opcije"
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonezijski"
   },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Ne pokreći AdBlock na..."
+  "typeimage":{
+    "description":"A resource type",
+    "message":"slika"
   },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Ako ne želite videti reklame poput ove, možete isključiti filter listu Prihvatljivih reklama."
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ ukupno",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Poništi"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Ne zaboravite da zapamtite!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"selektor"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Islandski"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Filter Liste za Blokiranje Reklama"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blokiraj samo reklame na ovim sajtovima:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Pokrenuto na stranici s domenom:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Dodaci koji su pre bili onemogućeni sada su omogućeni."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Očistite spisak"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Pomozite da proširimo reč!"
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Opcije AdBlock-a"
   },
   "catblock_latest_version":{
     "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
     "message":"CatBlock is up-to-date!"
   },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Sakrij ovo dugme"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Proveravanje ažuriranja (trebalo bi trajati samo par sekundi)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"upravo ažurirano"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Kliknite desnim klikom na reklamu da je blokirate -- ili je blokirajte ovde ručno."
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Švedski"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Kucaj"
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Da"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"ažurirano pre jedan minut"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"okvir"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Blokirani resurs"
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Danski"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Proveri filtere Prihvatljivih reklama:"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Dobavljanje... molimo sačekajte."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Nevažeći URL liste. Biće obrisan."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Opšte opcije"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Isključite 'Omogućeno' polje za potvrdu pored svakog priključka <b>osim</b> AdBlock-a. <b>Ostavite da AdBlock bude uključen</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"U tom pretraživaču, učitajte stranu sa reklamom."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Prikaži reklame <i>svuda</i> osim na ovim domenima..."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Ako želite da sakrijte dugme, kliknite na njega desnim klikom i izaberite Sakrij Dugme. Možete ga prikazati opet pod chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebrejski"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Ova AdBlock mogućnost ne radi na ovoj stranici jer koristi zastarelu tehnologiju. Možete staviti resorse na listu zabranjujućih i dopuštajućih filtera ručno u kartici 'Prilagodi' u podešavanjima."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Češki i slovački"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Onemogućili smo sva proširenja. Sada ćemo ponovno pokrenuti stranicu sa reklamom. Sekundu, molim."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Ostale Filter Liste"
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Ažuriranja će se preuzimati automatski; takođe možete <a>ažurirati sada</a>"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"nepoznato"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turski"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Što više filter lista koristite, to je AdBlock sporiji. Korišćenje previše lista mogu čak da blokiraju vaš pretraživač na nekim veb sajtovima. Kliknite OK da koristite ovu listu svejedno."
+  },
+  "catblock_enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
+    "message":"Enable CatBlock on this page"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock ažuriranja"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Naučite više o programu Prihvatljivih reklama."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Da li AdBlock treba da Vas obavesti kada pronađe maliciozni softver?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"ažurirano pre jedan dan"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL okvira: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Nemački"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"ažurirano pre $seconds$ sekundi",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Nemoj pokretati na ovoj strani"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Arapski"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Gotovo! Ponovo smo pokrenuli stranicu sa reklamom. Molimo proverite da li je reklama nestala. Onda se vratite na ovu stranicu i odgovorite na pitanje ispod."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Svi resursi"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Dopusti $name$ kanal",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Resurs"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Pokaži broj blokiranih reklama na AdBlock meniju"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Prijavljivanje reklame"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Nemoj pokretati na stranama ovog domena"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Prilagođene Filter Liste"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blokiraj još reklama:"
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domen ili url gde AdBlock ne treba da blokira bilo sta"
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (uklanja dosadne smetnje sa Weba)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock je blokirao preuzimanje sa web stranice koja je poznata da drži malver."
+  },
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Ako ne želite videti reklame poput ove, možete isključiti filter listu Prihvatljivih reklama."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Izgleda dobro"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Nazad"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Dopusti AdBlock-u anonimno prikupljanje podatka i korišćenja liste filtera"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Da biste prijavili reklamu, morate biti povezani na internet."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Da li ste sigurni da se želite pretplatiti na spisak filtera $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bugarski"
+  },
+  "typeobject":{
+    "description":"A resource type",
+    "message":"interaktivni objekat"
+  },
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Šta mislite da će biti tačno što se tiče ove reklame svaki put kad posetite stranicu?"
+  },
   "blocked_ads":{
     "description":"Title for popup menu section showing number of ads blocked",
     "message":"Blokirane reklame:"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Recite nam na našoj <a>stranici podrške</a>!"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Vrati moja blokiranja na ovom domenu"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Ručno uredite vaše filtere:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Korak 1: Odredite šta da blokirate"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Molimo ukucajte pravilni filter ispod i pritisnite OK"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Sajt:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock je ažuran!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Samo engleski"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Gotovo!"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ILI</b>, samo kliknite ovo dugme kako bi uradili sve ovo iznad: <a>Onemogući sve druge dodatke</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Šta je novo u poslednjem izdanju? Pogledajte <a style='cursor:pointer;'>spisak promena</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antisocijalna lista filtera (uklanja dugmad društevnih mreža)"
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Zaštita od malicioznog softvera"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock neće raditi na stranama:"
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Prekoračili ste nivo skladištenja kori AdBlock može da koristi. Molimo obustavite praćenje nekih lista filtera!"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Želite da vidite kako radi AdBlock?"
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Super! Sve je namešteno."
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Sakrij odeljak veb strane"
+  },
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Opšte"
+  },
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"ili AdBlock za Chrome"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Da sklonite dugme, idite na opera://extensions i obeležite opciju 'Ukloni sa alatne trake'. Možete ga vratiti kasnije tako što poništite tu opciju."
+  },
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Odlično! Pronađimo sada koje proširenje je uzrok. Prođite kroz listu i omogućite svako proširenje posebno. Proširenje koje ubacuje reklame je ono koje bi trebali ukloniti da bi se rešili reklama."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -477,609 +1089,72 @@
       }
     }
   },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"ili Chrome"
   },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Dodaj filtere za drugi jezik: "
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Letonski"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Proverite da li koristite ispravni filter za jezik:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS za traženje"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Da sklonite dugme, idite na opera://extensions i obeležite opciju 'Ukloni sa alatne trake'. Možete ga vratiti kasnije tako što poništite tu opciju."
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Pritisnite na reklamu, i ja ću vam objasniti kako da je blokirate."
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock podrška"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Prijavi reklamu na ovoj stranici"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Super! Sve je namešteno."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Ruski i ukrajinski"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Pomerite klizač dok je reklama ispravno blokirana na stranici, i blokirani element izgleda korisno."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Svi resursi"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Prilago AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock je ažuran!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ ukupno",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Hebrejski"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Izvinite, AdBlock je onesposobljen na ovoj strani zbog jedne od vaših lista filtera."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blokiraj URL-ove koji sadže ovaj tekst"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Vrati moja blokiranja na ovom domenu"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Molimo ukucajte pravilni filter ispod i pritisnite OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Korak 1: Odredite šta da blokirate"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "blocked_n_on_this_page":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
-    "message":"$count$ na ovoj stranici",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
-      }
-    }
-  },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Podokvir"
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Niste sigurni?</b> samo kliknite 'Blokiraj!' ispod."
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"ažurirano pre jedan sat"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Verzija $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
-  },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Kineski"
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Ova AdBlock mogućnost ne radi na ovoj stranici jer koristi zastarelu tehnologiju. Možete staviti resorse na listu zabranjujućih i dopuštajućih filtera ručno u kartici 'Prilagodi' u podešavanjima."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Ostalo"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"skriven"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Liste filtera"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Domen okvira: "
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Ostale Filter Liste"
-  },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Isključite 'Omogućeno' polje za potvrdu pored svakog priključka <b>osim</b> AdBlock-a. <b>Ostavite da AdBlock bude uključen</b>."
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blokiraj!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Gotovo!"
-  },
-  "headerresource":{
-    "description":"Resource list page: title of a column",
-    "message":"Resurs"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blokiraj reklamu na ovoj strani"
-  },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Proverite da li su svi filteri ažurni:"
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Prikaži sve zahteve"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Ne želim ovo da proverim"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "lang_english":{
-    "description":"language",
-    "message":"Engleski"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Poslednji korak: Sta čini ovo reklamom?"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pauziraj AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Da li ste sigurni da se želite pretplatiti na spisak filtera $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Otvori stranicu dodataka kako bi omogućili dodatke koji su bili onemogućeni."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domen strane na kojoj se primenjuje"
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Dopušteni resurs"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Strana:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Našli ste bag?"
-  },
-  "filtereasylist_plus_arabic":{
-    "description":"language",
-    "message":"Arapski"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~sajt1.com|~sajt2.com|~novosti.sajt3.org"
   },
   "pwyw":{
     "description":"Text of a payment request link",
     "message":"Plati koliko hoćeš!"
   },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"ili AdBlock za Chrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blokiraj reklamu"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Danski"
-  },
-  "typesub_frame":{
-    "description":"A resource type",
-    "message":"okvir"
-  },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Izmeni"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Pronalaženje reklama...<br/><br/><i>Ovo će potrajati samo malo.</i>"
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domen ili url gde AdBlock ne treba da blokira bilo sta"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Proveravanje ažuriranja (trebalo bi trajati samo par sekundi)..."
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"skripta"
-  },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Naučite više o malicioznom softveru"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Ponovo učitaj stranicu sa reklamom."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Instalirajte Firefox $chrome$ ukoliko ga nemate.",
+  "reportfilterlistproblem":{
+    "description":"Telling the user to report an ad to a filter list maintainer",
+    "message":"Ovo je problem liste filtera. Prijavi ga ovde: $link$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "catblock_enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
-    "message":"Enable CatBlock on this page"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Ne zaboravi: tvoj izveštaj može postati javno dostupan. Imaj to na umu pre uključivanja nečeg privatnog."
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock ažuriranja"
-  },
-  "filtereasylist_plun_korean":{
+  "filteritalian":{
     "description":"language",
-    "message":"Korejski"
+    "message":"Italijanski"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Ne"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Nešto se pokvarilo. Resursi nisu poslati. Stranica će se sada zatvoriti. Pokušajte ponovno pokrenuti vebsajt."
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Što više filter lista koristite, to je AdBlock sporiji. Korišćenje previše lista mogu čak da blokiraju vaš pretraživač na nekim veb sajtovima. Kliknite OK da koristite ovu listu svejedno."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Ukrajinski"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"ažurirano pre $minutes$ minuta",
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "example":{
+        "content":"<i>346406</i>"
       }
     }
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Francuski"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Ako vidite reklamu, nemojte napraviti prijavu baga, napravite prijavu <a>reklame</a>!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktivni objekat"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"upravo ažurirano"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Zapamti"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Upozorenje: na svim ostalim sajtovima ćete videti reklame!<br>Ovo poništava sve ostale filtere za te sajtove."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Onemogući ova obaveštenja"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Prijavljivanje na listu filtera..."
-  },
-  "updateddaysago":{
-    "description":"Label for subscription",
-    "message":"ažurirano pre $days$ dana",
-    "placeholders":{
-      "days":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ILI</b>, samo kliknite ovo dugme kako bi uradili sve ovo iznad: <a>Onemogući sve druge dodatke</a>"
-  },
-  "typesubdocument":{
-    "description":"A resource type",
-    "message":"okvir"
-  },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (zaštita privatnosti)"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Češki i slovački"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Koristite staru verziju AdBlock-a. Molimo idite do <a href='#'>strane za prijključke</a>, uključite 'Režim razvojnika' i kliknite na 'Ažuriraj priključke sada'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Opcije AdBlock-a"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Proveri za malver koji možda ubacuje reklame:"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Očistite spisak"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocijalna lista filtera (uklanja dugmad društevnih mreža)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Prikaži izjave uklanjanja greške u zapisu konzole (usporava AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Premašili ste Dropbox ograničenje veličine. Molimo uklonite neke unose iz vaših prilagođenih ili onemogućenih filtera pa pokušajte ponovo."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Ponovo aktivirati AdBlock"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Gotovo! Ponovo smo pokrenuli stranicu sa reklamom. Molimo proverite da li je reklama nestala. Onda se vratite na ovu stranicu i odgovorite na pitanje ispod."
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Nemački"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Pazite: ovaj filter blokira sve $elementtype$ elemente na strani!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Izaberite jezik "
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Da li se ova reklama vidi u filmu ili ispred filma ili nekog drugog priključka poput igre u Flash-u?"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Zaobiđite videe sa Hulu.com koji ne rade (zahteva restartovanje pretraživača)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Isključi"
-  },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Onemogućite sva proširenja osim AdBlock-a:"
-  },
-  "pagelanguagecheck":{
+  "adstillappear":{
     "description":"Question on ad report page",
-    "message":"Na kom jeziku je stranica napisana?"
+    "message":"Da li je reklama i dalje vidljiva?"
   },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Proverite da li koristite ispravni filter za jezik:"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Jeste li sigurni da želite ukloniti $count$ blokiranja koje ste napravili na $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Proveri u Firefox-u $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Zaslužan za prevodjenje:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"UČITAVANJE..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Kliknite desnim klikom na reklamu da je blokirate -- ili je blokirajte ovde ručno."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Ako želite da sakrijte dugme, kliknite na njega desnim klikom i izaberite Sakrij Dugme. Možete ga prikazati opet pod chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumunski"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Uredi onemogućene filtere:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Prihvatljive reklame (preporučeno)"
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Proverite da li su svi filteri ažurni:"
   },
   "somethingwentwrong":{
     "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
     "message":"Desila se nekakva greška kod provere ažuriranja."
   },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Proveri filtere Prihvatljivih reklama:"
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Kliknite na Safari meni &rarr; Podešavanja &rarr; Extenzije."
   },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Da biste sklonili dugme, desnim klikom na alatnu traku Safari-ja odaberite Customize toolbar (Prilogođivanje alatne trake), a zatim povucite dugme AdBlock iz alatne trake. Možete ga ponovo prikazati vraćanjem ga nazad u alatnoj traku."
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Pošalji"
   },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Onemogućili smo sva proširenja. Sada ćemo ponovno pokrenuti stranicu sa reklamom. Sekundu, molim."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"ažurirano pre jedan minut"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"stranica"
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Omogući režim kompatibilnosti ClickToFlash"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
   },
   "catblock_example_flickr_url":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1090,337 +1165,302 @@
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"ili Chrome"
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Ili unesite URL:"
-  },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Ukloni sa liste"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Koristite staru verziju Safarija. Nabavite najnoviju verziju da bi koristili dugme AdBlock-a na panelu sa alatkama da bi pauzirali AdBlock, omogućili prikaz reklama na određenim veb sajtovima, i kako bi prijavili reklame."
-  },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Vrsta okvira: "
-  },
-  "fetchinglabel":{
+  "unsubscribedlabel":{
     "description":"Status label",
-    "message":"Dobavljanje... molimo sačekajte."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Kliknite na Safari meni &rarr; Podešavanja &rarr; Extenzije."
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Instalirajte Adblock Plus za Firefox/$chrome$ ukoliko ga nemate.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Obustavi blokiranje reklama:"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Najpopularniji dodatak za Chrome, sa preko 40 miliona korisnika! Blokira reklame na celom internetu."
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Blokirani resurs"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Da li je reklama i dalje vidljiva?"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Zaštita od malicioznog softvera"
-  },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Podrška"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Bugarski"
-  },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Želite da vidite kako radi AdBlock?"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Odlično! Pronađimo sada koje proširenje je uzrok. Prođite kroz listu i omogućite svako proširenje posebno. Proširenje koje ubacuje reklame je ono koje bi trebali ukloniti da bi se rešili reklama."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Poreklo filtera:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Nije uspelo!"
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filter, koji se može promeni na strani sa podešavanjima:"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Ručno uredite vaše filtere:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Filter:<br/> $filter$ <br/> ima grešku: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popap"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Kucaj"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovenski"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Prijavite se na liste filtera"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Da li se reklama takođe pojavljuje u tom pretraživaču?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Nemoj pokretati na ovoj strani"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Litvanski"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blokiraj samo reklame na ovim sajtovima:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Recite nam na našoj <a>stranici podrške</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock je pauziran."
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Prekoračili ste nivo skladištenja kori AdBlock može da koristi. Molimo obustavite praćenje nekih lista filtera!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Ne možemo još da blokiramo reklame unutar Flash-a i ostalih priključaka. Čekamo podršku pretraživača i WebKit-a."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Pronašli ste reklamu na web-stranici? Pomoći ćemo Vam da pronađete pravo mesto da je prijavite!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, i dalje možete da blokirate ovu reklamu za sebe na strani sa podešavanjima. Hvala!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Opšte"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"ostalo"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Pošalji"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Filter nije specifikovan!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"nepoznato"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finski"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock je onesposobljen na ovoj strani."
+    "message":"Prekini pratnju."
   },
   "typemedia":{
     "description":"A resource type",
     "message":"audio/video"
   },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japanski"
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Letonski"
   },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Dozvoli neke nenametljive reklame"
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blokiraj reklamu na ovoj strani"
   },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Kliknite na ovo: <a>Ažuriraj moje filtere!</a>"
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Obustavi blokiranje reklama:"
   },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Nemoj pokretati na stranama ovog domena"
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Ukloni sa liste"
   },
   "failedtofetchfilter":{
     "description":"Error messagebox",
     "message":"Nije uspelo dobavljanje ovog filtera!"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Prikaži linkove na liste filtera"
-  },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Samo engleski"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Poništi"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Pomozite da proširimo reč!"
-  },
   "you_can_slide_to_change":{
     "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
     "message":"Možete da pomerite klizač ispod kako biste odredili tačno na kojim stranicama AdBlock neće raditi."
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock je blokirao preuzimanje sa web stranice koja je poznata da drži malver."
+  "typehiding":{
+    "description":"A resource type",
+    "message":"skriven"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Legenda: "
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Da li se ova reklama vidi u filmu ili ispred filma ili nekog drugog priključka poput igre u Flash-u?"
   },
-  "filtericelandic":{
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Ruski i ukrajinski"
+  },
+  "filtereasylist_plus_spanish":{
     "description":"language",
-    "message":"Islandski"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Prijavite se na ovu listu filtera, onda pokušajte ponovo: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Da biste prijavili reklamu, morate biti povezani na internet."
+    "message":"Španski"
   },
   "filtereasylist":{
     "description":"A filter list",
     "message":"EasyList (preporučeno)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Nevažeći URL liste. Biće obrisan."
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Omogući režim kompatibilnosti ClickToFlash"
   },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Ne"
   },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Da"
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filter, koji se može promeni na strani sa podešavanjima:"
   },
-  "filteritalian":{
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Ostalo"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, i dalje možete da blokirate ovu reklamu za sebe na strani sa podešavanjima. Hvala!"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Onemogućite sva proširenja osim AdBlock-a:"
+  },
+  "lang_russian":{
     "description":"language",
-    "message":"Italijanski"
+    "message":"Ruski"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Koristite staru verziju Safarija. Nabavite najnoviju verziju da bi koristili dugme AdBlock-a na panelu sa alatkama da bi pauzirali AdBlock, omogućili prikaz reklama na određenim veb sajtovima, i kako bi prijavili reklame."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (zaštita privatnosti)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ će biti $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Ili unesite URL:"
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Vrsta okvira: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"UČITAVANJE..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Da li je naš tim zatražio dodatne informacije o bagu? Kliknite <a href='#' id='debug'>ovde</a> za to!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Prijavi reklamu na ovoj stranici"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Prikaži izjave uklanjanja greške u zapisu konzole (usporava AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Domen okvira: "
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Pomerite klizač dok je reklama ispravno blokirana na stranici, i blokirani element izgleda korisno."
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Najpopularniji dodatak za Chrome, sa preko 40 miliona korisnika! Blokira reklame na celom internetu."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Našli ste bag?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Češki"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Ponovo učitaj stranicu sa reklamom."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Prikaži linkove na liste filtera"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Dozvoli neke nenametljive reklame"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Ima $matchcount$ takve stavke na ovoj strani.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock podrška"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Izaberite jezik "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Francuski"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Izmeni"
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Podrška"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blokiraj reklamu preko njenog URL-a"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Verzija $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Svrha ovog pitanja je da se odredi ko bi trebao da primi vaš izveštaj. Ukoliko odgovorite na ovo pitanje pogrešno, izveštaj će biti poslat pogrešnim ljudima, pa može biti ignorisan."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Prijavljivanje reklama je dobrovoljno. Pomaže drugima da takođe ne vide reklame tako što održavatelji lista filtera blokiraju reklamu za sve. Ako se ne osećate altruistički, to je isto u redu. Zatvorite ovu stranicu i <a>blokirajte reklamu</a> samo sebi."
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Izvorni kod je <a>otvoren i besplatan</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Holandski"
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"To odgovara <b>jednoj</b> stavci na ovoj strani."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"ažurirano pre $hours$ sati",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Proveri za malver koji možda ubacuje reklame:"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Kliknite ovo: <a>Onemogući Prihvatljive reklame</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domen strane na kojoj se primenjuje"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"ažurirano pre $minutes$ minuta",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Naučite više o malicioznom softveru"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Prihvatljive reklame (preporučeno)"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - kliknite za detalje"
   },
   "here":{
     "description":"This message is injected in other strings as a link/button",
     "message":"ovde"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Izgleda dobro"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Imate pitanje ili novu ideju?"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
   }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -1,723 +1,187 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Rapportera ett reklamtillägg"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Reklamblockerande filterlistor"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Domän:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Tillåt vitlistning av specifika YouTube-kanaler"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Ingen känd, skadlig kod hittades."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"I den webbläsaren prenumererar du på samma filterlistor som du har här."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - Klicka för meny"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Surfa till sidan med reklamtillägget, i den webbläsaren."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Svenska"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Nyheter i den senaste versionen? Läs i <a style='cursor:pointer;'> ändringsloggen</a>!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Blockera fler reklamtillägg:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Ryska"
+    "message":"Danska"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Betala vad du vill!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Hjälp till att sprida budskapet!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Prenumeration avslutad."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Blockera ett reklamtillägg via URL"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Grekiska"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Kinesiska"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video och Flash"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Skydd mot skadlig kod"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Vad tror du kommer att vara sant om det här reklamtillägget varje gång du besöker sidan?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Aktivera AdBlock på denna sida"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Tillbaka"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Visa antal blockerade reklamtillägg, på AdBlock-ikonen"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Har du en fråga eller någon ny idé?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Lettiska"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Filterlistorna blockerar de flesta reklamtillägg på webben.  Du kan också:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Källkoden är <a>fritt tillgänglig</a>!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Tillåt reklam på en webbsida eller domän"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Det matchar <b>1</b> objekt på den här sidan."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Dölj delar av en webbsida"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Vitlista $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Allmäna alternativ"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Din dator kan vara infekterad av skadlig kod. Klicka <a>här</a> för mer information."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock avaktiveras på alla sidor som matchar:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Vi har ingen filterlista för det språket.<br/>Försök hitta en passande lista som stöder språket $link$ eller blockera reklamen själv under fliken 'Anpassa'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Prenumerera"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Jag är avancerad användare, visa avancerade alternativ"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Dölj knapp"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Uppdateringar hämtas automatiskt. Du kan också <a>uppdatera nu</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Klick här: <a>Uppdatera mina filter!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Format: ~sida1.com|~sida2.se|~nyheter.sida3.org"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock är pausad."
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Det matchar $matchcount$ objekt på den här sidan.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Vi har också en <a>sida</a> som presenterar människorna bakom AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Indonesiska"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Typ"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Det finns en uppdatering för AdBlock! Gå till $here$ för att uppdatera. <br>Obs: om du vill få uppdateringar automatiskt, klicka bara på Safari > inställningar > Extensions > uppdateringar <br>och markera alternativet \"Installera uppdateringar automatiskt\".",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Turkiska"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Vad är detta?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Anpassade filterlistor"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Prenumerera inte på mer än du behöver -- Varje lista gör webbläsaren en liten aning långsammare! Listornas ursprung, och fler listor hittas <a>här</a>."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"stil-definition"
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Den här AdBlock-funktionen fungerar inte på denna sida eftersom den använder utdaterad teknologi. Du kan svart-/vitlista resurser manuellt, under fliken \"Anpassa\" i inställningarna."
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Syftet med denna fråga, är att avgöra vem som skall ta emot din rapport. Besvarar du denna fråga felaktigt, kommer rapporten att skickas till fel personer och riskerar därmed att ignoreras."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Polska"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Lägg till AdBlock i högerklickmenyn"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Blockera det här reklamtillägget"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"Uppdaterades för $hours$ timmar sedan",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"Uppdaterades för $seconds$ sekunder sedan",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Har vårt team begärt någon felinformation? Klicka <a href='#' id='debug'> här</a> för det!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interaktivt objekt"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Ungerska"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Ogiltig listadress. Den kommer att tas bort."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"OBS! Din rapport kan komma att bli pulicerad offentligt. Håll det i minnet om du inkluderar något av privat natur."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Uppdatera sidan."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"sida"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Nederländska"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Glöm inte att spara!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ är $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Stäng"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Blockerade element:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filtret är ogiltigt: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"<b>OBS!</b> Inget filter specificerat!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Tillåta AdBlock att samla in anonym filteranvändning och data"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Vill du att AdBlock skall meddela dig när den upptäcker skadlig kod?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Visa reklamtillägg <i>överallt</i> utom på dessa domäner..."
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Visa antal blockerade reklamtillägg, på AdBlock-menyn"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Alternativ"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Avaktivera AdBlock på..."
-  },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Blockerade tillägg:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock-anpassat filter (Rekommenderas)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Lägg till filter för andra språk: "
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (tar bort störande innehåll från webben)"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Tilläggen som tidigare inaktiverades, har nu återaktiverats."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Blockera URL:er innehållande den här texten"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS att matcha"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Om du vill dölja knappen, gå till 'opera://extensions' och markera alternativet \"Dölj verktygsfältet\". Du kan visa den igen genom att avmarkera alternativet."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Klicka på objektet, så hjälper jag dig igenom blockeringen."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Rapportera ett tillägg på den här sidan"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Ryska och Ukrainska"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Hämtar... vänta!"
   },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"<b>Varning!</b> Ett misstag här, kan resultera i att andra filter, inklusive dom officiella, kan förstöras!<br/>Läs '<a>syntax-guiden</a>' för att lära hur man skapar avancerade svart- och vitlistor."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Allmänt"
   },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock Support"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Anpassa AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock är uppdaterad!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ totalt",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"Hebreiska"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Ledsen, men AdBlock är inaktiverat på den här sidan av en av dina filterlistor."
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Ångra mina blockeringar på denna domän"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Redigera filter här under, och tryck 'OK'"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"Uppdaterades för 1 dag sedan"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (tar bort störande innehåll från webben)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ på den här sidan",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Osäker?</b> Tryck bara 'Blockera'."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Ogiltig listadress. Den kommer att tas bort."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"Uppdaterades för 1 timma sedan"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Polska"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Version $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Allmäna alternativ"
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Ta bort från listan"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Annat"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS att matcha"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"dold"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Filterlistor"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Framträder reklamen i eller före en film eller något annat tillägg, som ett Flash-spel?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Andra filterlistor"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"eller krom"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Blockera"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Slutförd!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Blockera ett objekt på denna sida"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Stäng"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Jag vill inte leka testpilot just nu"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Visa reklamtillägg <i>överallt</i> utom på dessa domäner..."
   },
-  "lang_english":{
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"<b>Varning!</b> Ett misstag här, kan resultera i att andra filter, inklusive dom officiella, kan förstöras!<br/>Läs '<a>syntax-guiden</a>' för att lära hur man skapar avancerade svart- och vitlistor."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"Engelska"
+    "message":"Slovakiska"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Anpassa"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Pausa AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Vill du verkligen prenumerera på filterlistan $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Öppna tilläggssidan för att aktivera de tillägg som tidigare inaktiverats."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Domän som skall filtreras"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Koreanska"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Sida:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Hittat ett fel?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Steg 1: Ta reda på vad som skall blockeras"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Tjeckiska"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Ju fler filterlistor du använder, dessto långsammare arbetar AdBlock.  För många listor kan även få din webbläsare att krascha på vissa sidor.  Tryck 'OK' för att prenumerera i alla fall."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"eller AdBlock för Chrome"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Blockera ett objekt"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Ja"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Finns reklamtillägget i den webbläsaren också?"
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Sista steget: Vad gör det här till ett reklamtillägg?"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Undanta denna sida"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Danska"
+    "message":"Rumänska"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Du kan dölja knappen genom att högerklicka på den och välja 'Dölj knapp'. Visa den igen under chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Hebreiska"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Den här AdBlock-funktionen fungerar inte på denna sida eftersom den använder utdaterad teknologi. Du kan svart-/vitlista resurser manuellt, under fliken \"Anpassa\" i inställningarna."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Tjeckiska och Slovakiska"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Andra filterlistor"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Alternativ"
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Din dator kan vara infekterad av skadlig kod. Klicka <a>här</a> för mer information."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Uppdateringar hämtas automatiskt. Du kan också <a>uppdatera nu</a>"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"okänd"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Redigera"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Tillåt reklam på en webbsida eller domän"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Söker reklamtillägg...<br/><br/><i>Det tar bara ett ögonblick!</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Turkiska"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Domän eller url där AdBlock inte skall blockera något"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Sök efter uppdateringar (tar bara några sekunder)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Ju fler filterlistor du använder, dessto långsammare arbetar AdBlock.  För många listor kan även få din webbläsare att krascha på vissa sidor.  Tryck 'OK' för att prenumerera i alla fall."
   },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Undanta denna domän"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Uppdatera sidan med reklamen."
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Installera Firefox $chrome$ om du inte redan har gjort det.",
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Prenumerera på denna filterlista, och försök igen: $list_title$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Vi har ingen filterlista för det språket.<br/>Försök hitta en passande lista som stöder språket $link$ eller blockera reklamen själv under fliken 'Anpassa'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -725,234 +189,381 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Klicka på objektet, så hjälper jag dig igenom blockeringen."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"stil-definition"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock-uppdateringar"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Nej"
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Högerklicka ett reklamtillägg på en sida för att blockera det -- eller blockera det manuellt här."
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Ledsen, men AdBlock är inaktiverat på den här sidan av en av dina filterlistor."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Vill du att AdBlock skall meddela dig när den upptäcker skadlig kod?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"Uppdaterades för 1 dag sedan"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Inget filter specificerat!"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Tyska"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Prenumerera på filterlistor"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Grekiska"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"Uppdaterades för $seconds$ sekunder sedan",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Osäker?</b> Tryck bara 'Blockera'."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Surfa till sidan med reklamtillägget, i den webbläsaren."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Låt oss veta, på vår <a>support-sida</a>!"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Blockera reklamtillägg, endast på dessa sidor:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Anpassa"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"För att rapportera ett reklamtillägg, måste du vara ansluten till internet."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Vitlista $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Dölj delar av en webbsida"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Visa antal blockerade reklamtillägg, på AdBlock-menyn"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Rapportera ett reklamtillägg"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgariska"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Undanta denna domän"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Anpassade filterlistor"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Blockera fler reklamtillägg:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukrainska"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"Uppdaterades för $minutes$ minuter sedan",
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Typ"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Domän eller url där AdBlock inte skall blockera något"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Avaktivera AdBlock på..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Blockera URL:er innehållande den här texten"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"Undanta"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Kontrollera i Firefox $chrome$",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Franska"
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ELLER</b>klicka bara på denna knapp, så sköter vi allt ovanstående: <a>Inaktivera alla andra tillägg</a>"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"Uppdaterades just nu"
   },
   "savebutton":{
     "description":"Save button",
     "message":"Spara"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Varning: Du kommer att se tillägg på alla andra sidor!<br>Det här åsidosätter också alla andra filter för dessa sidor ."
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
   },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Inaktivera dessa meddelanden"
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Prenumerera på filterlista..."
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Ser bra ut"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Anpassa AdBlock"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Ingen känd, skadlig kod hittades."
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Tillåta AdBlock att samla in anonym filteranvändning och data"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Fixa felet som gör att video inte spelas upp på Hulu.com (kräver omstart av webbläsaren)."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Finska"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Dölj knapp"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Reklamblockerande filterlistor"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"Uppdaterades för $days$ dagar sedan",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"interaktivt objekt"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (Integritetsskydd)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Vad tror du kommer att vara sant om det här reklamtillägget varje gång du besöker sidan?"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Läs mer om skadlig kod"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Tjeckiska och Slovakiska"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Du använder en gammal version av AdBlock. Gå till <a href='#'>the extensions page</a>, bocka i 'Programerarläge' och klicka på 'Uppdatera tillägg nu'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock-alternativ"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Rensa denna lista"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocial filterlista (tar bort knappar för sociala medier)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Visa felsökningsinformation i loggen (vilket gör AdBlock långsammare)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Du har uppnått storleksgränsen för Dropbox. Ta bort några poster från dina anpassade eller inaktiverade filter och försök igen."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Återaktivera AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Tyska"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Varning! Detta filter blockerar alla $elementtype$-element på sidan!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"Här"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Ja"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Fixa felet som gör att video inte spelas upp på Hulu.com (kräver omstart av webbläsaren)."
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"Undanta"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"På vilket språk är sidan skriven?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Vill du verkligen ta bort $count$ blockering(ar) som du har skapat för $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"bild"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Översättning till Svenska:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"LÄSER IN..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Högerklicka ett reklamtillägg på en sida för att blockera det -- eller blockera det manuellt här."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Du kan dölja knappen genom att högerklicka på den och välja 'Dölj knapp'. Visa den igen under chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumänska"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Redigera inaktiverade filter:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Något gick fel vid uppdateringskontrollen."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Om du vill dölja knappen, högerklicka på Safaris verktygsfält och välj \"Anpassa verktygsfältet\". Dra sedan AdBlock-knappen bort från verktygsfältet. Du kan visa den igen genom att dra den tillbaka in i verktygsfältet."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"Uppdaterades för 1 minut sedan"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Blockerade tillägg:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"sida"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Koreanska"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Ångra mina blockeringar på denna domän"
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Redigera dina filter manuellt:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Visa länk till filterlistorna"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (Rekommenderas)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Steg 1: Ta reda på vad som skall blockeras"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Vi har också en <a>sida</a> som presenterar människorna bakom AdBlock!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Domän:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"Här"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Om du ser en annons, skicka inte en felrapport. Rapportera ett <a>reklamtillägg</a>!"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock är uppdaterad!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Uppdatera sidan."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Endast på engelska"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Du använder en gammal version av AdBlock. Gå till <a href='#'>the extensions page</a>, bocka i 'Programerarläge' och klicka på 'Uppdatera tillägg nu'"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock är pausad."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ELLER</b>klicka bara på denna knapp, så sköter vi allt ovanstående: <a>Inaktivera alla andra tillägg</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Nyheter i den senaste versionen? Läs i <a style='cursor:pointer;'> ändringsloggen</a>!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antisocial filterlista (tar bort knappar för sociala medier)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Söker reklamtillägg...<br/><br/><i>Det tar bara ett ögonblick!</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Jag är avancerad användare, visa avancerade alternativ"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"I den webbläsaren prenumererar du på samma filterlistor som du har här."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Blockera ett objekt"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Varning: Du kommer att se tillägg på alla andra sidor!<br>Det här åsidosätter också alla andra filter för dessa sidor ."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Tilläggen som tidigare inaktiverades, har nu återaktiverats."
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Vill se vad som får AdBlock att fungera?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock-anpassat filter (Rekommenderas)"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Vad är detta?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -964,281 +575,83 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Eller ange en URL:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"eller AdBlock för Chrome"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Du använder en gammal version av Safari. Uppgradera till senaste version för att kunna använda AdBlocks verktygsikon till att pausa AdBlock, vitlista webbsidor och rapportera reklamtillägg. <a>Uppgradera nu</a>."
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Välj språk --"
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Översättning till Svenska:"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Format: ~sida1.com|~sida2.se|~nyheter.sida3.org"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Klicka på Safari-menyn &rarr; Alternativ &rarr; Tillägg."
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Sluta blockera reklamtillägg:"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video och Flash"
   },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Det mest populära Chrome-tillägget, med över 40 miljoner användare!  Blockerar reklamtillägg över hela webben."
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Filterlistorna blockerar de flesta reklamtillägg på webben.  Du kan också:"
   },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Är reklamtillägget fortfarande kvar?"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Om du vill dölja knappen, högerklicka på Safaris verktygsfält och välj \"Anpassa verktygsfältet\". Dra sedan AdBlock-knappen bort från verktygsfältet. Du kan visa den igen genom att dra den tillbaka in i verktygsfältet."
   },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Support"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Du har uppnått storleksgränsen för Dropbox. Ta bort några poster från dina anpassade eller inaktiverade filter och försök igen."
   },
-  "filtereasylist_plus_bulgarian":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Bulgariska"
+    "message":"Ungerska"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Vill se vad som får AdBlock att fungera?"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"eller krom"
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Misslyckades!"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Prenumerera"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Filtret, som kan ändras på Alternativ-sidan:"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Betala vad du vill!"
   },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"Redigera dina filter manuellt:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Följande filter:<br/> $filter$ <br/> har ett fel: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Dra i skjutreglaget tills reklamen är korrekt blockerad, och sidan förövrigt ser använbar ut."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Typ"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovakiska"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Prenumerera på filterlistor"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Finns reklamtillägget i den webbläsaren också?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Undanta denna sida"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Blockera reklamtillägg, endast på dessa sidor:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Låt oss veta, på vår <a>support-sida</a>!"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Sista steget: Vad gör det här till ett reklamtillägg?"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Du har överskridit den maximala mängden lagringsutrymme som AdBlock kan använda. Avsluta prenumerationen på en eller flera filterlistor!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Vi kan inte blockera reklam i Flash och andra tillägg än. Vi väntar på stöd från webbläsaren och WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"OK, du kan fortfarande blockera reklamen själv på 'Alternativ-sidan'. Tack!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Allmänt"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"annat"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Skicka"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Inget filter specificerat!"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"okänd"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Finska"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock är inaktiverad på denna sida."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japanska"
+    "message":"Redigera inaktiverade filter:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Detta är ett filterlistproblem. Rapportera det här: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Avaktivera alla tillägg <b>utom</b> AdBlock. <b>Lämna AdBlock aktiverat</b>."
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Blockerade element:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Visa länk till filterlistorna"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"OBS! Din rapport kan komma att bli pulicerad offentligt. Håll det i minnet om du inkluderar något av privat natur."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Endast på engelska"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Avbryt"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Hjälp till att sprida budskapet!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Du kan dra i skjutreglaget för att ändra mer exakt, på vilka sidor AdBlock skall avaktiveras."
-  },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock har blockerat en nedladdning från en plats, känd för skadlig kod."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Kontrollera i Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"Aktivera ClickToFlash kompatibilitetsläge"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Prenumerera på denna filterlista, och försök igen: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"För att rapportera ett reklamtillägg, måste du vara ansluten till internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (Rekommenderas)"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Kunde inte hämta detta filter!"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Italienska"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"Spanska"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Ser bra ut"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Om du ser en annons, skicka inte en felrapport. Rapportera ett <a>reklamtillägg</a>!"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Har du en fråga eller någon ny idé?"
+  "typepage":{
+    "description":"A resource type",
+    "message":"sida"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1248,5 +661,632 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Är reklamtillägget fortfarande kvar?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"annat"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Klick här: <a>Uppdatera mina filter!</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"Italienska"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Om du vill dölja knappen, gå till 'opera://extensions' och markera alternativet \"Dölj verktygsfältet\". Du kan visa den igen genom att avmarkera alternativet."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Något gick fel vid uppdateringskontrollen."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Klicka på Safari-menyn &rarr; Alternativ &rarr; Tillägg."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Skicka"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Sida:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Uppdatera sidan med reklamen."
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Prenumeration avslutad."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Lettiska"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Blockera ett objekt på denna sida"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Blockera"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Sluta blockera reklamtillägg:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Tillåt vitlistning av specifika YouTube-kanaler"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"På vilket språk är sidan skriven?"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Avaktivera alla tillägg <b>utom</b> AdBlock. <b>Lämna AdBlock aktiverat</b>."
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Ta bort från listan"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Vi kan inte blockera reklam i Flash och andra tillägg än. Vi väntar på stöd från webbläsaren och WebKit."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Du kan dra i skjutreglaget för att ändra mer exakt, på vilka sidor AdBlock skall avaktiveras."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"dold"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock är inaktiverad på denna sida."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Framträder reklamen i eller före en film eller något annat tillägg, som ett Flash-spel?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Ryska och Ukrainska"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Spanska"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Blockera det här reklamtillägget"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Varning! Detta filter blockerar alla $elementtype$-element på sidan!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"Aktivera ClickToFlash kompatibilitetsläge"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Nej"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Aktivera AdBlock på denna sida"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Filtret, som kan ändras på Alternativ-sidan:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Visa antal blockerade reklamtillägg, på AdBlock-ikonen"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Misslyckades!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Pausa AdBlock"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Följande filter:<br/> $filter$ <br/> har ett fel: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"Engelska"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Lägg till AdBlock i högerklickmenyn"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"OK, du kan fortfarande blockera reklamen själv på 'Alternativ-sidan'. Tack!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Ryska"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Vill du verkligen ta bort $count$ blockering(ar) som du har skapat för $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Du använder en gammal version av Safari. Uppgradera till senaste version för att kunna använda AdBlocks verktygsikon till att pausa AdBlock, vitlista webbsidor och rapportera reklamtillägg. <a>Uppgradera nu</a>."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (Integritetsskydd)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ är $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Eller ange en URL:"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Slutförd!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Återaktivera AdBlock"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Lägg till filter för andra språk: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"LÄSER IN..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Har vårt team begärt någon felinformation? Klicka <a href='#' id='debug'> här</a> för det!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Skydd mot skadlig kod"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Rapportera ett tillägg på den här sidan"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Visa felsökningsinformation i loggen (vilket gör AdBlock långsammare)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Installera Firefox $chrome$ om du inte redan har gjort det.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Dra i skjutreglaget tills reklamen är korrekt blockerad, och sidan förövrigt ser använbar ut."
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Du har överskridit den maximala mängden lagringsutrymme som AdBlock kan använda. Avsluta prenumerationen på en eller flera filterlistor!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Det mest populära Chrome-tillägget, med över 40 miljoner användare!  Blockerar reklamtillägg över hela webben."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Hittat ett fel?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Läs mer om skadlig kod"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Filterlistor"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock avaktiveras på alla sidor som matchar:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Kinesiska"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filtret är ogiltigt: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Prenumerera på filterlista..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Öppna tilläggssidan för att aktivera de tillägg som tidigare inaktiverats."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Inaktivera dessa meddelanden"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Det matchar $matchcount$ objekt på den här sidan.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"Uppdaterades för 1 timma sedan"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Välj språk --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Franska"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Indonesiska"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"bild"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Redigera"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Kunde inte hämta detta filter!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ totalt",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Support"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Blockera ett reklamtillägg via URL"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Avbryt"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Glöm inte att spara!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Version $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Syftet med denna fråga, är att avgöra vem som skall ta emot din rapport. Besvarar du denna fråga felaktigt, kommer rapporten att skickas till fel personer och riskerar därmed att ignoreras."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Vill du verkligen prenumerera på filterlistan $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Källkoden är <a>fritt tillgänglig</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Nederländska"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Redigera filter här under, och tryck 'OK'"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Det finns en uppdatering för AdBlock! Gå till $here$ för att uppdatera. <br>Obs: om du vill få uppdateringar automatiskt, klicka bara på Safari > inställningar > Extensions > uppdateringar <br>och markera alternativet \"Installera uppdateringar automatiskt\".",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Det matchar <b>1</b> objekt på den här sidan."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japanska"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Rensa denna lista"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"Uppdaterades för $hours$ timmar sedan",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Tillbaka"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock-alternativ"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock har blockerat en nedladdning från en plats, känd för skadlig kod."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Prenumerera inte på mer än du behöver -- Varje lista gör webbläsaren en liten aning långsammare! Listornas ursprung, och fler listor hittas <a>här</a>."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Sök efter uppdateringar (tar bara några sekunder)..."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Annat"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Domän som skall filtreras"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"Uppdaterades just nu"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"Uppdaterades för $minutes$ minuter sedan",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Tjeckiska"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Svenska"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock Support"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Typ"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"Uppdaterades för 1 minut sedan"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - Klicka för meny"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"<b>OBS!</b> Inget filter specificerat!"
   }
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -1,723 +1,187 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Reklam bildirme"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Reklam Engelleme Filtre Listeleri"
-  },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Site:"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Belirli Youtube kanallarını beyaz listeye eklemeye izin ver"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Bilinen bir zararlı yazılım bulunamadı."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Bu tarayıcıda, burada sahip olduğunuz aynı filtrelere abone olun."
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - ayrıntılar için tıklayın"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Yüklediğiniz tarayıcıda, reklam olan bir sayfayı açın."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"İsveççe"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"En son sürümde ne yenilikler var? <a style='cursor:pointer;'>Sürüm Notları</a>'nı inceleyin!"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Daha fazla reklam engelle:"
-  },
-  "lang_russian":{
+  "filterdanish":{
     "description":"language",
-    "message":"Rusça"
+    "message":"Danimarkaca"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"İstediğiniz kadar ödeyin!"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Lütfen AdBlock'u daha fazla kişiye ulaştırmama yardım edin!"
   },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Abonelik kaldırıldı."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Reklamı URL'sine göre engelle"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Yunanca"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Çince"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video ve Flash"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Zararlı yazılımlara karşı koruma"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Bu sayfayı her ziyaret ettiğinizde hangisinin geçerli olacağını düşünüyorsunuz?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Bu sayfada AdBlock'u etkinleştir"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Geri"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"AdBlock düğmesi üzerinde kaç tane reklamın engellendiğini göster"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Yeni bir fikriniz ya da bir sorunuz mu var?"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Letonca"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Filtre listeleri web sitelerindeki çoğu reklamı engeller. Ayrıca şunları da yapabilirsiniz:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Kaynak kodu <a>serbestçe kullanılabilir</a>!"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Bir web sayfasındaki ya da alan adındaki reklamları göster"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Bu sayfada <b>1</b> benzer öğe bulundu."
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Web sayfasının bir bölümünü sakla"
-  },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Bu kanala izin verin : $name$",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Genel Ayarlar"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Bilgisayarınıza kötü amaçlı yazılımlar bulaşmış olabilir. Daha çok bilgi için <a>buraya</a> tıklayın."
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock şu durumlarla eşleşen sayfalarda çalışmayacak:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Bu dil için varsayılan bir filtre listemiz yok.<br/> Lütfen bu dili destekleyen uygun bir liste bulmaya çalışın ya da $link$ \"Özelleştir\" seçeneğini kullanarak bu reklamı kendiniz için engelleyin.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Abone ol"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Tecrübeli bir kullanıcıyım, bana gelişmiş seçenekleri göster"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Bu düğmeyi gizle"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Güncellemeler otomatik olarak yüklenecek; siz de <a>şimdi güncelle</a> butonunu kullanarak güncelleyebilirsiniz"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Buraya tıklayın: <a>Filtrelerimi güncelleştir!</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Biçim: ~site1.com|~site2.com|~haberler.site3.org"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock duraklatıldı."
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Bu sayfada $matchcount$ benzer öğe bulundu.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"AdBlock'un arkasında kimlerin olduğunu öğrenmeniz için bir <a>sayfamız</a> da var!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Endonezce"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Tip"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"AdBlock için bir güncelleme var! $here$ güncelleyebilirsiniz.<br> Not: Eğer güncellemeleri otomatik olarak almak isterseniz, Safari > Preferences > Extensions > Updates<br> yolunu takip ederek 'install updates automatically' seçeneğini işaretleyin.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Türkçe"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Bu nedir?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Özelleştirilmiş Filtre Listeleri"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"İhtiyacınız olmayan filtrelere abone olmayın -- her biri AdBlock'u biraz daha yavaşlatır. \"Emeği geçenler\" listeleri ve daha fazlası <a>buradan</a> görülebilir."
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"stil tanımı"
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"AdBlock'un bu özelliği buradaki sitede çalışmıyor çünkü bu site eskimiş bir teknoloji kullanıyor. Seçenekler sayfasındaki 'Özelleştir' seçeneğini kullanarak kaynakları izin verilenlere veya engellenenlere kendiniz ekleyebilirsiniz."
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Bu sorunun amacı bildiriminizi kimin alacağını belirlemek içindir. Eğer bu soruyu yanlış yanıtlarsanız, bildiriminiz yanlış insanlara ulaşıp, dikkate alınmayabilir."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Lehçe"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Sağ tıklama menüsüne AdBlock seçeneklerini ekle"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Bu reklamı engelle"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"$hours$ saat önce güncelleştirildi.",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"$seconds$ saniye önce güncelleştirildi",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Ekibimiz sizden hata ayıklama bilgileri mi istedi? Onun için <a href='#' id='debug'>buraya</a> tıklayın!"
-  },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"etkileşimli öğe"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Macarca"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Geçersiz filtre listesi linki. Bu link silinecek."
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Not: Bildiriminiz halka açık bir şekilde görünebilir. Gizlilik içerebilecek bir bilgi dahil etmeden önce bunu göz önünde bulundurun."
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Sayfayı yeniden yükle."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"sayfa"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Flemenkçe"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Kaydetmeyi unutmayın!"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ olacak $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Kapat"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Engellenen öğe:"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Filtre geçersiz: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Dikkat: hiç filtre tanımlanmamış!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"AdBlock'un anonim olarak filtre listesi kullanımı ve verilerini toplamasına izin ver"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"AdBlock kötü amaçlı yazılım algıladığında size bildirsin mi?"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Şu alan adlarındakiler hariç <i>her yerdeki</i> reklamları göster"
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"AdBlock menüsünde kaç tane reklamın engellendiğini göster"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"Seçenekler"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"AdBlock'u şu sitelerde kullanma..."
-  },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Engellenmiş Reklamlar:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock özel filtreleri (tavsiye edilir)"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Başka diller için filtre ekle: "
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (web'deki can sıkıcı şeyleri kaldırır)"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Daha önce devre dışı bıraktığınız uzantılar tekrar etkinleştirildi."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Şu metni içeren URL'leri engelle"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"Eşleşen CSS öğeleri"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Düğmeyi gizlemek için, opera://eklentiler'e gidip 'Araç çubuğundan kaldır' seçeneğini işaretleyin. Yine bu seçeneğin işaretini kaldırarak görünmesini sağlayabilirsiniz."
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Reklamı tıklatın, ve engelleme seçeneklerini görün."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Bu sayfada bir reklam bildir"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Rusça ve Ukraynaca"
-  },
   "fetchinglabel":{
     "description":"Status label",
     "message":"Yükleniyor... lütfen bekleyin."
   },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"Dikkat: eğer burada bir hata yaparsanız, abone olduğunuz filtreler de dahil, çoğu liste tamamen bozulabilir!<br/> Gelişmiş \"izin verilenler\" ve \"engellenenler\" listesi oluşturmak için lütfen <a>filtre sözdizimi kuralları</a> bölümünü okuyun."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Genel"
   },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock Destek"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"AdBlock'u özelleştir"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock güncel!"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"Toplam: $count$",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"İbranice"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Üzgünüm, Filtre listelerinizden biri AdBlock'u bu sayfada kapatmak için ayarlanmış."
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Bu alan adında yaptığım engellemeleri geri al"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Lütfen eklemek istediğiniz filtreyi yazın ve OK tuşuna basın."
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"1 gün önce güncelleştirildi"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (web'deki can sıkıcı şeyleri kaldırır)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"Bu sayfada: $count$",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Emin değil misiniz?</b> Sadece \"Engelle!\" tuşuna basın."
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Geçersiz filtre listesi linki. Bu link silinecek."
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"1 saat önce güncelleştirildi"
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"Lehçe"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Sürüm $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Genel Ayarlar"
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Listeden sil"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Diğer"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"Eşleşen CSS öğeleri"
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"gizlenen"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Filtre listeleri"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Reklam bir video başlamadan önce, video oynatılırken ya da Flash oyunu gibi bir eklentide mi görünüyor?"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"Diğer Filtre Listeleri"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"ya da Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Engelle!"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"Tamamlandı!"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Bu sayfadaki bir reklamı engelleyin"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Kapat"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"Bunu kontrol etmek istemiyorum"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Şu alan adlarındakiler hariç <i>her yerdeki</i> reklamları göster"
   },
-  "lang_english":{
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"Dikkat: eğer burada bir hata yaparsanız, abone olduğunuz filtreler de dahil, çoğu liste tamamen bozulabilir!<br/> Gelişmiş \"izin verilenler\" ve \"engellenenler\" listesi oluşturmak için lütfen <a>filtre sözdizimi kuralları</a> bölümünü okuyun."
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"İngilizce"
+    "message":"Slovakça"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Özelleştir"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"AdBlock'u duraklat"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"$title$ filtre listesine abone olmak istiyor musunuz?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Devre dışı bıraktığınız uzantıları etkinleştirmek için uzantılar sayfasını açın."
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Sayfanın bulunduğu alan adında uygulanacak"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"Korece"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"Sayfa:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Bir hata mı buldunuz?"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"İlk Adım: Nelerin engelleneceğini belirle"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"Çekce"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Ne kadar çok filtre listesi kullanırsanız, AdBlock o kadar yavaşlar. Çok fazla liste kullanmak bazı sitelerde tarayıcınızın çökmesine bile sebep olabilir. Bu listeyi yine de eklemek istiyorsanız Tamam'a basın."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"ya da Chrome için AdBlock"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Bir reklam engelle"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Evet"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Reklam o tarayıcıda da görünüyor mu?"
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Son adım: Bu öğeyi reklam yapan nedir?"
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Bu sayfada AdBlock'u durdur"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"Danimarkaca"
+    "message":"Rumence"
   },
-  "typesub_frame":{
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Düğmeyi gizlemek için, sağ tıklayıp 'Düğmeyi gizle'yi seçin. Tekrar görünmesi için adres çubuğundan; chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"İbranice"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"AdBlock'un bu özelliği buradaki sitede çalışmıyor çünkü bu site eskimiş bir teknoloji kullanıyor. Seçenekler sayfasındaki 'Özelleştir' seçeneğini kullanarak kaynakları izin verilenlere veya engellenenlere kendiniz ekleyebilirsiniz."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Çekçe ve Slovakça"
+  },
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"Diğer Filtre Listeleri"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"Seçenekler"
+  },
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Bilgisayarınıza kötü amaçlı yazılımlar bulaşmış olabilir. Daha çok bilgi için <a>buraya</a> tıklayın."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Güncellemeler otomatik olarak yüklenecek; siz de <a>şimdi güncelle</a> butonunu kullanarak güncelleyebilirsiniz"
+  },
+  "typeunknown":{
     "description":"A resource type",
-    "message":"çerçeve"
+    "message":"bilinmeyen"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Düzenle"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Bir web sayfasındaki ya da alan adındaki reklamları göster"
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Reklamlar bulunuyor..<br/><br/><i>Bu sadece bir kaç saniye sürecek.</i>"
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Türkçe"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"AdBlock'un çalışmasını istemediğiniz sayfa ve alan adları"
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
   },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Güncelleştirmeler denetleniyor(sadece birkaç saniye sürer)..."
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Ne kadar çok filtre listesi kullanırsanız, AdBlock o kadar yavaşlar. Çok fazla liste kullanmak bazı sitelerde tarayıcınızın çökmesine bile sebep olabilir. Bu listeyi yine de eklemek istiyorsanız Tamam'a basın."
   },
-  "typescript":{
-    "description":"A resource type",
-    "message":"komut"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Bu alan adındaki sayfalarda çalışma"
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"Reklam içeren bir sayfayı yenileyin"
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Eğer zaten yüklü değilse, Firefox $chrome$ yükleyin.",
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"Bu filtreye abone olup, tekrar deneyin: $list_title$",
     "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Bu dil için varsayılan bir filtre listemiz yok.<br/> Lütfen bu dili destekleyen uygun bir liste bulmaya çalışın ya da $link$ \"Özelleştir\" seçeneğini kullanarak bu reklamı kendiniz için engelleyin.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -725,234 +189,381 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Reklamı tıklatın, ve engelleme seçeneklerini görün."
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"stil tanımı"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock güncellemeleri"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Hayır"
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Reklamı engellemek için sağ tıklayın -- ya da buradan manuel olarak engelleyin."
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Üzgünüm, Filtre listelerinizden biri AdBlock'u bu sayfada kapatmak için ayarlanmış."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"AdBlock kötü amaçlı yazılım algıladığında size bildirsin mi?"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"1 gün önce güncelleştirildi"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Filtre tanımlanmamış."
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Almanca"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Filtrelere abone olun"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Yunanca"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"$seconds$ saniye önce güncelleştirildi",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Emin değil misiniz?</b> Sadece \"Engelle!\" tuşuna basın."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Yüklediğiniz tarayıcıda, reklam olan bir sayfayı açın."
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"<a>Destek sitemize</a> bildirin!"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Sadece bu sitelerdeki reklamları engelle:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Özelleştir"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Bir reklam bildirmek için internete bağlı olmanız gerekir."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"Tamam!"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Bu kanala izin verin : $name$",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Web sayfasının bir bölümünü sakla"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"AdBlock menüsünde kaç tane reklamın engellendiğini göster"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Reklam bildirme"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Bulgarca"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Bu alan adındaki sayfalarda çalışma"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Özelleştirilmiş Filtre Listeleri"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Daha fazla reklam engelle:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"Ukraynaca"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"$minutes$ dakika önce güncelleştirildi",
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Tip"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"AdBlock'un çalışmasını istemediğiniz sayfa ve alan adları"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"AdBlock'u şu sitelerde kullanma..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Şu metni içeren URL'leri engelle"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"İstisna"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Firefox $chrome$ için reklamın görünüp görünmediğini kontrol edin.",
     "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Fransızca"
-  },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>VEYA</b> bu tuşa tıklayarak hepsini sizin yerinize yapmamızı sağlayabilirsiniz: <a>Tüm diğer eklentileri devre dışı bırak</a>"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"öğe_altistemi"
-  },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"şimdi güncellendi"
   },
   "savebutton":{
     "description":"Save button",
     "message":"Kaydet"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Dikkat: bu sitelerin dışında tüm sitelerde reklamları görebileceksiniz!<br> Kullandığınız filtreler bu siteler dışında geçersiz olacak."
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
   },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Bu bildirimleri devre dışı bırak"
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Filtre listelerine abone olunuyor..."
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"İyi görünüyor"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"AdBlock'u özelleştir"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Bilinen bir zararlı yazılım bulunamadı."
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"AdBlock'un anonim olarak filtre listesi kullanımı ve verilerini toplamasına izin ver"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Hulu.com videolarının oynatılmaması sorununu çöz (tarayıcınızı tekrar başlatmayı gerektirir)"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Fince"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Bu düğmeyi gizle"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Reklam Engelleme Filtre Listeleri"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"$days$ gün önce güncelleştirildi",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"çerçeve"
+    "message":"etkileşimli öğe"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (gizlilik koruması)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Bu sayfayı her ziyaret ettiğinizde hangisinin geçerli olacağını düşünüyorsunuz?"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Kötü amaçlı yazılım hakkında daha fazla bilgi edinin"
-  },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Çekçe ve Slovakça"
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"AdBlock'un eski bir sürümünü kullanıyorsunuz. Lütfen <a href='#'>uzantılar sayfası</a>, 'Geliştirici modu' ve 'Uzantıları şimdi güncelle' seçeneklerini kullanarak güncelleme yapın."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock Ayarları"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Bu listeyi temizle"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisosyal filtre listesi (sosyal medya düğmelerini kaldırır)"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Konsol Günlüğünde hata ayıklama bilgilerini göster (AdBlock'u yavaşlatır)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Size sunulan Dropbox boyut sınırını aştınız. Lütfen özelleştirilmiş veya engelli filtre listelerindeki birkaç girdiyi silip tekrar deneyin."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Tekrar başlat"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Almanca"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Dikkat: bu filtre sayfadaki tüm $elementtype$ öğelerini engelleyecek!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"buradan"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Evet"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Hulu.com videolarının oynatılmaması sorununu çöz (tarayıcınızı tekrar başlatmayı gerektirir)"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"İstisna"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Bu sayfa hangi dilde yazılmış?"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"$host$ alan adında yaptığınız $count$ engellemeyi kaldırmak istediğinize emin misiniz?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"resim"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Çeviri:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"YÜKLENİYOR..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Reklamı engellemek için sağ tıklayın -- ya da buradan manuel olarak engelleyin."
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Düğmeyi gizlemek için, sağ tıklayıp 'Düğmeyi gizle'yi seçin. Tekrar görünmesi için adres çubuğundan; chrome://chrome/extensions."
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Rumence"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Engelli filtreleri düzenleyin:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Güncelleştirmeleri denetlerken bir şeyler ters gitti."
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Bu düğmeyi gizlemek için, Safari araç çubuğuna sağ tıklayın ve Araç çubuğunu Özelleştir'i seçin. Daha sonra AdBlock düğmesini araç çubuğundan sürükleyerek çıkarın. Tekrar araç çubuğuna sürükleyerek görünmesini sağlayabilirsiniz."
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"1 dakika önce güncelleştirildi"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Engellenmiş Reklamlar:"
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"sayfa"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Korece"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Bu alan adında yaptığım engellemeleri geri al"
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Filtrelerinizi elle düzenleyin:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Filtre listeleri için linkleri göster"
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (tavsiye edilir)"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"İlk Adım: Nelerin engelleneceğini belirle"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"AdBlock'un arkasında kimlerin olduğunu öğrenmeniz için bir <a>sayfamız</a> da var!"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Site:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"buradan"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"açılan pencere"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Bir reklam görüyorsanız, hata raporu göndermek yerine <a>reklamı bildirin</a>!"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock güncel!"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Sayfayı yeniden yükle."
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Yalnızca İngilizce"
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"AdBlock'un eski bir sürümünü kullanıyorsunuz. Lütfen <a href='#'>uzantılar sayfası</a>, 'Geliştirici modu' ve 'Uzantıları şimdi güncelle' seçeneklerini kullanarak güncelleme yapın."
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock duraklatıldı."
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>VEYA</b> bu tuşa tıklayarak hepsini sizin yerinize yapmamızı sağlayabilirsiniz: <a>Tüm diğer eklentileri devre dışı bırak</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"En son sürümde ne yenilikler var? <a style='cursor:pointer;'>Sürüm Notları</a>'nı inceleyin!"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"Antisosyal filtre listesi (sosyal medya düğmelerini kaldırır)"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Reklamlar bulunuyor..<br/><br/><i>Bu sadece bir kaç saniye sürecek.</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Tecrübeli bir kullanıcıyım, bana gelişmiş seçenekleri göster"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Bu tarayıcıda, burada sahip olduğunuz aynı filtrelere abone olun."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Bir reklam engelle"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Dikkat: bu sitelerin dışında tüm sitelerde reklamları görebileceksiniz!<br> Kullandığınız filtreler bu siteler dışında geçersiz olacak."
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Daha önce devre dışı bıraktığınız uzantılar tekrar etkinleştirildi."
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock'un çalışmasını sağlayan şeyleri görmek ister misiniz?"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock özel filtreleri (tavsiye edilir)"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Bu nedir?"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -964,281 +575,83 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Ya da bir URL girin:"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"ya da Chrome için AdBlock"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Safari'nin eski bir sürümünü kullanıyorsunuz. AdBlock araç çubuğu butonunu kullanabilmek, bir web sitesine izin verebilmek ya da reklam bildirebilmek istiyorsanız, son sürüme geçin."
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"-- Dilinizi Seçin --"
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Çeviri:"
   },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Biçim: ~site1.com|~site2.com|~haberler.site3.org"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Safari menüsünü kullanarak; Tercihler &rarr; Uzantılar'a gidin."
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Şu reklamları engellemeyi durdur:"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video ve Flash"
   },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"40 milyondan fazla kullanıcısıyla en popüler Chrome eklentisi! İnternetteki tüm reklamları engeller."
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Filtre listeleri web sitelerindeki çoğu reklamı engeller. Ayrıca şunları da yapabilirsiniz:"
   },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Reklam hala görünüyor mu?"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Bu düğmeyi gizlemek için, Safari araç çubuğuna sağ tıklayın ve Araç çubuğunu Özelleştir'i seçin. Daha sonra AdBlock düğmesini araç çubuğundan sürükleyerek çıkarın. Tekrar araç çubuğuna sürükleyerek görünmesini sağlayabilirsiniz."
   },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"Destek"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Size sunulan Dropbox boyut sınırını aştınız. Lütfen özelleştirilmiş veya engelli filtre listelerindeki birkaç girdiyi silip tekrar deneyin."
   },
-  "filtereasylist_plus_bulgarian":{
+  "filterhungarian":{
     "description":"language",
-    "message":"Bulgarca"
+    "message":"Macarca"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock'un çalışmasını sağlayan şeyleri görmek ister misiniz?"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"ya da Chrome"
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Başarısız!"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Abone ol"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Ayarlar bölümünden değiştirilebilecek filtre:"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"İstediğiniz kadar ödeyin!"
   },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"Filtrelerinizi elle düzenleyin:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Bu filtre: <br/>$filter$<br/> bir hata ile karşılaştı: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"açılan pencere"
-  },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Reklam düzgün bir şekilde engelleninceye ve engellenen öğe sayfa yapısını bozmayacak şekilde görüntüleninceye kadar kaydırıcıyı ilerletin."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Tip"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Slovakça"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Filtrelere abone olun"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Reklam o tarayıcıda da görünüyor mu?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Bu sayfada AdBlock'u durdur"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Sadece bu sitelerdeki reklamları engelle:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"<a>Destek sitemize</a> bildirin!"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Son adım: Bu öğeyi reklam yapan nedir?"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"AdBlock'un kullanabileceği depolama alanını aştınız. Lütfen bazı filtreleri listeden silin!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Flash ve diğer eklentiler içinde bulunan reklamları henüz engelleyemiyoruz. Tarayıcı ve Webkit'in bu konuda desteğini bekliyoruz."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"Tamam!"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"Tamam, bu reklamı yine de Ayarlar menüsünü kullanarak kendiniz için engelleyebilirsiniz. Teşekkürler!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Genel"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"diğer"
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Gönder"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Filtre tanımlanmamış."
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"bilinmeyen"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Fince"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock bu sayfada kapatılmıştır."
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"ses/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Japonca"
+    "message":"Engelli filtreleri düzenleyin:"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Bu bir filtre listesi problemi. $link$ adresine bildirin",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"AdBlock <b>hariç</b>, tüm eklentilerin yanında bulunan \"Etkinleştirildi\" işaretini kaldırın. <b>AdBlock'u açık bırakın</b>."
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Engellenen öğe:"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Filtre listeleri için linkleri göster"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Not: Bildiriminiz halka açık bir şekilde görünebilir. Gizlilik içerebilecek bir bilgi dahil etmeden önce bunu göz önünde bulundurun."
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Yalnızca İngilizce"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"İptal"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Lütfen AdBlock'u daha fazla kişiye ulaştırmama yardım edin!"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Aşağı kaydırarak AdBlock'un tam olarak hangi sayfalarda çalışıp çalışmayacağını değiştirebilirsiniz"
-  },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock kötü amaçlı yazılım barındırdığı bilinen bir siteden başlatılan indirmeyi engelledi."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Firefox $chrome$ için reklamın görünüp görünmediğini kontrol edin.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"ClickToFlash uyumluluk modunu etkinleştir"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"Bu filtreye abone olup, tekrar deneyin: $list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Bir reklam bildirmek için internete bağlı olmanız gerekir."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (tavsiye edilir)"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Bu filtre kaynaktan yüklenemedi!"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"İtalyanca"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"İspanyolca"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"İyi görünüyor"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Bir reklam görüyorsanız, hata raporu göndermek yerine <a>reklamı bildirin</a>!"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Yeni bir fikriniz ya da bir sorunuz mu var?"
+  "typepage":{
+    "description":"A resource type",
+    "message":"sayfa"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1248,5 +661,632 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Reklam hala görünüyor mu?"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"diğer"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Buraya tıklayın: <a>Filtrelerimi güncelleştir!</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"İtalyanca"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Düğmeyi gizlemek için, opera://eklentiler'e gidip 'Araç çubuğundan kaldır' seçeneğini işaretleyin. Yine bu seçeneğin işaretini kaldırarak görünmesini sağlayabilirsiniz."
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Güncelleştirmeleri denetlerken bir şeyler ters gitti."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Safari menüsünü kullanarak; Tercihler &rarr; Uzantılar'a gidin."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"öğe_altistemi"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Gönder"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"Sayfa:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"Reklam içeren bir sayfayı yenileyin"
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Abonelik kaldırıldı."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"ses/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Letonca"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Bu sayfadaki bir reklamı engelleyin"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Engelle!"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Şu reklamları engellemeyi durdur:"
+  },
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Belirli Youtube kanallarını beyaz listeye eklemeye izin ver"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Bu sayfa hangi dilde yazılmış?"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"AdBlock <b>hariç</b>, tüm eklentilerin yanında bulunan \"Etkinleştirildi\" işaretini kaldırın. <b>AdBlock'u açık bırakın</b>."
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Listeden sil"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Flash ve diğer eklentiler içinde bulunan reklamları henüz engelleyemiyoruz. Tarayıcı ve Webkit'in bu konuda desteğini bekliyoruz."
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Aşağı kaydırarak AdBlock'un tam olarak hangi sayfalarda çalışıp çalışmayacağını değiştirebilirsiniz"
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"gizlenen"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock bu sayfada kapatılmıştır."
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Reklam bir video başlamadan önce, video oynatılırken ya da Flash oyunu gibi bir eklentide mi görünüyor?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Rusça ve Ukraynaca"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"İspanyolca"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Bu reklamı engelle"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Dikkat: bu filtre sayfadaki tüm $elementtype$ öğelerini engelleyecek!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"ClickToFlash uyumluluk modunu etkinleştir"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Hayır"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Bu sayfada AdBlock'u etkinleştir"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Ayarlar bölümünden değiştirilebilecek filtre:"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"AdBlock düğmesi üzerinde kaç tane reklamın engellendiğini göster"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Başarısız!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"AdBlock'u duraklat"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Bu filtre: <br/>$filter$<br/> bir hata ile karşılaştı: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"İngilizce"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Sağ tıklama menüsüne AdBlock seçeneklerini ekle"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"Tamam, bu reklamı yine de Ayarlar menüsünü kullanarak kendiniz için engelleyebilirsiniz. Teşekkürler!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Rusça"
+  },
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"$host$ alan adında yaptığınız $count$ engellemeyi kaldırmak istediğinize emin misiniz?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Safari'nin eski bir sürümünü kullanıyorsunuz. AdBlock araç çubuğu butonunu kullanabilmek, bir web sitesine izin verebilmek ya da reklam bildirebilmek istiyorsanız, son sürüme geçin."
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (gizlilik koruması)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ olacak $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Ya da bir URL girin:"
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"Tamamlandı!"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Tekrar başlat"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Başka diller için filtre ekle: "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"YÜKLENİYOR..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Ekibimiz sizden hata ayıklama bilgileri mi istedi? Onun için <a href='#' id='debug'>buraya</a> tıklayın!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Zararlı yazılımlara karşı koruma"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Bu sayfada bir reklam bildir"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Konsol Günlüğünde hata ayıklama bilgilerini göster (AdBlock'u yavaşlatır)"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Eğer zaten yüklü değilse, Firefox $chrome$ yükleyin.",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Reklam düzgün bir şekilde engelleninceye ve engellenen öğe sayfa yapısını bozmayacak şekilde görüntüleninceye kadar kaydırıcıyı ilerletin."
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"AdBlock'un kullanabileceği depolama alanını aştınız. Lütfen bazı filtreleri listeden silin!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"40 milyondan fazla kullanıcısıyla en popüler Chrome eklentisi! İnternetteki tüm reklamları engeller."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Bir hata mı buldunuz?"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Kötü amaçlı yazılım hakkında daha fazla bilgi edinin"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"komut"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Filtre listeleri"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock şu durumlarla eşleşen sayfalarda çalışmayacak:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Çince"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Filtre geçersiz: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Filtre listelerine abone olunuyor..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Devre dışı bıraktığınız uzantıları etkinleştirmek için uzantılar sayfasını açın."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Bu bildirimleri devre dışı bırak"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Bu sayfada $matchcount$ benzer öğe bulundu.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"1 saat önce güncelleştirildi"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"-- Dilinizi Seçin --"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Fransızca"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Endonezce"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"resim"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Düzenle"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Bu filtre kaynaktan yüklenemedi!"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"Toplam: $count$",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"Destek"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Reklamı URL'sine göre engelle"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"İptal"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Kaydetmeyi unutmayın!"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Sürüm $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Bu sorunun amacı bildiriminizi kimin alacağını belirlemek içindir. Eğer bu soruyu yanlış yanıtlarsanız, bildiriminiz yanlış insanlara ulaşıp, dikkate alınmayabilir."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"$title$ filtre listesine abone olmak istiyor musunuz?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Kaynak kodu <a>serbestçe kullanılabilir</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Flemenkçe"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Lütfen eklemek istediğiniz filtreyi yazın ve OK tuşuna basın."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"AdBlock için bir güncelleme var! $here$ güncelleyebilirsiniz.<br> Not: Eğer güncellemeleri otomatik olarak almak isterseniz, Safari > Preferences > Extensions > Updates<br> yolunu takip ederek 'install updates automatically' seçeneğini işaretleyin.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Bu sayfada <b>1</b> benzer öğe bulundu."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Japonca"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Bu listeyi temizle"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"$hours$ saat önce güncelleştirildi.",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Geri"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock Ayarları"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock kötü amaçlı yazılım barındırdığı bilinen bir siteden başlatılan indirmeyi engelledi."
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"İhtiyacınız olmayan filtrelere abone olmayın -- her biri AdBlock'u biraz daha yavaşlatır. \"Emeği geçenler\" listeleri ve daha fazlası <a>buradan</a> görülebilir."
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Güncelleştirmeler denetleniyor(sadece birkaç saniye sürer)..."
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Diğer"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Sayfanın bulunduğu alan adında uygulanacak"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"şimdi güncellendi"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"$minutes$ dakika önce güncelleştirildi",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Çekce"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"İsveççe"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock Destek"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Tip"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"çerçeve"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"1 dakika önce güncelleştirildi"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"çerçeve"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - ayrıntılar için tıklayın"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Dikkat: hiç filtre tanımlanmamış!"
   }
 }

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Прикріпити знімок:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Не знайдено жодної відомої шкідливої програми."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"У цьому браузері підпишіться на той же список фільтрів, як у вас тут."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"У тому переглядачі відкрийте сторінку із рекламою."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Шведською"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Блокувати більше реклами:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Російською"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Підписку скасовано."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Китайською"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Якщо ви створили робочий фільтр за допомогою майстра \"блокування реклами\", вставте його в поле нижче:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Антисоціальний список фільтрів (прибирає кнопки соціальних мереж)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Знайшли рекламу на сторінці? Ми допоможемо вам знайти правильне місце, щоб повідомити про це!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Показати кількість заблокованих оголошень на кнопці AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Вихідний код знаходиться у <a>вільному доступі</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"оновлено хвилину тому"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Помилка отримання фільтру!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Будь ласка, перезавантажте Safari, щоб закінчити вимкнення блокування вмісту."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Заблокувати рекламу за її URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Сховати цю кнопку"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"Списки оновлюватимуться автоматично, але ви можете <a>оновити їх</a> просто зараз"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Формат: ~site1.com|~site2.com|~novyny.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Естонською"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Тип"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"З’явилося оновлення AdBlock! Перейдіть $here$, щоб оновити його. <br> Зауважте: якщо ви хочете отримувати автоматичні оновлення, просто натисніть на «Safari» > «Налаштування» > «Розширення» > «Оновлення» <br> та відзначте прапорець «Встановлювати оновлення автоматично».",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Що це таке?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Не підписуйтесь на більше ніж потрібно — кожен з них трохи уповільнює роботу! Першоджерела та додаткові списки Ви можете знайти <a>тут<a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Ця функція AdBlock не працює на цьому сайті, тому що він використовує застарілі технології. Ви можете додати в чорний або білий список самостійно через вкладку 'Налаштування' на сторінці налаштувань."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Польською"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Дізнайтесь більше про програму Прийнятних рекламних оголошень."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"оновлено $seconds$ секунд(и) тому",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Угорською"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Зауважте: ваша скарга може стати публічно доступною. Пам’ятайте про це, залишаючи будь-яку особисту інформацію."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Будь ласка, вимкніть деякі списки фільтрів. Більше інформації дивіться в Параметрах AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Походження фільтру: $list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Перепрошуємо, AdBlock вимкнено на цій сторінці одним зі списків фільтрів."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Помилка введення фільтру: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Увага: фільтр не вказано!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock вимкнено на цій сторінці."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Показувати рекламу <i>всюди,</i> за винятком цих доменів..."
+    "message":"Є питання чи нова ідея?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Параметри"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Заблокована реклама:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Додати фільтри для сторінок іншою мовою: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Натисніть на рекламі, і я допоможу вам її позбутися."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Якщо Ви бачите рекламу, не відправляйте звіт про помилки, відправте <a> звіт про рекламу </a> !"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Чудово! Все налаштовано."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Іншою"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Підтримка користувачів AdBlock"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Налаштувати AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Обов'язкова інформація відсутня або неприпустима.  Будь ласка, дайте відповідь на запитання в червоних рамках."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Помилка під час збереження завантаженого файлу."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Будь ласка, введіть вірний фільтр та натисніть «ОК»"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Крок 1: З’ясуймо, що слід заблокувати"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Датською"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (рекомендуємо)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ на цій сторінці",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Субфрейм"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"оновлено годину тому"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Корейською"
+    "message":"Польською"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"або Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Як Вас звуть?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Найпопулярніше розширення для Chrome, яким користуються понад 40 мільйонів людей! Заблокуйте рекламу по всьому інтернету."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Показати всі запити"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Мені ліньки перевіряти"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Так"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Скасувати обмеження, запроваджені мною на цьому домені"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Налаштувати"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Призупинити AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Ви впевнені, що бажаєте підписатися на список фільтрів $title$?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Де саме на цій сторінці з'являється реклама? Як це виглядає?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"або AdBlock для Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"визначення стилю"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Бета"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Перевищено обмеження правил Блокування Вмісту"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Пошук реклами...<br/><br/><i>Це триватиме недовго.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Домен або URL, на якому AdBlock не працюватиме"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"скрипт"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ загалом",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Все готово! Ми скоро зв'яжемося з Вами, найімовірніше протягом одного-двох днів, якщо це не свята. Також, знайдіть в електронній пошті лист від AdBlock. Ви знайдете там посилання на Ваш запит на нашому сайті допомоги. Якщо Ви віддаєте перевагу стежити за результатами по електронній пошті, Ви можете робити це також!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Ні"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Щось пішло не так. Не було відпревлено жодних ресурсів. Цю сторінку буде закрито. Спробуйте перезавантажити сайт."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Українською"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"оновлено $minutes$ хвилин(и) тому",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Ми відписали Вас від Прийнятної Реклами, тому що Ви вимкнули блокування вмісту в Safari. Ви можете одночасно обрати лише одне. (<a>Чому?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Ви більше не підписані на список фільтрів Прийнятної реклами."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Захист від шкідливих програм"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Зберегти"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Увага: на всіх інших сайтах ви бачитимете рекламу!<br>Ці правила важливіші за інші фільтри для вказаних сайтів."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Відключити ці сповіщення"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Підписка на список фільтрів..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Ви користуєтесь старою версією AdBlock. Будь ласка, перейдіть на сторінку <a href='#'>розширень</a>, увімкніть «Режим розробника» та натисніть «Оновити розширення зараз»."
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Налаштування AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Перевірка наявності шкідливих програм, які можуть додавати рекламу:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Показувати інформацію для налагодження в Журналі Консолі (уповільнює роботу AdBlock)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Перевищено ліміт безкоштовного простору Dropbox. Вилучіть деякі записи з налаштованих чи вимкнених фільтрів та спробуйте ще раз."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Запустити AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Полагодити відео з Hulu.com, що не хочуть відтворюватися (потребує перезапуску вашого переглядача)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"захопити CSS"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Виключити"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Вимкніть усі розширення, окрім AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Переклад українською:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"ЗАВАНТАЖЕННЯ..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Натисніть правою кнопкою миші на рекламі, щоб заблокувати її, або зробіть це тут вручну."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Примітка: Білий список (дозволяє рекламу) на сторінці чи сайті не підтримується, коли блокування вмісту Safari увімкнено."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Ми будемо використовувати його тільки для зв'язку з Вами, якщо нам потрібно буде більше інформації."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Відредагуйте вимкнені фільтри:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Увімкнути блокування вмісту в Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Адреса Вашої електронної пошти?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Щоб приховати кнопку, клацніть правою кнопкою мишки по панелі інструментів Safari і виберіть Кастомізувати Тулбар, а потім перетягніть кнопку AdBlock з панелі інструментів. Ви можете відобразити її знову, перетягнувши назад на панель інструментів."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"При обробці Вашого запиту сталася помилка."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"сторінка"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Готово! Ми перезавантажили сторінку з рекламою. Будь ласка, перевірте чи зникла реклама на тій сторінці. Потім поверніться на цю сторінку та дайте відповіді на наступні запитання."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Введіть URL додаткового списку:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Ви користуєтесь застарілою версією Safari. Встановіть найновішу версію, аби користуватися кнопкою на панелі інструментів для призупинки AdBlock, занесення сайтів у білий список, та подання скарг на рекламу. <a>Оновити зараз</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Клацніть на меню «Safari» &rarr; «Налаштування» &rarr; «Розширення»."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Припинити блокувати рекламу:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Заблокувати!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Ви все ще її бачите?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Болгарською"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Чудово! Тепер давайте визначимо яке з розширень є причиною. Перевірте це вмикаючи розширення одне за одним. Розширення, яке поверне рекламні оголошення необхідно видалити, щоб позбавитися від реклами."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Невдало!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Налаштувати фільтри вручну:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Італійською"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"зринаючий"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Тип"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Словацькою"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Підписатись на список фільтрів"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Ви можете знову увімкнути це і підтримати улюблені веб-сайти, просто оберіть \"Дозволити деяку ненав’язливу рекламу\" нижче."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Чи з’являється реклама на нововідкритій сторінці?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Не запускати на цій сторінці"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Литовською"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Дайте нам знати на нашому <a>сайті підтримки</a>!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock призупинено."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Поки що ми не маємо змоги блокувати рекламу всередині Flash або інших плаґінів. Ми очікуємо на пітримку таких технологій від веб-переглядача та рушія виведення веб-сторінок WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Основні"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Якщо ви не бажаєте бачити рекламу на зразок цієї, вам необхідно залишити фільтр Прийнятних рекламних оголошень вимкнутим."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Ваш комп'ютер може бути заражений шкідливими програмами. Натисніть <a>тут</a> для отримання додаткової інформації."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"інший"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Фільтр не вказано!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"невідомо"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"аудіо/відео"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Японською"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Дозволити деяку ненав’язливу рекламу"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Скасувати"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Перетягніть, щоб визначити, чого саме не чіпатиме AdBlock."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Ми вимкнули блокування вмісту Safari, тому що Ви дозволити показ ненав'язливої реклами. Ви можете обрати одночасно лише одне. (<a>Чому?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Останній крок: повідомте нам про проблему."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Перевірте у Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Щоб надіслати скаргу на рекламу, потрібне підключення до інтернету."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (рекомендуємо)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock — скарга на рекламу"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Списки фільтрів реклами"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Як?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Дозволити рекламу на вподобаних вами каналах YouTube"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Сторонні"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (видаляє дратуючий вміст)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock — натисніть щоб побачити деталі"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"оновлено $hours$ годин(и) тому",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Українською та російською"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Що нового в останній версії? Дивіться  <a style='cursor:pointer;'>список змін</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Розширення, які були раніше вимкнуті були повторно увімкнено."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Грецькою"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Приховати частину веб-сторінки"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Відео та Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Які ознаки на вашу думку найкраще характеризуватимуть цю рекламу?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Увімкнути AdBlock на цій сторінці"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Назад"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Списки фільтрів блокують майже всю рекламу в інтернеті. Проте ви можете:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Перевіряємо фільтр Прийнятних рекламних оголошень:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Показувати рекламу на веб-сторінці або домені"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Під фільтр потрапляє <b>1</b> елемент на поточній сторінці."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Мені ліньки перевіряти"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Будь ласка, перезавантажте Safari, щоб закінчити вимкнення блокування вмісту."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Будьте обережні: якщо тут припуститися помилки, багато інших фільтрів, включаючи офіційні, можуть працювати некоректно!<br/>Читайте <a>порадник із синтаксису фільтрів (англ.)</a>, аби навчитися керувати чорними та білими списками фільтрів."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Додати $name$ в білий список",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Чи з’являється реклама на нововідкритій сторінці?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Основні настройки"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Якщо ви не бажаєте бачити рекламу на зразок цієї, вам необхідно залишити фільтр Прийнятних рекламних оголошень вимкнутим."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock не працюватиме на сторінках, що містять:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"У нас немає стандартного списку фільтрів для цієї мови.<br/>Будь ласка, спробуйте знайти гожий список з підтримкою цієї мови $link$ або заблокуйте цю рекламу самотужки на вкладці «Налаштування».",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Додати"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Я досвідчений користувач, покажіть мені просунуті налаштування"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Іспанською"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Завантажено на сторінці із доменом:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Натисніть: <a>Оновити мої списки фільтрів!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Що більше списків фільтрів ви використовуєте, то повільніше працює AdBlock. На деяких сайтах надмірне використання списків може навіть призвести до аварійного завершення роботи браузера. Натисніть OK, щоб все одно підписатись на цей список."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Останній крок: що робить це рекламою?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Елементів під фільтром на поточній сторінці: $matchcount$.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Ми маємо <a>сторінку</a>, яка допоможе вам дізнатись про людей, які створили AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Індонезійською"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Турецькою"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Заблокувати рекламу"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Додатковий список фільтрів"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL фрейму: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Мета цього питання визначити, хто має отримати вашу скаргу. Якщо ви дасте хибну відповідь, скарга потрапить не у ті руки і, у такому випадку, може бути проігнорована."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Керувати AdBlock за допомогою контекстного меню"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"селектор"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Заблокувати цю рекламу"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Наша команда запросила деяку налагоджувальну інформацію? Натисніть <a href='#' id='debug'>тут</a>!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Не застосовувати AdBlock до..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Повідомлення про наявність реклами є добровільним. Це допоможе іншим людям, додавання до списку фільтрів заблокує рекламу кожному користувачу. Якщо ви не відчуваєте себе альтруїстом прямо зараз - це нормально. Закрийте цю сторінку та <a>заблокуйте рекламу</a> тільки для себе."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Прихований елемент"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Перезавантажте сторінку."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"сторінка"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Голландською"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Це ім'я файлу занадто довге. Будь ласка, дайте Вашому файлу більш коротке ім'я."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Не забудьте зберегти!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Перевіряю оновлення (має зайняти лиш декілька секунд)..."
+    "message":"Литовською"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Передплатіть список фільтрів «$list_title$» та спробуйте знов.",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Чи показувати сповіщення AdBlock при виявленні шкідливих програм?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Ваш комп'ютер може бути заражений шкідливими програмами. Натисніть <a>тут</a> для отримання додаткової інформації."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Показати кількість заблокованих оголошень в меню AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Показувати рекламу на веб-сторінці або домені"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Сайт:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Власні фільтри AdBlock (рекомендуємо)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Латиською"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Переконайтеся, що ви використовуєте правильний мовний фільтр(и):"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"захопити CSS"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Щоб приховати цю кнопку, перейдіть на сторінку opera://extensions і позначте «Приховати з панелі інструментів». Кнопку можна буде повернути, знявши позначку."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Не певні?</b> просто натисніть «Заблокувати!» нижче."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Підпадає під фільтр"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Забираємо... будь ласка, чекайте."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Всі ресурси"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock оновлено до найсвіжішої версії!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Не виконувати на сторінках цього домена"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Івритом"
+    "message":"Словацькою"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Перетягуйте повзунок доти, доки реклама не зникне, проте не переборщіть."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Блокувати URL’и, що містять такий текст"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Кількість правил списку фільтрів перевищує обмеження в 50 000 і автоматично зменшена. Будь ласка, відпишіться від деяких списків фільтрів або вимкніть блокування вмісту Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"оновлено день тому"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Прийнятні рекламні оголошення (рекомендуємо)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Натисніть сюди:  <a>Вимкнути Прийнятні рекламні оголошення</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Версія $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Встановіть Adblock Plus для Firefox $chrome$, якщо ви досі не маєте його.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Видалити зі списку"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"У нас немає стандартного списку фільтрів для цієї мови.<br/>Будь ласка, спробуйте знайти гожий список з підтримкою цієї мови $link$ або заблокуйте цю рекламу самотужки на вкладці «Налаштування».",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Цей файл не є зображенням. Будь ласка, завантажте файл .png, .gif, або .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Чому б Вам не відправити нам <a>повідомлення про помилку</a>?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"приховане"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Список фільтрів"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Домен фрейму: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Натисніть на рекламі, і я допоможу вам її позбутися."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Топ фрейм"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"визначення стилю"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"невідомо"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Перепрошуємо, AdBlock вимкнено на цій сторінці одним зі списків фільтрів."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Сторонні"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Фільтр не вказано!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Грецькою"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Ви користуєтесь старою версією AdBlock. Будь ласка, перейдіть на сторінку <a href='#'>розширень</a>, увімкніть «Режим розробника» та натисніть «Оновити розширення зараз»."
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Як Вас звуть?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Полагодити відео з Hulu.com, що не хочуть відтворюватися (потребує перезапуску вашого переглядача)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Увага: фільтр не вказано!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Налаштувати"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Знайшли рекламу на сторінці? Ми допоможемо вам знайти правильне місце, щоб повідомити про це!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Естонською"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Налаштувати AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Болгарською"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Дозволений ресурс"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Перевищено обмеження правил Блокування Вмісту"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Не застосовувати AdBlock до..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Блокувати URL’и, що містять такий текст"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Закрити"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Перевірте у Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Останній крок: що робить це рекламою?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Якщо Ви бачите рекламу, не відправляйте звіт про помилки, відправте <a> звіт про рекламу </a> !"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Корейською"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Ви користуєтесь застарілою версією Safari. Встановіть найновішу версію, аби користуватися кнопкою на панелі інструментів для призупинки AdBlock, занесення сайтів у білий список, та подання скарг на рекламу. <a>Оновити зараз</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Фінською"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"скрипт"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Українською"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Не знайдено жодної відомої шкідливої програми."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Будь ласка, вимкніть деякі списки фільтрів. Більше інформації дивіться в Параметрах AdBlock."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Ми відписали Вас від Прийнятної Реклами, тому що Ви вимкнули блокування вмісту в Safari. Ви можете одночасно обрати лише одне. (<a>Чому?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Ми маємо <a>сторінку</a>, яка допоможе вам дізнатись про людей, які створили AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"сюди"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"зринаючий"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Перезавантажте сторінку."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Якою мовою складено цю сторінку?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock призупинено."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Запустити AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Пошук реклами...<br/><br/><i>Це триватиме недовго.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock вимкнено на цій сторінці."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"У цьому браузері підпишіться на той же список фільтрів, як у вас тут."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Заблокувати рекламу"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Увага: на всіх інших сайтах ви бачитимете рекламу!<br>Ці правила важливіші за інші фільтри для вказаних сайтів."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"З’явилося оновлення AdBlock! Перейдіть $here$, щоб оновити його. <br> Зауважте: якщо ви хочете отримувати автоматичні оновлення, просто натисніть на «Safari» > «Налаштування» > «Розширення» > «Оновлення» <br> та відзначте прапорець «Встановлювати оновлення автоматично».",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Готово!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Власні фільтри AdBlock (рекомендуємо)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Тип"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Що це таке?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Японською"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Походження фільтру: $list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Підписатись на список фільтрів"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Тип фрейму: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Додати фільтри для сторінок іншою мовою: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Ресурс"
+    "message":"Підпадає під фільтр"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Заблокувати рекламу на цій сторінці"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Списки фільтрів блокують майже всю рекламу в інтернеті. Проте ви можете:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Переконайтесь, що списки фільтрів свіжі:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Щоб приховати кнопку, клацніть правою кнопкою мишки по панелі інструментів Safari і виберіть Кастомізувати Тулбар, а потім перетягніть кнопку AdBlock з панелі інструментів. Ви можете відобразити її знову, перетягнувши назад на панель інструментів."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Англійською"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Перевищено ліміт безкоштовного простору Dropbox. Вилучіть деякі записи з налаштованих чи вимкнених фільтрів та спробуйте ще раз."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Ісландською"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Додати"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Відкрийте сторінку розширень, щоб увімкнути розширення, які раніше були відключені."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Примітка: Білий список (дозволяє рекламу) на сторінці чи сайті не підтримується, коли блокування вмісту Safari увімкнено."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Домен чи сторінка для обробки"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Заблокований елемент:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"сторінка"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"інший"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Натисніть: <a>Оновити мої списки фільтрів!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Прихований елемент"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Щоб приховати цю кнопку, перейдіть на сторінку opera://extensions і позначте «Приховати з панелі інструментів». Кнопку можна буде повернути, знявши позначку."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Сторінка:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Знайшли помилку?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Заблокувати!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Дозволити рекламу на вподобаних вами каналах YouTube"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Поки що ми не маємо змоги блокувати рекламу всередині Flash або інших плаґінів. Ми очікуємо на пітримку таких технологій від веб-переглядача та рушія виведення веб-сторінок WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Арабською"
+    "message":"Угорською"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Заблокувати цю рекламу"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Увімкнути AdBlock на цій сторінці"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Показати кількість заблокованих оголошень на кнопці AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Невдало!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Призупинити AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Чеською"
+    "message":"Англійською"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Заплатіть стільки, скільки готові!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Керувати AdBlock за допомогою контекстного меню"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Хочете побачити, хто робить AdBlock живим?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Будь ласка, перейдіть на <a>наш сайт підтримки</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Список Попереджень про видалення AdBlock (видаляє попередження про використання блокувальника реклами)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Неприпустимий список URL. Його буде видалено."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"фрейм"
+    "message":"сторінка"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Змінити"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Ви впевнені, що хочете видалити блокування, створені на $host$? Кількість створених блокувань: $count$",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Є питання чи нова ідея?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Умовні позначення: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Ви забули прикріпити знімок екрану! Ми не зможемо допомогти Вам не побачивши рекламу, про яку ви повідомляєте."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>ЧИ</b>, просто натисніть цю кнопку щоб ми зробили все що вище: <a>Вимкнути всі інші розширення</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"оновлено $minutes$ хвилин(и) тому",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Дізнатися більше про шкідливі програми"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Прикріпити знімок:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Румунською"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Відредагуйте вимкнені фільтри:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Субфрейм"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Оновіть сторінку з рекламою."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Увімкнути блокування вмісту в Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Встановіть Firefox$chrome$, якщо",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Список фільтрів"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Якщо ви створили робочий фільтр за допомогою майстра \"блокування реклами\", вставте його в поле нижче:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Цей файл завеликий. Переконайтесь, що ваш файл менш ніж 10 МБ."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock не працюватиме на сторінках, що містять:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Китайською"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Помилка введення фільтру: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Підписка на список фільтрів..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Відкрийте сторінку розширень, щоб увімкнути розширення, які раніше були відключені."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Відключити ці сповіщення"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Турецькою"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Не підписуйтесь на більше ніж потрібно — кожен з них трохи уповільнює роботу! Першоджерела та додаткові списки Ви можете знайти <a>тут<a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"фрейм"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Індонезійською"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"зображення"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ загалом",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Скасувати"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Не забудьте зберегти!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"селектор"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Ми вимкнули блокування вмісту Safari, тому що Ви дозволити показ ненав'язливої реклами. Ви можете обрати одночасно лише одне. (<a>Чому?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Ісландською"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Списки фільтрів реклами"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Блокувати рекламу лише на цих сайтах:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Завантажено на сторінці із доменом:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Розширення, які були раніше вимкнуті були повторно увімкнено."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Очистити цей список"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Допоможіть розказати всім!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Оновлення AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Список Попереджень про видалення AdBlock (видаляє попередження про використання блокувальника реклами)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Налаштування AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"При обробці Вашого запиту сталася помилка."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"оновлено годину тому"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Перевіряю оновлення (має зайняти лиш декілька секунд)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"щойно оновлено"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Натисніть правою кнопкою миші на рекламі, щоб заблокувати її, або зробіть це тут вручну."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Перевірка наявності шкідливих програм, які можуть додавати рекламу:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Підтримка користувачів AdBlock"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Тип"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Перетягуйте повзунок доти, доки реклама не зникне, проте не переборщіть."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"оновлено хвилину тому"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"фрейм"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Заблокований ресурс"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Наступні відомості будуть також включені у звіт про рекламу."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Датською"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Перевіряємо фільтр Прийнятних рекламних оголошень:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Ви можете знову увімкнути це і підтримати улюблені веб-сайти, просто оберіть \"Дозволити деяку ненав’язливу рекламу\" нижче."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Забираємо... будь ласка, чекайте."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Неприпустимий список URL. Його буде видалено."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Основні настройки"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Зніміть позначку «Увімкнено» навпроти кожного розширення <b>за виключенням</b> AdBlock. <b>Залиште AdBlock увімкненим</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"У тому переглядачі відкрийте сторінку із рекламою."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Показувати рекламу <i>всюди,</i> за винятком цих доменів..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Ви забули прикріпити знімок екрану! Ми не зможемо допомогти Вам не побачивши рекламу, про яку ви повідомляєте."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"І вручну створити картку, а також копіювати та вставити інформацію нижче в розділ «Fill in any details you think will help us understand your issue»."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Щоб приховати цю кнопку, натисніть на неї правою кнопкою миші та оберіть «Приховати кнопку». Її можна буде повернути на сторінці chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Івритом"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Ця функція AdBlock не працює на цьому сайті, тому що він використовує застарілі технології. Ви можете додати в чорний або білий список самостійно через вкладку 'Налаштування' на сторінці налаштувань."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Чеською та словацькою"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Ми вимкнули усі інші розширення. Зараз ми перезавантажимо сторінку з рекламою. Зачекайте секунду, будь ласка."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Інші списки фільтрів"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Французькою"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"Списки оновлюватимуться автоматично, але ви можете <a>оновити їх</a> просто зараз"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Заблокований елемент:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Показати всі запити"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"інтерактивний об’єкт"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Що більше списків фільтрів ви використовуєте, то повільніше працює AdBlock. На деяких сайтах надмірне використання списків може навіть призвести до аварійного завершення роботи браузера. Натисніть OK, щоб все одно підписатись на цей список."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Чудово! Все налаштовано."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Бета"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Відкрити <a href='#'>сторінку розширень</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Все готово! Ми скоро зв'яжемося з Вами, найімовірніше протягом одного-двох днів, якщо це не свята. Також, знайдіть в електронній пошті лист від AdBlock. Ви знайдете там посилання на Ваш запит на нашому сайті допомоги. Якщо Ви віддаєте перевагу стежити за результатами по електронній пошті, Ви можете робити це також!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Дізнайтесь більше про програму Прийнятних рекламних оголошень."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Чи показувати сповіщення AdBlock при виявленні шкідливих програм?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"щойно оновлено"
+    "message":"оновлено день тому"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL фрейму: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Німецькою"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Це ім'я файлу занадто довге. Будь ласка, дайте Вашому файлу більш коротке ім'я."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"оновлено $seconds$ секунд(и) тому",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Не запускати на цій сторінці"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Дайте нам знати на нашому <a>сайті підтримки</a>!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Готово! Ми перезавантажили сторінку з рекламою. Будь ласка, перевірте чи зникла реклама на тій сторінці. Потім поверніться на цю сторінку та дайте відповіді на наступні запитання."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Всі ресурси"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Додати $name$ в білий список",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Ресурс"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Показати кількість заблокованих оголошень в меню AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock — скарга на рекламу"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Як?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Не виконувати на сторінках цього домена"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Додатковий список фільтрів"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Блокувати більше реклами:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Обов'язкова інформація відсутня або неприпустима.  Будь ласка, дайте відповідь на запитання в червоних рамках."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Домен або URL, на якому AdBlock не працюватиме"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Ви більше не підписані на список фільтрів Прийнятної реклами."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (видаляє дратуючий вміст)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock заблокував завантаження з сайту, який містить шкідливі програми."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Зберегти"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Не певні?</b> просто натисніть «Заблокувати!» нижче."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Останній крок: повідомте нам про проблему."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Де саме на цій сторінці з'являється реклама? Як це виглядає?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Так краще"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Дозволити AdBlock збирати інформацію про використання списку анонімного фільтра та дані"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Щоб надіслати скаргу на рекламу, потрібне підключення до інтернету."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Ви впевнені, що бажаєте підписатися на список фільтрів $title$?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"оновлено $days$ дні(в) тому",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"фрейм"
+    "message":"інтерактивний об’єкт"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Які ознаки на вашу думку найкраще характеризуватимуть цю рекламу?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Заблокована реклама:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Арабською"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Скасувати обмеження, запроваджені мною на цьому домені"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Налаштувати фільтри вручну:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Крок 1: З’ясуймо, що слід заблокувати"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Будь ласка, введіть вірний фільтр та натисніть «ОК»"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Переклад українською:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock оновлено до найсвіжішої версії!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Лише англійською мовою"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>ЧИ</b>, просто натисніть цю кнопку щоб ми зробили все що вище: <a>Вимкнути всі інші розширення</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Що нового в останній версії? Дивіться  <a style='cursor:pointer;'>список змін</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (для захисту приватності)"
+    "message":"Антисоціальний список фільтрів (прибирає кнопки соціальних мереж)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Поскаржитись на рекламу на цій сторінці"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Захист від шкідливих програм"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Очистити цей список"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Я досвідчений користувач, покажіть мені просунуті налаштування"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Німецькою"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Перевищено ліміт місця, яке для AdBlock виділяється веб-переглядачем. Будь ласка, скасуйте передплату кількох списків фільтрів!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Будьте обережні: цей фільтр заблокує усі елементи $elementtype$ на цій сторінці!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"сюди"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Адреса Вашої електронної пошти?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Якою мовою складено цю сторінку?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Хочете побачити, хто робить AdBlock живим?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Ви впевнені, що хочете видалити блокування, створені на $host$? Кількість створених блокувань: $count$",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"зображення"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Приховати частину веб-сторінки"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"І вручну створити картку, а також копіювати та вставити інформацію нижче в розділ «Fill in any details you think will help us understand your issue»."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Основні"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Щоб приховати цю кнопку, натисніть на неї правою кнопкою миші та оберіть «Приховати кнопку». Її можна буде повернути на сторінці chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"або AdBlock для Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Румунською"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Відео та Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Під час перевірки оновлень щось пішло не так."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Ми вимкнули усі інші розширення. Зараз ми перезавантажимо сторінку з рекламою. Зачекайте секунду, будь ласка."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Дозволений ресурс"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Чудово! Тепер давайте визначимо яке з розширень є причиною. Перевірте це вмикаючи розширення одне за одним. Розширення, яке поверне рекламні оголошення необхідно видалити, щоб позбавитися від реклами."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Чеською та словацькою"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"або Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Тип фрейму: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Формат: ~site1.com|~site2.com|~novyny.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Оберіть якою -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Встановіть Adblock Plus для Firefox $chrome$, якщо ви досі не маєте його.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Заблокований ресурс"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Чи з’являється ця реклама усередині чи перед початком відео, або ж у рамках якихось інших плаґінів на кшталт ігр на Flash?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ відповідатиме $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Фільтр, який можна змінити на сторінці «Налаштувати»:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Наступний фільтр: <br/> $filter$ <br/> містить помилку: <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Закрити"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Блокувати рекламу лише на цих сайтах:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Перевищено ліміт місця, яке для AdBlock виділяється веб-переглядачем. Будь ласка, скасуйте передплату кількох списків фільтрів!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Дозволити AdBlock збирати інформацію про використання списку анонімного фільтра та дані"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"Гаразд, ви все ще можете заблокувати цю рекламу лише для себе на сторінці настройок. Дякуємо!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Надіслати"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Фінською"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Цей файл завеликий. Переконайтесь, що ваш файл менш ніж 10 МБ."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Наступні відомості будуть також включені у звіт про рекламу."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Заплатіть стільки, скільки готові!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Проблема у списку фільтрів. Поскаржіться тут: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Зніміть позначку «Увімкнено» навпроти кожного розширення <b>за виключенням</b> AdBlock. <b>Залиште AdBlock увімкненим</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Зауважте: ваша скарга може стати публічно доступною. Пам’ятайте про це, залишаючи будь-яку особисту інформацію."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Показати посилання на списки фільтрів"
+  "filteritalian":{
+    "description":"language",
+    "message":"Італійською"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Лише англійською мовою"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Допоможіть розказати всім!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Ви все ще її бачите?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock заблокував завантаження з сайту, який містить шкідливі програми."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Переконайтеся, що ви використовуєте правильний мовний фільтр(и):"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Умовні позначення: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Переконайтесь, що списки фільтрів свіжі:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Під час перевірки оновлень щось пішло не так."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Клацніть на меню «Safari» &rarr; «Налаштування» &rarr; «Розширення»."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Надіслати"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Підписку скасовано."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"аудіо/відео"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Латиською"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Заблокувати рекламу на цій сторінці"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Припинити блокувати рекламу:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Помилка під час збереження завантаженого файлу."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Елементів під фільтром на поточній сторінці: $matchcount$.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Помилка отримання фільтру!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Перетягніть, щоб визначити, чого саме не чіпатиме AdBlock."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"приховане"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Чи з’являється ця реклама усередині чи перед початком відео, або ж у рамках якихось інших плаґінів на кшталт ігр на Flash?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Українською та російською"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Іспанською"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Будьте обережні: цей фільтр заблокує усі елементи $elementtype$ на цій сторінці!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Увімкнути режим сумісності ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Ні"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Фільтр, який можна змінити на сторінці «Налаштувати»:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Сховати цю кнопку"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Іншою"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"Гаразд, ви все ще можете заблокувати цю рекламу лише для себе на сторінці настройок. Дякуємо!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Російською"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Чому б Вам не відправити нам <a>повідомлення про помилку</a>?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (для захисту приватності)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ відповідатиме $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Введіть URL додаткового списку:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Наступний фільтр: <br/> $filter$ <br/> містить помилку: <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"ЗАВАНТАЖЕННЯ..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Наша команда запросила деяку налагоджувальну інформацію? Натисніть <a href='#' id='debug'>тут</a>!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Кількість правил списку фільтрів перевищує обмеження в 50 000 і автоматично зменшена. Будь ласка, відпишіться від деяких списків фільтрів або вимкніть блокування вмісту Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Поскаржитись на рекламу на цій сторінці"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Показувати інформацію для налагодження в Журналі Консолі (уповільнює роботу AdBlock)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Домен фрейму: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Найпопулярніше розширення для Chrome, яким користуються понад 40 мільйонів людей! Заблокуйте рекламу по всьому інтернету."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Знайшли помилку?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Чеською"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Цей файл не є зображенням. Будь ласка, завантажте файл .png, .gif, або .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Показати посилання на списки фільтрів"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Дозволити деяку ненав’язливу рекламу"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Шведською"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Видалити зі списку"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Оберіть якою -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Французькою"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Змінити"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Підтримка"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Будь ласка, перейдіть на <a>наш сайт підтримки</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Заблокувати рекламу за її URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Щоб призупинити AdBlock з увімкненим Блокуванням Вмісту, будь ласка, оберіть Safari (в меню) > Вподобання > Розширення > AdBlock та зніміть прапорець 'Увімкнути AdBlock'."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Версія $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Мета цього питання визначити, хто має отримати вашу скаргу. Якщо ви дасте хибну відповідь, скарга потрапить не у ті руки і, у такому випадку, може бути проігнорована."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Повідомлення про наявність реклами є добровільним. Це допоможе іншим людям, додавання до списку фільтрів заблокує рекламу кожному користувачу. Якщо ви не відчуваєте себе альтруїстом прямо зараз - це нормально. Закрийте цю сторінку та <a>заблокуйте рекламу</a> тільки для себе."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Так"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Вихідний код знаходиться у <a>вільному доступі</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Голландською"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Ми будемо використовувати його тільки для зв'язку з Вами, якщо нам потрібно буде більше інформації."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Під фільтр потрапляє <b>1</b> елемент на поточній сторінці."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"оновлено $hours$ годин(и) тому",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Назад"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Натисніть сюди:  <a>Вимкнути Прийнятні рекламні оголошення</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Домен чи сторінка для обробки"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Оновлення AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Щось пішло не так. Не було відпревлено жодних ресурсів. Цю сторінку буде закрито. Спробуйте перезавантажити сайт."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Дізнатися більше про шкідливі програми"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Сайт:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Прийнятні рекламні оголошення (рекомендуємо)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Так краще"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Щоб призупинити AdBlock з увімкненим Блокуванням Вмісту, будь ласка, оберіть Safari (в меню) > Вподобання > Розширення > AdBlock та зніміть прапорець 'Увімкнути AdBlock'."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Відкрити <a href='#'>сторінку розширень</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock — натисніть щоб побачити деталі"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Вимкніть усі розширення, окрім AdBlock:"
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"Đính kèm một ảnh chụp màn hình:"
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"Không tim thấy mã độc đã được nhận dạng nào."
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Trong trình duyệt khác, đăng ký danh sách bộ lọc giống như ở đây."
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Trong trình duyệt đó, tải lại trang cùng với quảng cáo."
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"Tiếng Thụy Điển"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Chặn thêm quảng cáo:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"Tiếng Nga"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"Đã hủy đăng ký."
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"Tiếng Trung"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"Nếu bạn đã tạo một bộ lọc sử dụng thuật sĩ \"chặn một quảng cáo\", dán nó vào hộp dưới đây:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Danh sách bộ lọc chặn mạng xã hội (loại bỏ các nút bấm liên quan đến mạng xã hội)"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Bạn tìm thấy quảng cáo trên một trang web? Chúng tôi sẽ giúp bạn tìm thấy đúng nơi để báo cáo nó!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Hiển thị số quảng cáo bị chặn trên nút AdBlock"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"Mã nguồn của AdBlock là <a>hoàn toàn miễn phí</a>!"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"đã được cập nhật 1 phút trước"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"Không thể lấy được dữ liệu của bộ lọc này!"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"Vui lòng khởi động lại Safari để hoàn tất việc tắt Chặn Nội Dung."
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Chặn quảng cáo bằng URL"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"Ẩn nút này"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"AdBlock sẽ cập nhật bộ lọc một cách tự động; bạn cũng có thể <a>cập nhật ngay</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"Cấu trúc: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"Tiếng Estonia"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"Loại"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"Đã có bản cập nhật mới cho AdBlock! Đi đến $here$ để cập nhật. <br> Lưu ý: Nếu bạn muốn nhận cập nhật một cách tự động, chỉ cần nhấp chuột trên Safari > Preferences > Extensions > Updates <br> và tích ô tùy chọn 'Install updates automatically'.",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"Đây là gì?"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"Bạn chỉ nên đăng ký những bộ lọc cần thiết -- sử dụng nhiều bộ lọc sẽ làm chậm trình duyệt của bạn! Danh sách bộ lọc bạn có thể tìm thấy <a>ở đây</a>."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"Tính năng này của AdBlock không hoạt động trên trang này bởi vì nó sử dụng công nghệ đã lỗi thời. Bạn có thể dùng danh sách đen hoặc danh sách trắng để chặn bằng tay trong thẻ 'Tùy Chỉnh' trên trang tùy chọn."
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"Tiếng Ba Lan"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"Tìm hiểu thêm về chương trình Quảng Cáo Chấp Nhận Được."
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"đã được cập nhật $seconds$ giây trước",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"Tiếng Hungari"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"Lưu ý: báo cáo của bạn có thể được công bố công khai. Hãy lưu ý điều đó trước khi bạn báo cáo điều gì đó riêng tư."
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Vui lòng tắt một vài bộ lọc. Thông tin thêm có trong tùy chọn của AdBlock."
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"Bộ lọc gốc:\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Xin lỗi, AdBlock đã bị tắt trên trang này bởi một trong số các bộ lọc của bạn."
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"Bộ lọc không hợp lệ: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"Cảnh báo: Không có bộ lọc nào được chỉ định!"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock đã bị tắt trên trang này."
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"Hiển thị quảng cáo <i>ở tất cả mọi nơi</i> trừ những tên miền này..."
+    "message":"Bạn có câu hỏi hoặc một ý tưởng mới?"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"Tùy chọn"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"Số quảng cáo đã bị chặn:"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"Thêm bộ lọc cho ngôn ngữ khác: "
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"Nhấp vào phần quảng cáo, và tôi sẽ hướng dẫn bạn cách chặn nó."
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"Nếu bạn thấy có quảng cáo, bạn không nên dùng báo cáo lỗi, mà hãy dùng <a>báo cáo quảng cáo</a>!"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"Tuyệt vời! Vậy là đã xong."
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"Khác"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"Trung tâm hỗ trợ"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Tùy chỉnh AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"Thông tin được yêu cầu còn thiếu hoặc không hợp lệ. Hãy điền vào những câu hỏi có khung màu đỏ."
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"Lỗi lưu tập tin đã tải lên."
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"Vui lòng nhập đúng bộ lọc dưới đây và bấm OK"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"Bước 1: Chọn phần tử để chặn"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"Tiếng Đan Mạch"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList (khuyến khích)"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ trên trang này",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"Frame phụ"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"đã được cập nhật 1 giờ trước"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"Tiếng Hàn"
+    "message":"Tiếng Ba Lan"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"hoặc Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"Bạn tên gì?"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"Tiện ích phổ biến nhất trên Chrome, với trên 40 triệu người dùng! AdBlock sẽ giúp bạn chặn tất cả quảng cáo trên internet."
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"Hiển thị tất cả yêu cầu"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"Tôi không muốn kiểm tra cái này"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"Có"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"Hủy bỏ lệnh chặn của tôi trên tên miền này"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"Tùy chỉnh"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"Tạm dừng AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"Bạn có chắc bạn muốn đăng ký bộ lọc $title$ không?",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"Chính xác thì quảng cáo ở đâu trên trang? Nó trông như thế nào?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"hoặc AdBlock cho Chrome"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"style definition"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"Đã vượt quá giới hạn quy tắc của Chặn Nội Dung"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"Đang tìm quảng cáo...<br/><br/><i>Chỉ mất chút thời gian thôi.</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"Tên miền hoặc url mà AdBlock không chặn bất cứ thứ gì"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"mã"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ trong tổng số",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"Đã xong! Chúng tôi sẽ sớm liên hệ với bạn, rất có thể là ngay trong ngày, hoặc hai ngày nếu là ngày lễ. Trong khi chờ đợi, bạn hãy tìm một email từ AdBlock. Bạn sẽ thấy một liên kết đến thẻ của bạn trên trang giúp đỡ của chúng tôi tại đó. Bạn cũng có thể theo dõi qua email nếu muốn!"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"Không"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"Đã xảy ra chuyện gì đó. Không có nguồn nào được gửi đi. Trang này sẽ bị đóng lại. Hãy thử tải lại trang web này."
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"Tiếng Ukraina"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"đã được cập nhật $minutes$ phút trước",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"Chúng tôi đã bỏ đăng ký bạn khỏi Quảng Cáo Chấp Nhận Được bởi vì bạn đã bật Chặn Nội Dung Safari. Bạn chỉ có thể chọn một trong hai cùng một lúc. (<a>Tại sao?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Bạn đã không còn đăng ký bộ lọc Quảng Cáo Chấp Nhận Được."
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"Chống phần mềm độc hại"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"Lưu"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"Cảnh báo: trên tất cả những trang web khác bạn sẽ thấy có quảng cáo!<br>Điều này sẽ ghi đè tất cả các bộ lọc khác được áp dụng cho những trang này."
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"Vô hiệu hóa những thông báo này"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"Đang đăng ký bộ lọc..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"Bạn đang sử dụng phiên bản cũ của AdBlock. Vui lòng đi đến <a href='#'>tiện ích mở rộng</a>, bật 'Chế độ dành cho nhà phát triển' và nhấp 'Cập nhật'"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"Tùy chọn AdBlock"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"Kiểm tra phần mềm độc hại có thể chèn quảng cáo:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Hiển thị báo cáo gỡ lỗi trong Console Log (sẽ làm AdBlock chậm đi)"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"Bạn đã vượt quá giới hạn dung lượng của Dropbox. Hãy xóa một số mục khỏi bộ lọc tùy chỉnh hoặc tắt một số bộ lọc, sau đó thử lại."
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"Hủy tạm dừng AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"Không chạy trên Hulu nếu video không phát (yêu cầu khởi động lại trình duyệt)"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"CSS phù hợp với"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"Loại trừ"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Vô hiệu hóa tất cả các tiện ích khác ngoại trừ AdBlock:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"Việt hóa bởi:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"ĐANG TẢI..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"Nhấp chuột phải vào quảng cáo để chặn -- hoặc chặn bằng tay ở đây."
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"Lưu ý: Danh sách trắng (cho phép hiển thị quảng cáo) một trang hoặc địa chỉ chưa được hỗ trợ với Chặn Nội Dung Safari được bật."
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"Chúng tôi sẽ chỉ sử dụng địa chỉ này để liên hệ với bạn nếu cần thêm thông tin."
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Chỉnh sửa bộ lọc bị vô hiệu hóa:"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"Bật Chặn Nội Dung Safari"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"Địa chỉ email của bạn là gì?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"Để ẩn nút này, nhấp chuột phải vào thanh công cụ và chọn Customize Toolbar, sau đó kéo nút AdBlock ra khỏi thanh công cụ. Bạn có thể hiển thị nó trở lại bằng cách kéo trở lại thanh công cụ."
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"Đã có lỗi khi xử lý yêu cầu của bạn."
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"trang"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Đã xong! Chúng tôi đã tải lại trang cùng với quảng cáo. Vui lòng kiểm tra lại trang xem quảng cáo đã mất hay chưa. Sau đó quay lại trang này và trả lời những câu hỏi dưới đây."
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"Hoặc nhập một địa chỉ:"
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"Bạn đang sử dụng phiên bản cũ của Safari. Hãy cài đặt phiên bản mới nhất để sử dụng nút AdBlock trên thanh công cụ để tạm dừng AdBlock, tạo danh sách trắng, và báo cáo quảng cáo. <a>Nâng cấp ngay</a>."
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"Nhấp vào menu Safari chọn &rarr; Preferences &rarr; Extensions."
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"Dừng chặn quảng cáo:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"Chặn!"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"Quảng cáo vẫn còn xuất hiện phải không?"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"Tiếng Bulgaria"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"Tuyệt vời! Bây giờ hãy tìm hiểu xem tiện ích nào là nguyên nhân gây ra quảng cáo. Bật lần lượt từng tiện ích một, tiện ích nào khi bật gây ra quảng cáo chính là tiện ích bạn cần gỡ bỏ để loại bỏ quảng cáo."
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"Thất bại!"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"Chỉnh sửa bộ lọc bằng tay:"
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"Tiếng Ý"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"popup"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"Loại"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"Tiếng Slovakia"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"Đăng ký bộ lọc"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"Bạn có thể bật lại và hỗ trợ trang web bạn yêu thích bằng cách chọn \"Cho phép những quảng cáo không gây khó chịu\" dưới đây."
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"Quảng cáo có xuất hiện ở trình duyệt đó không?"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"Không chạy trên trang này"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"Tiếng Lít-va"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"Hãy cho chúng tôi biết trên <a>trang hỗ trợ</a> của chúng tôi!"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock đã bị tạm dừng."
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"Chúng tôi tạm thời không thể chặn quảng cáo bên trong Flash và các trình cắm khác. Chúng tôi đang chờ sự hỗ tợ từ các trình duyệt và WebKit."
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"OK!"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"Tổng quan"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"Nếu bạn không muốn nhìn thấy những quảng cáo như này, có thể bạn sẽ muốn tắt bộ lọc Quảng Cáo Chấp Nhận Được."
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"Máy tính của bạn có thể đã bị nhiễm mã độc. Bấm <a>vào đây</a> để biết thêm chi tiết."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"khác"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"Không có bộ lọc nào được chỉ định!"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"không rõ"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"Tiếng Nhật"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"Cho phép những quảng cáo không gây khó chịu"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"Hủy bỏ"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"Bạn có thể di chuyển thanh trượt dưới đây để chọn chính xác những trang nào mà AdBlock sẽ không chạy."
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"Chúng tôi đã tắt Chặn Nội Dung Safari bởi vì bạn đã chọn cho phép những quảng cáo không gây khó chịu. Bạn chỉ có thể chọn một trong hai cùng một lúc. (<a>Tại sao?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"Bước cuối cùng: báo cáo vấn đề cho chúng tôi."
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"Kiểm tra trên Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"Để báo cáo một quảng cáo, bạn phải có kết nối đến internet."
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList (khuyến khích)"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - Báo cáo một quảng cáo"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"Danh sách các bộ lọc chặn quảng cáo"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"Cách dùng?"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Cho phép một số kênh YouTube trong danh sách trắng"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"Bên thứ ba"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances (loại bỏ những sự khó chịu trên Web)"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - bấm để biết thêm chi tiết"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"đã được cập nhật $hours$ giờ trước",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"Tiếng Nga và Ukraina"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"Có gì mới trong phiên bản mới nhất? Xem <a style='cursor:pointer;'>các thay đổi</a>!"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"Những tiện ích mở rộng bị vô hiệu hóa trước đây đã được kích hoạt lại."
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"Tiếng Hy Lạp"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Ẩn một phần của trang web"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"Video và Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Bạn nghĩ điều gì sẽ đúng về quảng cáo này mỗi khi bạn truy cập trang này?"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"Bật AdBlock trên trang này"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"Trở lại"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"Danh sách các bộ lọc đã chặn hầu hết các quảng cáo. Bạn cũng có thể:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"Kiểm tra những bộ lọc Quảng Cáo Chấp Nhận Được:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"Hiển thị quảng cáo trên trang web hoặc tên miền này"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"Khớp <b>1</b> mục trên trang này."
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"Tôi không muốn kiểm tra cái này"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"Vui lòng khởi động lại Safari để hoàn tất việc tắt Chặn Nội Dung."
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"Hãy cẩn thận: Nếu bạn chỉnh sửa không chính xác, rất nhiều bộ lọc khác bao gồm cả bộ lọc chính thức cũng có thể bị lỗi!<br/>Bạn có thể đọc thêm về <a>cú pháp bộ lọc</a> để biết cách chỉnh sửa bộ lọc."
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"Đưa kênh $name$ vào danh sách trắng",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Quảng cáo có xuất hiện ở trình duyệt đó không?"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"Cài đặt chung"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"Nếu bạn không muốn nhìn thấy những quảng cáo như này, có thể bạn sẽ muốn tắt bộ lọc Quảng Cáo Chấp Nhận Được."
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock sẽ không chạy trên những trang có đường dẫn này:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"Chúng tôi không có bộ lọc mặc định cho ngôn ngữ này.<br/>Bạn vui lòng tìm kiếm bộ lọc khác có hỗ trợ ngôn ngữ này $link$ hoặc bạn có thể chặn quảng cáo này bằng tay ở thẻ 'Tùy chỉnh'.",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"Đăng ký"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Hiển thị các tùy chọn nâng cao"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"Tiếng Tây Ban Nha"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"Tải trên trang với tên miền:\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"Nhấp vào đây: <a>Cập nhật bộ lọc của tôi!</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"Bạn sử dụng càng nhiều bộ lọc thì AdBlock chạy càng chậm. Thậm chí một số website còn bị treo nếu bạn sử dụng quá nhiều bộ lọc. Nếu bạn vẫn muốn đăng ký bộ lọc này, nhấp OK."
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"Bước cuối cùng: Điều gì khiến cái này trở thành quảng cáo?"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"Khớp $matchcount$ mục trên trang này.",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"Chúng tôi cũng đã có một <a>trang</a> để giúp bạn tìm hiểu về những người đứng sau AdBlock!"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"Tiếng Indonesia"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"Tiếng Thổ Nhĩ Kỳ"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"Chặn quảng cáo"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"Danh sách bộ lọc tùy chỉnh"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"URL frame: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"Mục đích của câu hỏi này là để xác định ai sẽ nhận được báo cáo của bạn. Nếu bạn trả lời câu hỏi này không chính xác, báo cáo sẽ được gửi đến nhầm người. do đó nó có thể bị bỏ qua."
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Thêm AdBlock vào menu chuột phải"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"chọn"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"Chặn quảng cáo này"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"Nhóm của chúng tôi đã yêu cầu một số thông tin để gỡ lỗi chưa? Bấm <a href='#' id='debug'>vào đây</a> để làm điều đó!"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Không chạy AdBlock trên..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"Báo cáo quảng cáo là tự nguyện. Nó giúp những người khác bằng cách giúp chỉnh sửa bộ lọc quảng cáo để có thể chặn quảng cáo cho tất cả mọi người. Nếu bạn không muốn báo cáo, không sao cả. Bạn hãy đóng trang này lại và <a>chặn quảnq cáo</a> chỉ cho mình bạn thôi."
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"Phần tử bị ẩn"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"Tải lại trang."
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"trang"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"Tiếng Hà Lan"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"Tên tập tin quá dài. Hãy đặt tên tập tin ngắn hơn."
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"Đừng quên lưu lại bộ lọc!"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"Đang kiểm tra cập nhật (chỉ mất vài giây thôi)..."
+    "message":"Tiếng Lít-va"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"Đăng ký bộ lọc này, sau đó thử lại: $list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Bạn có muốn AdBlock thông báo cho bạn khi phát hiện ra malware không?"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"Máy tính của bạn có thể đã bị nhiễm mã độc. Bấm <a>vào đây</a> để biết thêm chi tiết."
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"Hiển thị số quảng cáo bị chặn trên menu AdBlock"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Hiển thị quảng cáo trên trang web hoặc tên miền này"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"Trang web:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"Bộ lọc tùy chỉnh AdBlock (khuyến khích)"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"Tiếng Latvia"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"Hãy chắn chắn bạn dùng đúng ngôn ngữ bộ lọc:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"CSS phù hợp với"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"Để ẩn nút này, đi đến opera://extensions và chọn 'Ẩn khỏi thanh cộng cụ'. Để hiển thị trở lại bạn chỉ cần bỏ chọn tùy chọn đó."
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>Không chắc chắn?</b> bạn chi cần bấm nút 'Chặn' dưới đây."
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"Khớp với bộ lọc"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"Đang lấy dữ liệu... vui lòng chờ trong giây lát."
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"Tất cả nguồn"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock đã được cập nhật!"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"Không chạy trên trang của những tên miền này"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"Tiếng Do Thái"
+    "message":"Tiếng Slovakia"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"Trượt thanh trượt cho đến khi chọn đúng quảng cáo cần chặn, và các phần tử bị chặn sẽ trở nên hữu ích."
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"Chặn các URL trong văn bản này"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"Số lượng quy tắc trong danh sách bộ lọc đã vượt quá giới hạn 50,000 và đã được tự động giảm xuống. Vui lòng bỏ đăng ký một vài bộ lọc hoặc tắt Chặn Nội Dung Safari!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"đã được cập nhật 1 ngày trước"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"Quảng Cáo Chấp Nhận Được (được khuyến khích)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"Bấm vào đây: <a>Vô hiệu hóa Quảng Cáo Chấp Nhận Được:</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"Phiên bản $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"Cài đặt Adblock Plus cho Firefox $chrome$ nếu bạn chưa có.",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"Xóa khỏi danh sách"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"Chúng tôi không có bộ lọc mặc định cho ngôn ngữ này.<br/>Bạn vui lòng tìm kiếm bộ lọc khác có hỗ trợ ngôn ngữ này $link$ hoặc bạn có thể chặn quảng cáo này bằng tay ở thẻ 'Tùy chỉnh'.",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"Đó không phải tập tin ảnh. Hãy tải lên tập tin .png, .gif, hoặc .jpg."
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"Sao bạn không gửi một <a>báo cáo lỗi</a> cho chúng tôi?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"ẩn"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"Danh sách bộ lọc"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"Tên miền frame: "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"Nhấp vào phần quảng cáo, và tôi sẽ hướng dẫn bạn cách chặn nó."
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"Frame trên cùng"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"style definition"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"không rõ"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Xin lỗi, AdBlock đã bị tắt trên trang này bởi một trong số các bộ lọc của bạn."
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"Bên thứ ba"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"Không có bộ lọc nào được chỉ định!"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"Tiếng Hy Lạp"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"Bạn đang sử dụng phiên bản cũ của AdBlock. Vui lòng đi đến <a href='#'>tiện ích mở rộng</a>, bật 'Chế độ dành cho nhà phát triển' và nhấp 'Cập nhật'"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"Bạn tên gì?"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"Không chạy trên Hulu nếu video không phát (yêu cầu khởi động lại trình duyệt)"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"Cảnh báo: Không có bộ lọc nào được chỉ định!"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"Tùy chỉnh"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Bạn tìm thấy quảng cáo trên một trang web? Chúng tôi sẽ giúp bạn tìm thấy đúng nơi để báo cáo nó!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"Tiếng Estonia"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Tùy chỉnh AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"Tiếng Bulgaria"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Nguồn được cho phép"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Đã vượt quá giới hạn quy tắc của Chặn Nội Dung"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Không chạy AdBlock trên..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"Chặn các URL trong văn bản này"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"Đóng"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"Kiểm tra trên Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"Bước cuối cùng: Điều gì khiến cái này trở thành quảng cáo?"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"Nếu bạn thấy có quảng cáo, bạn không nên dùng báo cáo lỗi, mà hãy dùng <a>báo cáo quảng cáo</a>!"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"Tiếng Hàn"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"Bạn đang sử dụng phiên bản cũ của Safari. Hãy cài đặt phiên bản mới nhất để sử dụng nút AdBlock trên thanh công cụ để tạm dừng AdBlock, tạo danh sách trắng, và báo cáo quảng cáo. <a>Nâng cấp ngay</a>."
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"Tiếng Phần Lan"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"mã"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"Tiếng Ukraina"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"Không tim thấy mã độc đã được nhận dạng nào."
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Vui lòng tắt một vài bộ lọc. Thông tin thêm có trong tùy chọn của AdBlock."
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"Chúng tôi đã bỏ đăng ký bạn khỏi Quảng Cáo Chấp Nhận Được bởi vì bạn đã bật Chặn Nội Dung Safari. Bạn chỉ có thể chọn một trong hai cùng một lúc. (<a>Tại sao?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"Chúng tôi cũng đã có một <a>trang</a> để giúp bạn tìm hiểu về những người đứng sau AdBlock!"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"đây"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"popup"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"Tải lại trang."
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"Trang đó đươc viết bằng ngôn ngữ nào?"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock đã bị tạm dừng."
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"Hủy tạm dừng AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"Đang tìm quảng cáo...<br/><br/><i>Chỉ mất chút thời gian thôi.</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock đã bị tắt trên trang này."
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Trong trình duyệt khác, đăng ký danh sách bộ lọc giống như ở đây."
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"Chặn quảng cáo"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"Cảnh báo: trên tất cả những trang web khác bạn sẽ thấy có quảng cáo!<br>Điều này sẽ ghi đè tất cả các bộ lọc khác được áp dụng cho những trang này."
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"Đã có bản cập nhật mới cho AdBlock! Đi đến $here$ để cập nhật. <br> Lưu ý: Nếu bạn muốn nhận cập nhật một cách tự động, chỉ cần nhấp chuột trên Safari > Preferences > Extensions > Updates <br> và tích ô tùy chọn 'Install updates automatically'.",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"Hoàn thành!"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"Bộ lọc tùy chỉnh AdBlock (khuyến khích)"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"Loại"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"Đây là gì?"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"Tiếng Nhật"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"Bộ lọc gốc:\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"Đăng ký bộ lọc"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"Kiểu frame: "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"Thêm bộ lọc cho ngôn ngữ khác: "
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"Nguồn cấp"
+    "message":"Khớp với bộ lọc"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"Chặn quảng cáo trên trang này"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"Danh sách các bộ lọc đã chặn hầu hết các quảng cáo. Bạn cũng có thể:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"Hãy chắc chắn rằng danh sách bộ lọc của bạn luôn được cập nhật:"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"Để ẩn nút này, nhấp chuột phải vào thanh công cụ và chọn Customize Toolbar, sau đó kéo nút AdBlock ra khỏi thanh công cụ. Bạn có thể hiển thị nó trở lại bằng cách kéo trở lại thanh công cụ."
   },
-  "lang_english":{
-    "description":"language",
-    "message":"Tiếng Anh"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"Bạn đã vượt quá giới hạn dung lượng của Dropbox. Hãy xóa một số mục khỏi bộ lọc tùy chỉnh hoặc tắt một số bộ lọc, sau đó thử lại."
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"Tiếng Icecland"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"Đăng ký"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"Mở trang tiện ích mở rộng để kích hoạt lại các tiện ích mở rộng đã bị vô hiệu hóa trước đây."
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"Lưu ý: Danh sách trắng (cho phép hiển thị quảng cáo) một trang hoặc địa chỉ chưa được hỗ trợ với Chặn Nội Dung Safari được bật."
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"Tên miền của trang web để áp dụng"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"Phần tử bị chặn:"
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"trang"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"khác"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"Nhấp vào đây: <a>Cập nhật bộ lọc của tôi!</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"Phần tử bị ẩn"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"Để ẩn nút này, đi đến opera://extensions và chọn 'Ẩn khỏi thanh cộng cụ'. Để hiển thị trở lại bạn chỉ cần bỏ chọn tùy chọn đó."
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"Trang:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Bạn tìm thấy lỗi?"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"Chặn!"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Cho phép một số kênh YouTube trong danh sách trắng"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"Chúng tôi tạm thời không thể chặn quảng cáo bên trong Flash và các trình cắm khác. Chúng tôi đang chờ sự hỗ tợ từ các trình duyệt và WebKit."
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"Tiếng Ả-Rập"
+    "message":"Tiếng Hungari"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"Chặn quảng cáo này"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"Bật AdBlock trên trang này"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Hiển thị số quảng cáo bị chặn trên nút AdBlock"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"Thất bại!"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"Tạm dừng AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"Tiếng Séc"
+    "message":"Tiếng Anh"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"Trả bất cứ thứ gì bạn muốn!"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Thêm AdBlock vào menu chuột phải"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Bạn muốn tìm hiểu cách AdBlock hoạt động?"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Hãy vào <a>trang web hỗ trợ của chúng tôi</a>."
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Danh sách loại bỏ cảnh báo Adblock (loại bỏ các cảnh báo về việc sử dụng trình chặn quảng cáo)"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"Địa chỉ bộ lọc không hợp lệ. Bộ lọc sẽ bị xóa."
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"trang"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"Chỉnh sửa"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"Bạn có chắc chắn muốn gõ bỏ $count$ khối quảng cáo mà bạn đã chặn trên $host$?",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Bạn có câu hỏi hoặc một ý tưởng mới?"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"Chú thích: "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"Bạn quên đính kèm ảnh chụp màn hình rồi! Chúng tôi không thể giúp bạn nếu không thấy (những) quảng cáo mà bạn đang báo cáo."
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>HOẶC</b>, chỉ cần kích vào nút này để chúng tôi làm tất cả những việc trên:<a>Vô hiệu hóa tất cả các tiện ích mở rộng</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"đã được cập nhật $minutes$ phút trước",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"Tìm hiểu thêm về malware"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"Đính kèm một ảnh chụp màn hình:"
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"Tiếng Rumani"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Chỉnh sửa bộ lọc bị vô hiệu hóa:"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"Frame phụ"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"Tải lại trang cùng với quảng cáo."
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"Bật Chặn Nội Dung Safari"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"Cài đặt Firefox $chrome$ nếu bạn chưa cài đặt 2 trình duyệt này.",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"Danh sách bộ lọc"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"Nếu bạn đã tạo một bộ lọc sử dụng thuật sĩ \"chặn một quảng cáo\", dán nó vào hộp dưới đây:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"Tập tin quá lớn. Hãy đảm bảo rằng tập tin của bạn nhỏ hơn 10 MB."
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock sẽ không chạy trên những trang có đường dẫn này:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"Tiếng Trung"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"Bộ lọc không hợp lệ: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"Đang đăng ký bộ lọc..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"Mở trang tiện ích mở rộng để kích hoạt lại các tiện ích mở rộng đã bị vô hiệu hóa trước đây."
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"Vô hiệu hóa những thông báo này"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"Tiếng Thổ Nhĩ Kỳ"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"Bạn chỉ nên đăng ký những bộ lọc cần thiết -- sử dụng nhiều bộ lọc sẽ làm chậm trình duyệt của bạn! Danh sách bộ lọc bạn có thể tìm thấy <a>ở đây</a>."
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"Tiếng Indonesia"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"ảnh"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ trong tổng số",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"Hủy bỏ"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"Đừng quên lưu lại bộ lọc!"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"chọn"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"Chúng tôi đã tắt Chặn Nội Dung Safari bởi vì bạn đã chọn cho phép những quảng cáo không gây khó chịu. Bạn chỉ có thể chọn một trong hai cùng một lúc. (<a>Tại sao?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"Tiếng Icecland"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"Danh sách các bộ lọc chặn quảng cáo"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"Chỉ chặn quảng cáo trên những trang web này:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"Tải trên trang với tên miền:\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"Những tiện ích mở rộng bị vô hiệu hóa trước đây đã được kích hoạt lại."
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"Dọn dẹp danh sách này"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"Chia sẻ!"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"Cập nhật AdBlock"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Danh sách loại bỏ cảnh báo Adblock (loại bỏ các cảnh báo về việc sử dụng trình chặn quảng cáo)"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"Tùy chọn AdBlock"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"Đã có lỗi khi xử lý yêu cầu của bạn."
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"đã được cập nhật 1 giờ trước"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"Đang kiểm tra cập nhật (chỉ mất vài giây thôi)..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"vừa được cập nhật"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"Nhấp chuột phải vào quảng cáo để chặn -- hoặc chặn bằng tay ở đây."
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"Kiểm tra phần mềm độc hại có thể chèn quảng cáo:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"Trung tâm hỗ trợ"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"Loại"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"Trượt thanh trượt cho đến khi chọn đúng quảng cáo cần chặn, và các phần tử bị chặn sẽ trở nên hữu ích."
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"đã được cập nhật 1 phút trước"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"Nguồn bị chặn"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"Thông tin sau sẽ được kèm theo trong báo cáo quảng cáo."
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"Tiếng Đan Mạch"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"Kiểm tra những bộ lọc Quảng Cáo Chấp Nhận Được:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Bạn có thể bật lại và hỗ trợ trang web bạn yêu thích bằng cách chọn \"Cho phép những quảng cáo không gây khó chịu\" dưới đây."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"Đang lấy dữ liệu... vui lòng chờ trong giây lát."
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"Địa chỉ bộ lọc không hợp lệ. Bộ lọc sẽ bị xóa."
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"Cài đặt chung"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Bỏ chọn ô 'Đã bật' bên cạnh tất cả các tiện ích khác <b>ngoại trừ</b> AdBlock. <b>Giữ AdBlock luôn bật</b>."
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"Trong trình duyệt đó, tải lại trang cùng với quảng cáo."
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"Hiển thị quảng cáo <i>ở tất cả mọi nơi</i> trừ những tên miền này..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"Bạn quên đính kèm ảnh chụp màn hình rồi! Chúng tôi không thể giúp bạn nếu không thấy (những) quảng cáo mà bạn đang báo cáo."
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"Và tự tạo một thẻ, sau đó chép và dán thông tin dưới đây vào phần \"Điền mọi thông tin chi tiết bạn nghĩ sẽ giúp chúng tôi hiểu được vấn đề của bạn\"."
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"Để ẩn nút này, nhấp chuột phải và chọn 'Nút ẩn'. Để hiển thị trở lại bạn bấm vào 'Nút hiển thị' ở đây chrome://chrome/extensions."
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"Tiếng Do Thái"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"Tính năng này của AdBlock không hoạt động trên trang này bởi vì nó sử dụng công nghệ đã lỗi thời. Bạn có thể dùng danh sách đen hoặc danh sách trắng để chặn bằng tay trong thẻ 'Tùy Chỉnh' trên trang tùy chọn."
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"Tiếng Séc và Slovakia"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Chúng tôi đã vô hiệu hoá tất cả các tiện ích khác. Bây giờ chúng tôi sẽ tải lại trang cùng với quảng cáo. Chỉ vài giây nữa thôi."
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"Các bộ lọc khác"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"Tiếng Pháp"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"AdBlock sẽ cập nhật bộ lọc một cách tự động; bạn cũng có thể <a>cập nhật ngay</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"Phần tử bị chặn:"
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"Hiển thị tất cả yêu cầu"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interactive object"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"Bạn sử dụng càng nhiều bộ lọc thì AdBlock chạy càng chậm. Thậm chí một số website còn bị treo nếu bạn sử dụng quá nhiều bộ lọc. Nếu bạn vẫn muốn đăng ký bộ lọc này, nhấp OK."
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"Tuyệt vời! Vậy là đã xong."
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"Mở <a href='#'>trang tiện ích</a>."
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"Đã xong! Chúng tôi sẽ sớm liên hệ với bạn, rất có thể là ngay trong ngày, hoặc hai ngày nếu là ngày lễ. Trong khi chờ đợi, bạn hãy tìm một email từ AdBlock. Bạn sẽ thấy một liên kết đến thẻ của bạn trên trang giúp đỡ của chúng tôi tại đó. Bạn cũng có thể theo dõi qua email nếu muốn!"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"Tìm hiểu thêm về chương trình Quảng Cáo Chấp Nhận Được."
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Bạn có muốn AdBlock thông báo cho bạn khi phát hiện ra malware không?"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"vừa được cập nhật"
+    "message":"đã được cập nhật 1 ngày trước"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"URL frame: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"Tiếng Đức"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"Tên tập tin quá dài. Hãy đặt tên tập tin ngắn hơn."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"đã được cập nhật $seconds$ giây trước",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"Không chạy trên trang này"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"Hãy cho chúng tôi biết trên <a>trang hỗ trợ</a> của chúng tôi!"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"OK!"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"Đã xong! Chúng tôi đã tải lại trang cùng với quảng cáo. Vui lòng kiểm tra lại trang xem quảng cáo đã mất hay chưa. Sau đó quay lại trang này và trả lời những câu hỏi dưới đây."
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"Tất cả nguồn"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"Đưa kênh $name$ vào danh sách trắng",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"Nguồn cấp"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"Hiển thị số quảng cáo bị chặn trên menu AdBlock"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - Báo cáo một quảng cáo"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"Cách dùng?"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"Không chạy trên trang của những tên miền này"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"Danh sách bộ lọc tùy chỉnh"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Chặn thêm quảng cáo:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"Thông tin được yêu cầu còn thiếu hoặc không hợp lệ. Hãy điền vào những câu hỏi có khung màu đỏ."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"Tên miền hoặc url mà AdBlock không chặn bất cứ thứ gì"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"Bạn đã không còn đăng ký bộ lọc Quảng Cáo Chấp Nhận Được."
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances (loại bỏ những sự khó chịu trên Web)"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock đã chặn tải xuống từ một trang được biết có chứa mã độc."
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"Lưu"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>Không chắc chắn?</b> bạn chi cần bấm nút 'Chặn' dưới đây."
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"Bước cuối cùng: báo cáo vấn đề cho chúng tôi."
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"Chính xác thì quảng cáo ở đâu trên trang? Nó trông như thế nào?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"Đẹp rồi"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Cho phép AdBlock thu thập dữ liệu và cách sử dụng danh sách bộ lọc ẩn danh"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"Để báo cáo một quảng cáo, bạn phải có kết nối đến internet."
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"Bạn có chắc bạn muốn đăng ký bộ lọc $title$ không?",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"đã được cập nhật $days$ ngày trước",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"interactive object"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Bạn nghĩ điều gì sẽ đúng về quảng cáo này mỗi khi bạn truy cập trang này?"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"Số quảng cáo đã bị chặn:"
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"Tiếng Ả-Rập"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"Hủy bỏ lệnh chặn của tôi trên tên miền này"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"Chỉnh sửa bộ lọc bằng tay:"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"Bước 1: Chọn phần tử để chặn"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"Vui lòng nhập đúng bộ lọc dưới đây và bấm OK"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"Việt hóa bởi:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock đã được cập nhật!"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"Chỉ có sẵn bằng Tiếng Anh"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>HOẶC</b>, chỉ cần kích vào nút này để chúng tôi làm tất cả những việc trên:<a>Vô hiệu hóa tất cả các tiện ích mở rộng</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"Có gì mới trong phiên bản mới nhất? Xem <a style='cursor:pointer;'>các thay đổi</a>!"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (bảo vệ sự riêng tư)"
+    "message":"Danh sách bộ lọc chặn mạng xã hội (loại bỏ các nút bấm liên quan đến mạng xã hội)"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"Báo cáo một quảng cáo trên trang này"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"Chống phần mềm độc hại"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"Dọn dẹp danh sách này"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Hiển thị các tùy chọn nâng cao"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"Tiếng Đức"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"Bạn đã vượt quá dung lượng lưu trữ mà AdBlock có thể sử dụng. Vui lòng bỏ đăng ký một số bộ lọc của bạn!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"Hãy cẩn thận: bộ lọc này sẽ chặn tất cả đối tượng $elementtype$ trên trang này!",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"đây"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"Địa chỉ email của bạn là gì?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"Trang đó đươc viết bằng ngôn ngữ nào?"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Bạn muốn tìm hiểu cách AdBlock hoạt động?"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"Bạn có chắc chắn muốn gõ bỏ $count$ khối quảng cáo mà bạn đã chặn trên $host$?",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"ảnh"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Ẩn một phần của trang web"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Và tự tạo một thẻ, sau đó chép và dán thông tin dưới đây vào phần \"Điền mọi thông tin chi tiết bạn nghĩ sẽ giúp chúng tôi hiểu được vấn đề của bạn\"."
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"Tổng quan"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"Để ẩn nút này, nhấp chuột phải và chọn 'Nút ẩn'. Để hiển thị trở lại bạn bấm vào 'Nút hiển thị' ở đây chrome://chrome/extensions."
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"hoặc AdBlock cho Chrome"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"Tiếng Rumani"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"Video và Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"Đã xảy ra lỗi trong khi kiểm tra cập nhật."
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"Chúng tôi đã vô hiệu hoá tất cả các tiện ích khác. Bây giờ chúng tôi sẽ tải lại trang cùng với quảng cáo. Chỉ vài giây nữa thôi."
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Nguồn được cho phép"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"Tuyệt vời! Bây giờ hãy tìm hiểu xem tiện ích nào là nguyên nhân gây ra quảng cáo. Bật lần lượt từng tiện ích một, tiện ích nào khi bật gây ra quảng cáo chính là tiện ích bạn cần gỡ bỏ để loại bỏ quảng cáo."
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"Tiếng Séc và Slovakia"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"hoặc Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"Kiểu frame: "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"Cấu trúc: ~site1.com|~site2.com|~news.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" -- Chọn ngôn ngữ -- "
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"Cài đặt Adblock Plus cho Firefox $chrome$ nếu bạn chưa có.",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"Nguồn bị chặn"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"Quảng cáo có xuất hiện trước hoặc trong khi phát video hay bất cứ plugin nào như Flash không?"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ sẽ là $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"Bộ lọc này có thể được thay đổi ở trang Tùy chọn:"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"Bộ lọc sau đây:<br/>$filter$<br/> đã xảy ra lỗi:<br/>$message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"Đóng"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"Chỉ chặn quảng cáo trên những trang web này:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"Bạn đã vượt quá dung lượng lưu trữ mà AdBlock có thể sử dụng. Vui lòng bỏ đăng ký một số bộ lọc của bạn!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Cho phép AdBlock thu thập dữ liệu và cách sử dụng danh sách bộ lọc ẩn danh"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"Được rồi, bạn vẫn có thể chặn quảng cáo này bằng tay ở trang 'Tùy chọn'. Cảm ơn bạn!"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"Gửi"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"Tiếng Phần Lan"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"Tập tin quá lớn. Hãy đảm bảo rằng tập tin của bạn nhỏ hơn 10 MB."
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"Thông tin sau sẽ được kèm theo trong báo cáo quảng cáo."
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"Trả bất cứ thứ gì bạn muốn!"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"Đây là lỗi của bộ lọc. Bạn có thể báo cáo nó ở đây: $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Bỏ chọn ô 'Đã bật' bên cạnh tất cả các tiện ích khác <b>ngoại trừ</b> AdBlock. <b>Giữ AdBlock luôn bật</b>."
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"Lưu ý: báo cáo của bạn có thể được công bố công khai. Hãy lưu ý điều đó trước khi bạn báo cáo điều gì đó riêng tư."
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"Hiển thị đường dẫn đến bộ lọc"
+  "filteritalian":{
+    "description":"language",
+    "message":"Tiếng Ý"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"Chỉ có sẵn bằng Tiếng Anh"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"Chia sẻ!"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"Quảng cáo vẫn còn xuất hiện phải không?"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock đã chặn tải xuống từ một trang được biết có chứa mã độc."
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"Hãy chắn chắn bạn dùng đúng ngôn ngữ bộ lọc:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"Chú thích: "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"Hãy chắc chắn rằng danh sách bộ lọc của bạn luôn được cập nhật:"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"Đã xảy ra lỗi trong khi kiểm tra cập nhật."
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"Nhấp vào menu Safari chọn &rarr; Preferences &rarr; Extensions."
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"Gửi"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"Đã hủy đăng ký."
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"Tiếng Latvia"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"Chặn quảng cáo trên trang này"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"Dừng chặn quảng cáo:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"Lỗi lưu tập tin đã tải lên."
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"Khớp $matchcount$ mục trên trang này.",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"Không thể lấy được dữ liệu của bộ lọc này!"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"Bạn có thể di chuyển thanh trượt dưới đây để chọn chính xác những trang nào mà AdBlock sẽ không chạy."
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"ẩn"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"Quảng cáo có xuất hiện trước hoặc trong khi phát video hay bất cứ plugin nào như Flash không?"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"Tiếng Nga và Ukraina"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"Tiếng Tây Ban Nha"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"Hãy cẩn thận: bộ lọc này sẽ chặn tất cả đối tượng $elementtype$ trên trang này!",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"Sử dụng chế độ tương thích với ClickToFlash"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"Không"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"Bộ lọc này có thể được thay đổi ở trang Tùy chọn:"
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"Ẩn nút này"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"Khác"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"Được rồi, bạn vẫn có thể chặn quảng cáo này bằng tay ở trang 'Tùy chọn'. Cảm ơn bạn!"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"Tiếng Nga"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"Sao bạn không gửi một <a>báo cáo lỗi</a> cho chúng tôi?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (bảo vệ sự riêng tư)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ sẽ là $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"Hoặc nhập một địa chỉ:"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"Bộ lọc sau đây:<br/>$filter$<br/> đã xảy ra lỗi:<br/>$message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"ĐANG TẢI..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"Nhóm của chúng tôi đã yêu cầu một số thông tin để gỡ lỗi chưa? Bấm <a href='#' id='debug'>vào đây</a> để làm điều đó!"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"Số lượng quy tắc trong danh sách bộ lọc đã vượt quá giới hạn 50,000 và đã được tự động giảm xuống. Vui lòng bỏ đăng ký một vài bộ lọc hoặc tắt Chặn Nội Dung Safari!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"Báo cáo một quảng cáo trên trang này"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Hiển thị báo cáo gỡ lỗi trong Console Log (sẽ làm AdBlock chậm đi)"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"Tên miền frame: "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"Tiện ích phổ biến nhất trên Chrome, với trên 40 triệu người dùng! AdBlock sẽ giúp bạn chặn tất cả quảng cáo trên internet."
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Bạn tìm thấy lỗi?"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"Tiếng Séc"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"Đó không phải tập tin ảnh. Hãy tải lên tập tin .png, .gif, hoặc .jpg."
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"Hiển thị đường dẫn đến bộ lọc"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"Cho phép những quảng cáo không gây khó chịu"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"Tiếng Thụy Điển"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"Xóa khỏi danh sách"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" -- Chọn ngôn ngữ -- "
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"Tiếng Pháp"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"Chỉnh sửa"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"Hỗ trợ"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"Hãy vào <a>trang web hỗ trợ của chúng tôi</a>."
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"Chặn quảng cáo bằng URL"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"Để tạm dừng AdBlock với Chặn Nội Dung Safari được bật, vui lòng chọn Safari (trong thanh trình đơn) > Tùy chọn > Tiện ích mở rộng > AdBlock, và bỏ chọn 'Bật AdBlock'."
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"Phiên bản $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"Mục đích của câu hỏi này là để xác định ai sẽ nhận được báo cáo của bạn. Nếu bạn trả lời câu hỏi này không chính xác, báo cáo sẽ được gửi đến nhầm người. do đó nó có thể bị bỏ qua."
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"Báo cáo quảng cáo là tự nguyện. Nó giúp những người khác bằng cách giúp chỉnh sửa bộ lọc quảng cáo để có thể chặn quảng cáo cho tất cả mọi người. Nếu bạn không muốn báo cáo, không sao cả. Bạn hãy đóng trang này lại và <a>chặn quảnq cáo</a> chỉ cho mình bạn thôi."
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"Có"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"Mã nguồn của AdBlock là <a>hoàn toàn miễn phí</a>!"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"Tiếng Hà Lan"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"Chúng tôi sẽ chỉ sử dụng địa chỉ này để liên hệ với bạn nếu cần thêm thông tin."
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"Khớp <b>1</b> mục trên trang này."
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"đã được cập nhật $hours$ giờ trước",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"Trở lại"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"Bấm vào đây: <a>Vô hiệu hóa Quảng Cáo Chấp Nhận Được:</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"Tên miền của trang web để áp dụng"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Cập nhật AdBlock"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"Đã xảy ra chuyện gì đó. Không có nguồn nào được gửi đi. Trang này sẽ bị đóng lại. Hãy thử tải lại trang web này."
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"Tìm hiểu thêm về malware"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"Trang web:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"Quảng Cáo Chấp Nhận Được (được khuyến khích)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"Đẹp rồi"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"Để tạm dừng AdBlock với Chặn Nội Dung Safari được bật, vui lòng chọn Safari (trong thanh trình đơn) > Tùy chọn > Tiện ích mở rộng > AdBlock, và bỏ chọn 'Bật AdBlock'."
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"Mở <a href='#'>trang tiện ích</a>."
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - bấm để biết thêm chi tiết"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Vô hiệu hóa tất cả các tiện ích khác ngoại trừ AdBlock:"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,1369 +1,1177 @@
 {
-  "catblock_whatmakesadblocktick":{
+  "questionoridea":{
     "description":"Subtitle on the Support tab of the options",
-    "message":"Want to see what makes CatBlock tick?"
-  },
-  "adreport_screen_cap_upload":{
-    "description":"Label next to a file upload button.",
-    "message":"上传截图："
-  },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"没有发现已知的恶意软件。"
-  },
-  "checkinfirefox_3":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"在该浏览器中，订阅同样的的过滤列表。"
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "checkinfirefox_4":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"在浏览器中，打开含有广告的页面。"
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"瑞典文"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"屏蔽更多广告:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"俄文"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"已取消订阅。"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"中文"
-  },
-  "adreport_filter":{
-    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
-    "message":"如果您使用“屏蔽广告”向导创建了一条能屏蔽此广告的过滤规则，请将其粘贴在下面的框中:"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"Antisocial过滤列表（去除社交媒体的按钮）"
-  },
-  "adreportintro":{
-    "description":"Introduction of the ad reporting page",
-    "message":"您发现页面上有广告? 我们会帮您找到正确的地方来报告!"
-  },
-  "show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"在AdBlock按钮上显示被屏蔽的广告数"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"您可以<a>免费获取</a>AdBlock源代码！"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"1分钟前更新"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"无法获取此过滤列表！"
-  },
-  "browserestartrequired":{
-    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
-    "message":"请重启Safari以关闭内容屏蔽。"
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"按网址屏蔽广告"
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"隐藏这个按钮"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"AdBlock会自动获取更新；您也可以要求<a>现在更新</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"格式: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "filtereasylist_plus_estonian":{
-    "description":"language",
-    "message":"爱沙尼亚文"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"类型"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"AdBlock有可用更新！到$here$进行更新。<br>注：如果您希望自动获取更新，单击Safari>选项>扩展程序>更新<br>并勾选“自动安装更新”选项。",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"这是什么？"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"请不要订阅过多列表——每新增一个列表都会让浏览器的速度降低一点！更多详细信息和过滤列表可在<a>这里</a>找到。"
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"由于该网站使用了过时的技术，AdBlock的这项功能无法在此网站使用。您可以在在选项中的“自定义”标签下手工添加黑名单或白名单。"
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"波兰文"
-  },
-  "aalinkadreport":{
-    "description":"Acceptable Ads link message on ad report page",
-    "message":"了解更多关于可接受广告计划的情况。"
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"$seconds$秒前更新",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"来自对象的请求"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"匈牙利文"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"注意： 您的报告可能公开。如果您的报告包含隐私信息，请牢记这一点。"
-  },
-  "safarinotificationbody":{
-    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"请禁用一些过滤列表。更多详细信息请参阅AdBlock的选项。"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterorigin":{
-    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
-    "message":"过滤规则来源：\n$list$",
-    "placeholders":{
-      "list":{
-        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'",
-        "content":"$1"
-      }
-    }
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"抱歉, 因为您的一个过滤列表，AdBlock在这个页面被禁用了"
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"无效的过滤规则: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"警告：未指定过滤规则！"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock在这个页面上被禁用。"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"<i>在所有网站</i> 显示广告，除了这些网域..."
+    "message":"有问题或有新点子？"
   },
   "options":{
     "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
     "message":"选项"
   },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"已屏蔽广告："
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"添加其它语言的过滤列表："
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"点选要屏蔽的广告，AdBlock会协助您设定。"
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"如果您看到广告，不要在此提交bug报告，请转到<a>报告广告</a>！"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "adalreadyblocked":{
-    "description":"On the ad report page, telling a user there is nothing to do",
-    "message":"太好了! 您已经完成全部设置。"
-  },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"其它"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock技术支持"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"自定义AdBlock"
-  },
-  "adreport_missing_info":{
-    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
-    "message":"所需的信息未填写或无效。 请填写有红色边框的问题。"
-  },
-  "adreport_response_save_error":{
-    "description":"Error message shown when the server could not save an attached file.",
-    "message":"保存上传的文件时出错。"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"请在下面输入正确的过滤规则，并点选「确定」"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"第一步:找出要屏蔽的目标"
-  },
-  "filterdanish":{
-    "description":"language",
-    "message":"丹麦文"
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList （推荐）"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"此页面上$count$个",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "subframe":{
-    "description":"Resource list page: frame type",
-    "message":"辅助框架"
-  },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"1小时前更新"
-  },
-  "filtereasylist_plun_korean":{
+  "filtereasylist_plus_polish":{
     "description":"language",
-    "message":"韩文"
+    "message":"波兰文"
   },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"或者Chrome"
-  },
-  "adreport_name":{
-    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
-    "message":"尊姓大名？"
-  },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"最受欢迎的Chrome扩展，拥有超过4000万用户！屏蔽整个互联网上的广告。"
-  },
-  "show_resourcelist":{
-    "description":"Menu entry to open the resource list page",
-    "message":"显示资源列表"
-  },
-  "refusetocheck":{
-    "description":"User is telling us they don't wish to investigate something for us",
-    "message":"我不想检查这个"
-  },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"是"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"撤销我在此域上设置的屏蔽"
-  },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"自定义"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"暂停AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"您确定要订阅 $title$ 过滤列表？",
-    "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
-      }
-    }
-  },
-  "adreport_location":{
-    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
-    "message":"广告具体在页面的何处? 它看起来什么样?"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"或者Chrome上的AdBlock"
-  },
-  "typestylesheet":{
-    "description":"A resource type",
-    "message":"样式定义"
-  },
-  "catblock_debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"Show debug statements in Console Log (which slows down CatBlock)"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"测试功能"
-  },
-  "safarinotificationtitle":{
-    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
-    "message":"内容屏蔽规则数量超出限制"
-  },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"正在寻找广告...<br/><br/><i>这只需要一点时间。</i>"
-  },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
-      }
-    }
-  },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"AdBlock网域及网址白名单"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"脚本"
-  },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"总共$count$个",
-    "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "adreport_response_success":{
-    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
-    "message":"完成了! 我们很快就会联系您；一般会在一天内，假期期间则为两天。同时，请注意接收从AdBlock发送的电子邮件。您会找到我们的帮助站点的链接。您也可以通过电子邮件跟进问题的解决进度！"
-  },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"否"
-  },
-  "noresourcessend2":{
-    "description":"Resource list page: error message",
-    "message":"出错了。没有资源被发送。页面即将关闭。请尝试重新加载该网站。"
-  },
-  "lang_ukranian":{
-    "description":"language",
-    "message":"乌克兰文"
-  },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"$minutes$分钟前更新",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "acceptable_ads_content_blocking_disbled_message":{
-    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
-    "message":"因为您开启了Safari内容屏蔽，我们为您取消订阅了可接受广告列表。这两者您只能选择其一。(<a>为什么?</a>)"
-  },
-  "acceptableadsdisable_done":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"您不再订阅可接受广告列表。"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"恶意软件防护"
-  },
-  "savebutton":{
-    "description":"Save button",
-    "message":"保存"
-  },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"警告: 您会在其​​他所有网站看见广告!<br> 这会覆盖其它所有应用在那些网站的的过滤规则。"
-  },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"禁用通知"
-  },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"正在订阅过滤列表..."
-  },
-  "adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"您正在使用旧版本的 AdBlock。请转到 <a href='#'> 扩展程序页面</a>，启用“开发者模式”并单击“立即更新扩展程序”"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock选项"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "malwarecheck":{
-    "description":"Section header on the ad report page",
-    "message":"检查可以注入广告的恶意软件:"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"在控制台日志中显示调试信息（这将会降低AdBlock的效能）"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"您已超出 Dropbox 大小限制。请您从自定义列表或禁用的过滤列表中删除一些条目，然后重试。"
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"重新启用AdBlock"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"解决Hulu.com视频无法播放的问题（需要重启您的浏览器）"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"匹配的CSS"
   },
   "buttonexclude":{
     "description":"Button for excluding a domain in the whitelister dialog",
     "message":"排除"
   },
-  "disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"禁用除AdBlock之外的所有扩展:"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"翻译贡献者:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"载入中..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"右键点选页面上的广告来屏蔽它——或在此处手动屏蔽。"
-  },
-  "contentblockingwarning":{
-    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
-    "message":"注意: 启用Safari内容屏蔽将无法支持将网页或网站加入白名单 (允许显示广告) 功能。"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "adreport_email_privacy":{
-    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
-    "message":"我们只会在需要更多的信息时使用此地址与您联系。"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"编辑禁用的过滤列表项目"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "safaricontentblocking":{
-    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
-    "message":"启用Safari内容屏蔽"
-  },
-  "adreport_email":{
-    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
-    "message":"您的电子邮件地址?"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"若要隐藏按钮，请右键单击Safari的工具栏并选择“自定义工具栏“，然后将AdBlock按钮拖出工具栏。若要再次显示按钮，您可以将它拖放回工具栏。"
-  },
-  "adreport_server_response_error_msg":{
-    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
-    "message":"处理您的请求时出错。"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "typemain_frame":{
-    "description":"A resource type",
-    "message":"页面"
-  },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
-  },
-  "tabreloadcomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"完成了! 含广告的页面已重新载入。请检查该页面广告是否消失。然后回到此页面并回答下面的问题。"
-  },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"或输入过滤列表网址："
-  },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"您正在使用旧版本的Safari浏览器。升级到新版本可以获得AdBlock工具栏按钮、广告白名单、报告广告等功能。 <a>现在升级</a>。"
-  },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"单击Safari菜单 &rarr; 选项 &rarr; 扩展程序。"
-  },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"停止屏蔽广告:"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"屏蔽它！"
-  },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"广告是否还在？"
-  },
-  "filtereasylist_plus_bulgarian":{
-    "description":"language",
-    "message":"保加利亚文"
-  },
-  "reenableadsonebyone":{
-    "description":"Tells the user to reenable the extensions one by one",
-    "message":"太好了! 现在让我们找出是哪个扩展带来了广告。逐个启用每个扩展。带出广告的那个扩展就是您必须删除的。"
-  },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"失败！"
-  },
-  "manualfilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"手动编辑您的过滤规则："
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"意大利文"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"弹窗"
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"类型"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"斯洛伐克文"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"订阅过滤列表"
-  },
-  "acceptableadsdisable_how_to_reenable":{
-    "description":"Message shown to users after disabling Acceptable Ads via update page.",
-    "message":"您可以通过勾选下面的“允许一些非侵入式广告”来重新启用它并支持一些您喜爱的网站。"
-  },
-  "checkinfirefox_5":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"广告是否仍在浏览器中显示？"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"不要在这个页面上运行"
-  },
-  "filtereasylist_plus_lithuania":{
-    "description":"language",
-    "message":"立陶宛文"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"到我们的<a>技术支持网站</a>上告诉我们！"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock 已暂停。"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"我们目前还无法屏蔽Flash或其他plugins中的广告。此功能尚在等待浏览器与WebKit 的支持。"
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"确定"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"一般"
-  },
-  "aamessageadreport":{
-    "description":"Acceptable Ads message on ad report page",
-    "message":"如果您不想看到这样的广告，您可能希望禁用可接受广告列表。"
-  },
-  "malwarewarning":{
-    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
-    "message":"您的计算机可能感染了恶意软件。单击 <a>此处</a> 了解更多信息。"
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"其它"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"未指定过滤规则！"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"未知"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"音频/视频"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"日文"
-  },
-  "acceptableadsoption":{
-    "description":"option on the 'General' tab",
-    "message":"允许一些非侵入式广告"
-  },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"取消"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"你可以滑动滑块来精确定义AdBlock白名单网域。"
-  },
-  "content_blocking_acceptable_ads_disbled_message":{
-    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
-    "message":"因为您选择允许非侵入式的广告，我们为您关闭了Safari内容屏蔽。这两者您只能选择其一。(<a>为什么?</a>)"
-  },
-  "adreport_laststep":{
-    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
-    "message":"最后一步: 向我们报告问题"
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"使用Firefox $chrome$检查",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"要报告一个广告，您必须连接到互联网。"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList （推荐）"
-  },
-  "catblock_example_flickr_id":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset ID (e.g. $example$)",
-    "placeholders":{
-      "example":{
-        "content":"<i>346406</i>"
-      }
-    }
-  },
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - 报告广告"
-  },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"广告屏蔽过滤列表"
-  },
-  "how":{
-    "description":"Text of a link pointing to instructions on how to do something",
-    "message":"如何操作？"
-  },
-  "allow_whitelisting_youtube_channels":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"允许特定YouTube频道的白名单"
-  },
-  "thirdparty":{
-    "description":"Resource list page: column title telling if the resource originates from a different domain",
-    "message":"第三方"
-  },
-  "filterannoyances":{
-    "description":"A filter list",
-    "message":"Fanboy's Annoyances（去除网页上令人心烦的干扰）"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock - 点击查看详情"
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"$hours$小时前更新",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"俄文和乌克兰文"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"最新的版本有什么变化？请参阅 <a style='cursor:pointer;'>更新日志</a>！"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"被禁用的扩展已重新启用。"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"希腊文"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"隐藏部分页面"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"视频或Flash"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"您认为下列哪个规则会在每次浏览此页面时屏蔽此广告？"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"在此页上启用AdBlock"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"返回"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"过滤列表能屏蔽网络上大多数的广告。 您也可以:"
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "disableaa":{
-    "description":"Section header on the ad report page",
-    "message":"检查可接受广告规则:"
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"在页面或网域显示广告"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"页面上只有<b>1</b>个匹配项目被屏蔽。"
+  "refusetocheck":{
+    "description":"User is telling us they don't wish to investigate something for us",
+    "message":"我不想检查这个"
+  },
+  "browserestartrequired":{
+    "description":"Displayed after disabling Safari Content Blocking, which requres a browser relaunch",
+    "message":"请重启Safari以关闭内容屏蔽。"
   },
   "filtersavewarning":{
     "description":"Warning when blacklisting manually",
     "message":"请小心: 如果您在这里设置出错，许多其它过滤规则，包括官方的过滤规则，可能会失效！<br/>参阅<a>过滤规则语法教程</a>来学习正确地添加高级黑名单、白名单规则。"
   },
-  "whitelist_youtube_channel":{
-    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
-    "message":"将$name$频道添加到白名单",
-    "placeholders":{
-      "name":{
-        "example":"Name of channel",
-        "content":"$1"
-      }
-    }
+  "checkinfirefox_5":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"广告是否仍在浏览器中显示？"
   },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"一般选项"
+  "aamessageadreport":{
+    "description":"Acceptable Ads message on ad report page",
+    "message":"如果您不想看到这样的广告，您可能希望禁用可接受广告列表。"
   },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock不会在任何符合以下规则的网域启用:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"我们没有这个语言的预设过滤列表。<br/>请尝试寻找一个支持此语言的合适列表$link$ 或者自行在选项中的“自定义”标签加入过滤规则。",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"订阅"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"我是专业用户, 显示高级选项"
-  },
-  "filtereasylist_plus_spanish":{
+  "filtereasylist_plus_lithuania":{
     "description":"language",
-    "message":"西班牙文"
-  },
-  "resourcedomain":{
-    "description":"Resource list page: text shown when hovering over an item in the third-party column",
-    "message":"在以下网域上加载：\n$domain$",
-    "placeholders":{
-      "domain":{
-        "example":"example.com",
-        "content":"$1"
-      }
-    }
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"点击这里：<a>更新我的过滤列表！</a>"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"使用越多的过滤列表，AdBlock 越慢。过多的过滤列表甚至会使浏览器在部分网站崩溃。点击“确认”继续订阅此列表。"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"最后一步：此广告是由什么组成的？"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"页面上有$matchcount$个匹配项目被屏蔽。",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"我们也有<a>一个页面</a>让您了解AdBlock幕后的贡献者们！"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"印度尼西亚文"
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"土耳其文"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"屏蔽广告"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"自定义过滤列表"
-  },
-  "frameurl":{
-    "description":"Resource list page: full URL of the frame",
-    "message":"框架URL: "
-  },
-  "firefox_explanation":{
-    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
-    "message":"这个问题的目的是确定谁应当接收您的报告。如果您没有正确地回答这个问题，您的报告会送至错误的人手中，以致它被忽略。"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"在右键菜单中加入选项"
-  },
-  "typeselector":{
-    "description":"A resource type",
-    "message":"选择器"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"屏蔽这个广告"
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"我们的团队向您请求调试信息？点击<a href='#' id='debug'>这里</a>获取它们！"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"不要在此网域运行AdBlock..."
-  },
-  "adreportvoluntary":{
-    "description":"Introduction of the ad reporting page",
-    "message":"报告广告是自愿的。它有助于让过滤列表的维护人员帮助所有人屏蔽这个广告。如果您现在不想帮助他人，没关系。关闭这个页面然后自行<a>屏蔽这个广告</a>。"
-  },
-  "hiddenelement":{
-    "description":"Resource list page: resource status",
-    "message":"隐藏元素"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"重新载入页面"
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"页面"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"荷兰文"
-  },
-  "adreport_response_file_name":{
-    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
-    "message":"文件名过长。请给您的文件命名一个更短的名称。"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"别忘了保存！"
-  },
-  "checkforupdates":{
-    "description":"Displayed when AdBlock is checking the newest available version",
-    "message":"正在检查更新（这应当只需几秒钟）..."
+    "message":"立陶宛文"
   },
   "retryaftersubscribe":{
     "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
     "message":"先订阅此过滤列表，然后重试一次：$list_title$",
     "placeholders":{
       "list_title":{
-        "example":"French filters",
-        "content":"$1"
+        "content":"$1",
+        "example":"French filters"
       }
     }
   },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"AdBlock在检测到恶意软件时是否显示通知？"
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
   },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  "malwarewarning":{
+    "description":"On the ad report page, the ads the user is seeing might be caused by malware/adware",
+    "message":"您的计算机可能感染了恶意软件。单击 <a>此处</a> 了解更多信息。"
   },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"在AdBlock菜单中显示被屏蔽的广告数"
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"在页面或网域显示广告"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"网站:"
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock 自订过滤清单（推荐）"
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"拉脱维亚文"
-  },
-  "correctfilters":{
-    "description":"On the ad report page, label describing having the right set of filters",
-    "message":"请确保您正在使用正确语言的过滤列表:"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"匹配的CSS"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"要隐藏按钮，转到 opera://extensions 并勾选“从工具栏隐藏”选项。通过取消选中该选项，您可以再次显示它。"
-  },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>不确定？</b>直接点选下方的「屏蔽它！」。 "
-  },
-  "headerfilter":{
-    "description":"Resource list page: title of a column",
-    "message":"符合的过滤规则"
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"正在获取列表...请稍候。"
-  },
-  "resourceblocktitle":{
-    "description":"Resource list page name",
-    "message":"所有资源"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock已经是最新版！"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"不要在这个网域的页面上运行"
-  },
-  "filterisraeli":{
+  "lang_slovak":{
     "description":"language",
-    "message":"希伯来文"
+    "message":"斯洛伐克文"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"移动滑块直到页面上的广告被正确地屏蔽。"
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"屏蔽包含以下字符串的网址"
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "safaricontentblockinglimitexceeded":{
-    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
-    "message":"过滤列表中规则的数量超出了50,000条的限制，并已自动删减。请取消订阅一些过滤列表或禁用Safari内容屏蔽!"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"1天前更新"
-  },
-  "filteracceptable_ads":{
-    "description":"A filter list",
-    "message":"可接受广告 (推荐)"
-  },
-  "clickdisableaa":{
-    "description":"Instruction on ad report page",
-    "message":"单击此选项: <a>禁用可接受广告</a>"
-  },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"版本 $version$",
+  "checkinfirefox_2":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
+    "message":"安装Firefox上的Adblock Plus $chrome$。",
     "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='adblockforchrome'></span>",
+        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"从列表中移除"
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"我们没有这个语言的预设过滤列表。<br/>请尝试寻找一个支持此语言的合适列表$link$ 或者自行在选项中的“自定义”标签加入过滤规则。",
+    "placeholders":{
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
+      }
+    }
   },
-  "adreport_response_invalid_file":{
-    "description":"Error message shown when the user uploads an invalid file type.",
-    "message":"这不是一个图像文件。请上传.png、.gif 或.jpg 文件。"
-  },
-  "bugreport":{
-    "description":"Link to send a bug report on the Support tab of the options",
-    "message":"为什么不向我们发送一份<a>bug 报告</a>呢?"
-  },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"隐藏"
-  },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"过滤列表"
-  },
-  "framedomain":{
-    "description":"Resource list page: domain name of the frame",
-    "message":"框架所在网域： "
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"点选要屏蔽的广告，AdBlock会协助您设定。"
   },
   "topframe":{
     "description":"Resource list page: frame type",
     "message":"顶部框架"
   },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"样式定义"
+  },
+  "typeunknown":{
+    "description":"A resource type",
+    "message":"未知"
+  },
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"抱歉, 因为您的一个过滤列表，AdBlock在这个页面被禁用了"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "thirdparty":{
+    "description":"Resource list page: column title telling if the resource originates from a different domain",
+    "message":"第三方"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"未指定过滤规则！"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"希腊文"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"您正在使用旧版本的 AdBlock。请转到 <a href='#'> 扩展程序页面</a>，启用“开发者模式”并单击“立即更新扩展程序”"
+  },
+  "adreport_name":{
+    "description":"Label for a textbox where the user enters their name (or nickname) to submit a bug or ad report.",
+    "message":"尊姓大名？"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"解决Hulu.com视频无法播放的问题（需要重启您的浏览器）"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"警告：未指定过滤规则！"
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"自定义"
+  },
+  "adreportintro":{
+    "description":"Introduction of the ad reporting page",
+    "message":"您发现页面上有广告? 我们会帮您找到正确的地方来报告!"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "filtereasylist_plus_estonian":{
+    "description":"language",
+    "message":"爱沙尼亚文"
+  },
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"自定义AdBlock"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"保加利亚文"
+  },
+  "whitelistedresource":{
+    "description":"Resource list page: resource status",
+    "message":"已加入白名单的资源"
+  },
+  "safarinotificationtitle":{
+    "description":"Title of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"内容屏蔽规则数量超出限制"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"不要在此网域运行AdBlock..."
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"屏蔽包含以下字符串的网址"
+  },
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"关闭"
+  },
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"使用Firefox $chrome$检查",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"最后一步：此广告是由什么组成的？"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"如果您看到广告，不要在此提交bug报告，请转到<a>报告广告</a>！"
+  },
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"韩文"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"您正在使用旧版本的Safari浏览器。升级到新版本可以获得AdBlock工具栏按钮、广告白名单、报告广告等功能。 <a>现在升级</a>。"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"芬兰文"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"脚本"
+  },
+  "lang_ukranian":{
+    "description":"language",
+    "message":"乌克兰文"
+  },
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"没有发现已知的恶意软件。"
+  },
+  "safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"请禁用一些过滤列表。更多详细信息请参阅AdBlock的选项。"
+  },
+  "acceptable_ads_content_blocking_disbled_message":{
+    "description":"Warning shown when Safari Content Blocking is enabled while the Acceptable Ads filter list was already enabled.",
+    "message":"因为您开启了Safari内容屏蔽，我们为您取消订阅了可接受广告列表。这两者您只能选择其一。(<a>为什么?</a>)"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"我们也有<a>一个页面</a>让您了解AdBlock幕后的贡献者们！"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"这里"
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"弹窗"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"重新载入页面"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"此页面使用什么语言？"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock 已暂停。"
+  },
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"重新启用AdBlock"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"正在寻找广告...<br/><br/><i>这只需要一点时间。</i>"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock在这个页面上被禁用。"
+  },
+  "checkinfirefox_3":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"在该浏览器中，订阅同样的的过滤列表。"
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"屏蔽广告"
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"警告: 您会在其​​他所有网站看见广告!<br> 这会覆盖其它所有应用在那些网站的的过滤规则。"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"AdBlock有可用更新！到$here$进行更新。<br>注：如果您希望自动获取更新，单击Safari>选项>扩展程序>更新<br>并勾选“自动安装更新”选项。",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
   "subscribingfinished":{
     "description":"abp: link subscriber result",
     "message":"完成！"
   },
-  "headerresource":{
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock 自订过滤清单（推荐）"
+  },
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"类型"
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"这是什么？"
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"日文"
+  },
+  "filterorigin":{
+    "description":"Resource list page: tooltip of matching filter, telling which filter list contains the filter",
+    "message":"过滤规则来源：\n$list$",
+    "placeholders":{
+      "list":{
+        "content":"$1",
+        "example":"A filter list name OR AdBlock OR the translation of 'tabcustomize'"
+      }
+    }
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"订阅过滤列表"
+  },
+  "frametype":{
+    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
+    "message":"框架类型： "
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"添加其它语言的过滤列表："
+  },
+  "headerfilter":{
     "description":"Resource list page: title of a column",
-    "message":"资源"
+    "message":"符合的过滤规则"
   },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"屏蔽此页面上的广告"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"过滤列表能屏蔽网络上大多数的广告。 您也可以:"
   },
-  "updateyourlists":{
-    "description":"Section header on the ad report page",
-    "message":"请确认您的过滤列表都已是最新的："
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"若要隐藏按钮，请右键单击Safari的工具栏并选择“自定义工具栏“，然后将AdBlock按钮拖出工具栏。若要再次显示按钮，您可以将它拖放回工具栏。"
   },
-  "lang_english":{
-    "description":"language",
-    "message":"英文"
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"您已超出 Dropbox 大小限制。请您从自定义列表或禁用的过滤列表中删除一些条目，然后重试。"
   },
-  "filtericelandic":{
-    "description":"language",
-    "message":"冰岛文"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"订阅"
   },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"请打开扩展管理页面，启用先前被禁用的扩展。"
+  "contentblockingwarning":{
+    "description":"Notice shown on the 'Customize' tab of the options page when Safari Content Blocking is enabled",
+    "message":"注意: 启用Safari内容屏蔽将无法支持将网页或网站加入白名单 (允许显示广告) 功能。"
   },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"应用的网域"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"被屏蔽的页面元素："
+  },
+  "typepage":{
+    "description":"A resource type",
+    "message":"页面"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"其它"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"点击这里：<a>更新我的过滤列表！</a>"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "hiddenelement":{
+    "description":"Resource list page: resource status",
+    "message":"隐藏元素"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"要隐藏按钮，转到 opera://extensions 并勾选“从工具栏隐藏”选项。通过取消选中该选项，您可以再次显示它。"
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"来自对象的请求"
   },
   "modifypath":{
     "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
     "message":"页面:"
   },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"发现了bug？"
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"屏蔽它！"
   },
-  "filtereasylist_plus_arabic":{
+  "allow_whitelisting_youtube_channels":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"允许特定YouTube频道的白名单"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"我们目前还无法屏蔽Flash或其他plugins中的广告。此功能尚在等待浏览器与WebKit 的支持。"
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"阿拉伯文"
+    "message":"匈牙利文"
   },
-  "lang_czech":{
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"屏蔽这个广告"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"在此页上启用AdBlock"
+  },
+  "show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"在AdBlock按钮上显示被屏蔽的广告数"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"失败！"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"暂停AdBlock"
+  },
+  "lang_english":{
     "description":"language",
-    "message":"捷克文"
+    "message":"英文"
   },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"自愿捐款！"
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"在右键菜单中加入选项"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"想知道是什么造就了AdBlock魔法？"
+  "adreport_server_response_error__manual_msg_step1":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"请移步<a>我们的技术支持站点</a>。"
   },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  "filterwarning_removal":{
+    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
+    "message":"Adblock警告移除列表（移除使用广告屏蔽软件时网站显示的警告信息）"
   },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"无效的列表网址。 它将会被删除。"
-  },
-  "typesub_frame":{
+  "typemain_frame":{
     "description":"A resource type",
-    "message":"框架"
+    "message":"页面"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"编辑"
+  "confirm_undo_custom_filters":{
+    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
+    "message":"您确定要移除您在$host$上创建的$count$个屏蔽规则？",
+    "placeholders":{
+      "count":{
+        "content":"$1",
+        "example":"The number of custom blocks for a domain."
+      },
+      "host":{
+        "content":"$2",
+        "example":"code.google.ph, ph.msn.com, stackoverflow.com"
+      }
+    }
   },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"有问题或有新点子？"
+  "legend":{
+    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
+    "message":"图例： "
   },
-  "adreport_missing_screenshot":{
-    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
-    "message":"您未粘贴截图! 看不到您所报告的广告，我们无法帮助您。"
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b>或者</b>，单击此按钮来完成以上所有步骤： <a>禁用其他所有扩展</a>"
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"$minutes$分钟前更新",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"了解更多关于恶意软件的信息"
+  "adreport_screen_cap_upload":{
+    "description":"Label next to a file upload button.",
+    "message":"上传截图："
+  },
+  "filtereasylist_plus_romanian":{
+    "description":"language",
+    "message":"罗马尼亚文"
+  },
+  "manualexcludefilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"编辑禁用的过滤列表项目"
+  },
+  "subframe":{
+    "description":"Resource list page: frame type",
+    "message":"辅助框架"
   },
   "reloadadpage":{
     "description":"Instruction on ad report page",
     "message":"重新载入出现广告的页面。"
+  },
+  "safaricontentblocking":{
+    "description":"Checkbox on the 'General' tab of the Options page. 'Content Blocking' is the name of a different way of blocking resources introduced in Safari 9.",
+    "message":"启用Safari内容屏蔽"
   },
   "checkinfirefox_1":{
     "description":"instruction for how to check Firefox/Chrome for a reported ad",
     "message":"安装Firefox $chrome$。",
     "placeholders":{
       "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"过滤列表"
+  },
+  "adreport_filter":{
+    "description":"Optional question on the ad report page when the ad needs to be reported to AdBlock.",
+    "message":"如果您使用“屏蔽广告”向导创建了一条能屏蔽此广告的过滤规则，请将其粘贴在下面的框中:"
+  },
+  "adreport_response_large_file":{
+    "description":"Error message shown when the user tries to upload a large image file.",
+    "message":"文件过大。请确保您的文件小于10MB。"
+  },
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock不会在任何符合以下规则的网域启用:"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"中文"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"无效的过滤规则: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"正在订阅过滤列表..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"请打开扩展管理页面，启用先前被禁用的扩展。"
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"禁用通知"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"土耳其文"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"请不要订阅过多列表——每新增一个列表都会让浏览器的速度降低一点！更多详细信息和过滤列表可在<a>这里</a>找到。"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"框架"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"印度尼西亚文"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"图像"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"总共$count$个",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"取消"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"别忘了保存！"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "typeselector":{
+    "description":"A resource type",
+    "message":"选择器"
+  },
+  "content_blocking_acceptable_ads_disbled_message":{
+    "description":"Warning shown when the Acceptable Ads filter list is enabled while Safari Content Blocking was already enabled.",
+    "message":"因为您选择允许非侵入式的广告，我们为您关闭了Safari内容屏蔽。这两者您只能选择其一。(<a>为什么?</a>)"
+  },
+  "filtericelandic":{
+    "description":"language",
+    "message":"冰岛文"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"广告屏蔽过滤列表"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"只在屏蔽以下网站的广告:"
+  },
+  "resourcedomain":{
+    "description":"Resource list page: text shown when hovering over an item in the third-party column",
+    "message":"在以下网域上加载：\n$domain$",
+    "placeholders":{
+      "domain":{
+        "content":"$1",
+        "example":"example.com"
+      }
+    }
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"被禁用的扩展已重新启用。"
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"优化这个过滤列表"
+  },
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"请帮助我们宣传AdBlock！"
   },
   "catblock_enable_adblock":{
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
-  "adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"AdBlock更新"
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
   },
-  "filterwarning_removal":{
-    "description":"A filter list. \"Adblock\" is written with a lowercase B in this string as it refers to ad blocking extensions in general, not just AdBlock specifically.",
-    "message":"Adblock警告移除列表（移除使用广告屏蔽软件时网站显示的警告信息）"
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock选项"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "adreport_server_response_error_msg":{
+    "description":"Error message shown when an new ticket is sumbitted for an ad or bug report, and the server had an issue while processing the data.",
+    "message":"处理您的请求时出错。"
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"1小时前更新"
+  },
+  "checkforupdates":{
+    "description":"Displayed when AdBlock is checking the newest available version",
+    "message":"正在检查更新（这应当只需几秒钟）..."
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"刚刚更新"
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"右键点选页面上的广告来屏蔽它——或在此处手动屏蔽。"
+  },
+  "malwarecheck":{
+    "description":"Section header on the ad report page",
+    "message":"检查可以注入广告的恶意软件:"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock技术支持"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"类型"
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"移动滑块直到页面上的广告被正确地屏蔽。"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"1分钟前更新"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"框架"
+  },
+  "blockedresource":{
+    "description":"Resource list page: resource status",
+    "message":"已屏蔽的资源"
+  },
+  "adreport_all_debug_info":{
+    "description":"Shows the user the debug information that will be sent along with their report.",
+    "message":"以下信息也将列入广告报告。"
+  },
+  "filterdanish":{
+    "description":"language",
+    "message":"丹麦文"
+  },
+  "disableaa":{
+    "description":"Section header on the ad report page",
+    "message":"检查可接受广告规则:"
+  },
+  "acceptableadsdisable_how_to_reenable":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"您可以通过勾选下面的“允许一些非侵入式广告”来重新启用它并支持一些您喜爱的网站。"
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"Want to see what makes CatBlock tick?"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"正在获取列表...请稍候。"
+  },
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"无效的列表网址。 它将会被删除。"
+  },
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"一般选项"
+  },
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"取消<b>除了</b>AdBlock之外所有扩展的“已启用”复选框。<b>保持AdBlock启用</b>。"
+  },
+  "checkinfirefox_4":{
+    "description":"Instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"在浏览器中，打开含有广告的页面。"
+  },
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"<i>在所有网站</i> 显示广告，除了这些网域..."
+  },
+  "adreport_missing_screenshot":{
+    "description":"Error message shown when the user doesn't attach a screenshot to an ad report.",
+    "message":"您未粘贴截图! 看不到您所报告的广告，我们无法帮助您。"
+  },
+  "catblock_debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"Show debug statements in Console Log (which slows down CatBlock)"
+  },
+  "adreport_server_response_error__manual_msg_step2":{
+    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
+    "message":"手动创建一个话题，复制并粘贴下面的信息到 \"Fill in any details you think will help us understand your issue\" 部分。"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"要隐藏按钮，请右键单击它并选择\"隐藏按钮\"。您可以在 chrome://chrome/extensions 中选择重新显示按钮。"
+  },
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "filterisraeli":{
+    "description":"language",
+    "message":"希伯来文"
+  },
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"由于该网站使用了过时的技术，AdBlock的这项功能无法在此网站使用。您可以在在选项中的“自定义”标签下手工添加黑名单或白名单。"
+  },
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"捷克文和斯洛伐克文"
+  },
+  "disableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"我们已经禁用了所有其他扩展。现在含广告的页面将重新载入。请稍等。"
   },
   "otherfilters":{
     "description":"List for other filters the user subscribed to",
     "message":"其它过滤列表"
   },
-  "filtereasylist_plus_french":{
-    "description":"language",
-    "message":"法文"
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"AdBlock会自动获取更新；您也可以要求<a>现在更新</a>"
   },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"被屏蔽的页面元素："
+  "show_resourcelist":{
+    "description":"Menu entry to open the resource list page",
+    "message":"显示资源列表"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"交互式对象"
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
   },
-  "updatedrightnow":{
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"使用越多的过滤列表，AdBlock 越慢。过多的过滤列表甚至会使浏览器在部分网站崩溃。点击“确认”继续订阅此列表。"
+  },
+  "adalreadyblocked":{
+    "description":"On the ad report page, telling a user there is nothing to do",
+    "message":"太好了! 您已经完成全部设置。"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"测试功能"
+  },
+  "disableforchromestepone":{
+    "description":"Step 1 for disabling Chrome extensions",
+    "message":"打开<a href='#'>扩展程序</a>页面。"
+  },
+  "adreport_response_success":{
+    "description":"Shown when a ticket has been sumbitted to AdBlock's support site successfully.",
+    "message":"完成了! 我们很快就会联系您；一般会在一天内，假期期间则为两天。同时，请注意接收从AdBlock发送的电子邮件。您会找到我们的帮助站点的链接。您也可以通过电子邮件跟进问题的解决进度！"
+  },
+  "aalinkadreport":{
+    "description":"Acceptable Ads link message on ad report page",
+    "message":"了解更多关于可接受广告计划的情况。"
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"AdBlock在检测到恶意软件时是否显示通知？"
+  },
+  "updateddayago":{
     "description":"Label for subscription",
-    "message":"刚刚更新"
+    "message":"1天前更新"
+  },
+  "frameurl":{
+    "description":"Resource list page: full URL of the frame",
+    "message":"框架URL: "
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"德文"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "adreport_response_file_name":{
+    "description":"Error message shown when the file name of an attachement the user is trying to submit in a report is longer than 255 characters.",
+    "message":"文件名过长。请给您的文件命名一个更短的名称。"
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"$seconds$秒前更新",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"不要在这个页面上运行"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"到我们的<a>技术支持网站</a>上告诉我们！"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"确定"
+  },
+  "tabreloadcomplete":{
+    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
+    "message":"完成了! 含广告的页面已重新载入。请检查该页面广告是否消失。然后回到此页面并回答下面的问题。"
+  },
+  "resourceblocktitle":{
+    "description":"Resource list page name",
+    "message":"所有资源"
+  },
+  "whitelist_youtube_channel":{
+    "description":"Entry in the AdBlock menu, when a user is browsing YouTube and has enabled the YouTube channel whitelisting option",
+    "message":"将$name$频道添加到白名单",
+    "placeholders":{
+      "name":{
+        "content":"$1",
+        "example":"Name of channel"
+      }
+    }
+  },
+  "headerresource":{
+    "description":"Resource list page: title of a column",
+    "message":"资源"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"在AdBlock菜单中显示被屏蔽的广告数"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - 报告广告"
+  },
+  "how":{
+    "description":"Text of a link pointing to instructions on how to do something",
+    "message":"如何操作？"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"不要在这个网域的页面上运行"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"自定义过滤列表"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"屏蔽更多广告:"
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
+  "adreport_missing_info":{
+    "description":"Error message shown when the user doesn't enter anything in some of the text fields.",
+    "message":"所需的信息未填写或无效。 请填写有红色边框的问题。"
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"AdBlock网域及网址白名单"
+  },
+  "acceptableadsdisable_done":{
+    "description":"Message shown to users after disabling Acceptable Ads via update page.",
+    "message":"您不再订阅可接受广告列表。"
+  },
+  "filterannoyances":{
+    "description":"A filter list",
+    "message":"Fanboy's Annoyances（去除网页上令人心烦的干扰）"
+  },
+  "malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"AdBlock已阻止了一个从已知包含恶意软件的网站进行的下载。"
+  },
+  "savebutton":{
+    "description":"Save button",
+    "message":"保存"
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>不确定？</b>直接点选下方的「屏蔽它！」。 "
+  },
+  "adreport_laststep":{
+    "description":"Heading on the ad report page. Shown when the ad needs to be reported to AdBlock, and not filter list maintainers.",
+    "message":"最后一步: 向我们报告问题"
+  },
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
+  },
+  "adreport_location":{
+    "description":"Question on the ad report page asking the user to describe the ad and its location on a webpage.",
+    "message":"广告具体在页面的何处? 它看起来什么样?"
+  },
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"看上去不错"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "datacollectionoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"允许AdBlock收集匿名的过滤列表使用情况及其他使用数据"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"要报告一个广告，您必须连接到互联网。"
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"您确定要订阅 $title$ 过滤列表？",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"$days$天前更新",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"框架"
+    "message":"交互式对象"
   },
-  "filtereasyprivacy":{
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"您认为下列哪个规则会在每次浏览此页面时屏蔽此广告？"
+  },
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"已屏蔽广告："
+  },
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
+  },
+  "filtereasylist_plus_arabic":{
+    "description":"language",
+    "message":"阿拉伯文"
+  },
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"撤销我在此域上设置的屏蔽"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"手动编辑您的过滤规则："
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"第一步:找出要屏蔽的目标"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"请在下面输入正确的过滤规则，并点选「确定」"
+  },
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"翻译贡献者:"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock已经是最新版！"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"仅英文"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b>或者</b>，单击此按钮来完成以上所有步骤： <a>禁用其他所有扩展</a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"最新的版本有什么变化？请参阅 <a style='cursor:pointer;'>更新日志</a>！"
+  },
+  "filterantisocial":{
     "description":"A filter list",
-    "message":"EasyPrivacy (隐私保护)"
+    "message":"Antisocial过滤列表（去除社交媒体的按钮）"
   },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"报告这个页面上的广告"
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"恶意软件防护"
   },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"优化这个过滤列表"
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"我是专业用户, 显示高级选项"
   },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"德文"
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"您的订阅超出了AdBlock能使用的储存空间。请取消订阅一些列表!"
   },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"注意：此过滤规则会屏蔽页面上所有的$elementtype$元素！",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
   },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"这里"
+  "adreport_email":{
+    "description":"Label for a textbox where the user enters their email address to submit a bug or ad report.",
+    "message":"您的电子邮件地址?"
   },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"此页面使用什么语言？"
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"想知道是什么造就了AdBlock魔法？"
   },
-  "confirm_undo_custom_filters":{
-    "description":"Confirmation message when user wants to undo their custom blocks for a domain. $count$ will be a number between 1 and 999,999,999, $host$ will be the domain where the custom blocks will be reset.",
-    "message":"您确定要移除您在$host$上创建的$count$个屏蔽规则？",
-    "placeholders":{
-      "host":{
-        "example":"code.google.ph, ph.msn.com, stackoverflow.com",
-        "content":"$2"
-      },
-      "count":{
-        "example":"The number of custom blocks for a domain.",
-        "content":"$1"
-      }
-    }
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
   },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"图像"
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"隐藏部分页面"
   },
-  "adreport_server_response_error__manual_msg_step2":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"手动创建一个话题，复制并粘贴下面的信息到 \"Fill in any details you think will help us understand your issue\" 部分。"
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"一般"
   },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"要隐藏按钮，请右键单击它并选择\"隐藏按钮\"。您可以在 chrome://chrome/extensions 中选择重新显示按钮。"
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"或者Chrome上的AdBlock"
   },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"罗马尼亚文"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"视频或Flash"
   },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"检查更新时出错。"
-  },
-  "disableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've disabled all other extensions",
-    "message":"我们已经禁用了所有其他扩展。现在含广告的页面将重新载入。请稍等。"
-  },
-  "whitelistedresource":{
-    "description":"Resource list page: resource status",
-    "message":"已加入白名单的资源"
-  },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "reenableadsonebyone":{
+    "description":"Tells the user to reenable the extensions one by one",
+    "message":"太好了! 现在让我们找出是哪个扩展带来了广告。逐个启用每个扩展。带出广告的那个扩展就是您必须删除的。"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -1375,184 +1183,416 @@
       }
     }
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"捷克文和斯洛伐克文"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"或者Chrome"
   },
-  "frametype":{
-    "description":"Resource list page: followed by frame type (e.g. top frame, subframe)",
-    "message":"框架类型： "
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"格式: ~site1.com|~site2.com|~news.site3.org"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":"——选择语言——"
-  },
-  "checkinfirefox_2":{
-    "description":"Instruction for how to check Firefox/Chrome for a reported ad. Don't translate the name 'Adblock Plus'.",
-    "message":"安装Firefox上的Adblock Plus $chrome$。",
-    "placeholders":{
-      "chrome":{
-        "example":"'or AdBlock for Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='adblockforchrome'></span>"
-      }
-    }
-  },
-  "blockedresource":{
-    "description":"Resource list page: resource status",
-    "message":"已屏蔽的资源"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"该广告是出现在视频或Flash游戏等外部plugin中吗？"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$为$value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"即将套用的规则（您仍然可在选项中编辑）："
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"以下过滤规则： <br/> $filter$ <br/> 有一个错误： <br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"关闭"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"只在屏蔽以下网站的广告:"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"您的订阅超出了AdBlock能使用的储存空间。请取消订阅一些列表!"
-  },
-  "datacollectionoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"允许AdBlock收集匿名的过滤列表使用情况及其他使用数据"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"好了。您仍然可以在选项中手动屏蔽此广告。 谢谢！"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "buttonsubmit":{
-    "description":"Button to send a form.",
-    "message":"提交"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"芬兰文"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "adreport_response_large_file":{
-    "description":"Error message shown when the user tries to upload a large image file.",
-    "message":"文件过大。请确保您的文件小于10MB。"
-  },
-  "adreport_all_debug_info":{
-    "description":"Shows the user the debug information that will be sent along with their report.",
-    "message":"以下信息也将列入广告报告。"
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"自愿捐款！"
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"这是广告过滤列表方面的问题。请在这里报告：$link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"取消<b>除了</b>AdBlock之外所有扩展的“已启用”复选框。<b>保持AdBlock启用</b>。"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"注意： 您的报告可能公开。如果您的报告包含隐私信息，请牢记这一点。"
   },
-  "showlinkstolists2":{
-    "description":"Option on the 'Filter lists' tab of the Options page",
-    "message":"显示过滤列表的网址"
+  "filteritalian":{
+    "description":"language",
+    "message":"意大利文"
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"仅英文"
+  "catblock_example_flickr_id":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset ID (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>346406</i>"
+      }
+    }
   },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"请帮助我们宣传AdBlock！"
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"广告是否还在？"
   },
-  "malwarenotificationmessage":{
-    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
-    "message":"AdBlock已阻止了一个从已知包含恶意软件的网站进行的下载。"
+  "correctfilters":{
+    "description":"On the ad report page, label describing having the right set of filters",
+    "message":"请确保您正在使用正确语言的过滤列表:"
   },
-  "legend":{
-    "description":"Resource list page: followed by color codes for various resource statuses (e.g. blocked, whitelisted, hidden)",
-    "message":"图例： "
+  "updateyourlists":{
+    "description":"Section header on the ad report page",
+    "message":"请确认您的过滤列表都已是最新的："
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"检查更新时出错。"
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"单击Safari菜单 &rarr; 选项 &rarr; 扩展程序。"
+  },
+  "buttonsubmit":{
+    "description":"Button to send a form.",
+    "message":"提交"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"已取消订阅。"
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"音频/视频"
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"拉脱维亚文"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"屏蔽此页面上的广告"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"停止屏蔽广告:"
+  },
+  "adreport_response_save_error":{
+    "description":"Error message shown when the server could not save an attached file.",
+    "message":"保存上传的文件时出错。"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"页面上有$matchcount$个匹配项目被屏蔽。",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"无法获取此过滤列表！"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"你可以滑动滑块来精确定义AdBlock白名单网域。"
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"隐藏"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"该广告是出现在视频或Flash游戏等外部plugin中吗？"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"俄文和乌克兰文"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"西班牙文"
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"注意：此过滤规则会屏蔽页面上所有的$elementtype$元素！",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
   },
   "disableyoutubestreamingads":{
     "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
     "message":"启用ClickToFlash兼容模式"
   },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"否"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"即将套用的规则（您仍然可在选项中编辑）："
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"隐藏这个按钮"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"其它"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"好了。您仍然可以在选项中手动屏蔽此广告。 谢谢！"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"俄文"
+  },
+  "bugreport":{
+    "description":"Link to send a bug report on the Support tab of the options",
+    "message":"为什么不向我们发送一份<a>bug 报告</a>呢?"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (隐私保护)"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$为$value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"或输入过滤列表网址："
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"以下过滤规则： <br/> $filter$ <br/> 有一个错误： <br/> $message$",
+    "placeholders":{
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
+      }
+    }
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"载入中..."
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"我们的团队向您请求调试信息？点击<a href='#' id='debug'>这里</a>获取它们！"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "safaricontentblockinglimitexceeded":{
+    "description":"Displayed when the number of rules in the subscribed filter lists is larger than the number supported by Safari Content Blocking, if that option is enabled",
+    "message":"过滤列表中规则的数量超出了50,000条的限制，并已自动删减。请取消订阅一些过滤列表或禁用Safari内容屏蔽!"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"报告这个页面上的广告"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"在控制台日志中显示调试信息（这将会降低AdBlock的效能）"
+  },
+  "framedomain":{
+    "description":"Resource list page: domain name of the frame",
+    "message":"框架所在网域： "
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"最受欢迎的Chrome扩展，拥有超过4000万用户！屏蔽整个互联网上的广告。"
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"发现了bug？"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"捷克文"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "adreport_response_invalid_file":{
+    "description":"Error message shown when the user uploads an invalid file type.",
+    "message":"这不是一个图像文件。请上传.png、.gif 或.jpg 文件。"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "showlinkstolists2":{
+    "description":"Option on the 'Filter lists' tab of the Options page",
+    "message":"显示过滤列表的网址"
+  },
+  "acceptableadsoption":{
+    "description":"option on the 'General' tab",
+    "message":"允许一些非侵入式广告"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"瑞典文"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"从列表中移除"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":"——选择语言——"
+  },
+  "filtereasylist_plus_french":{
+    "description":"language",
+    "message":"法文"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"编辑"
+  },
   "tabsupport":{
     "description":"A tab on the options page",
     "message":"技术支持"
   },
-  "adreport_server_response_error__manual_msg_step1":{
-    "description":"Error message shown when the server has an unrecoverable error during the submission of an ad or bug report.",
-    "message":"请移步<a>我们的技术支持站点</a>。"
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"按网址屏蔽广告"
   },
-  "safaricontentblockingpausemessage":{
-    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
-    "message":"要在启用内容屏蔽的情况下暂停AdBlock，请选择 Safari (菜单栏中) > 偏好设置 > 扩展 > AdBlock，并取消\"启用AdBlock\"。"
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"版本 $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "firefox_explanation":{
+    "description":"Explanation of the Check-in-Firefox or Chrome step in the ad reporter",
+    "message":"这个问题的目的是确定谁应当接收您的报告。如果您没有正确地回答这个问题，您的报告会送至错误的人手中，以致它被忽略。"
+  },
+  "adreportvoluntary":{
+    "description":"Introduction of the ad reporting page",
+    "message":"报告广告是自愿的。它有助于让过滤列表的维护人员帮助所有人屏蔽这个广告。如果您现在不想帮助他人，没关系。关闭这个页面然后自行<a>屏蔽这个广告</a>。"
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"是"
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"您可以<a>免费获取</a>AdBlock源代码！"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"荷兰文"
+  },
+  "adreport_email_privacy":{
+    "description":"Let the user know that their email address won't be used for reasons other than contacting them about their bug or ad report.",
+    "message":"我们只会在需要更多的信息时使用此地址与您联系。"
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"页面上只有<b>1</b>个匹配项目被屏蔽。"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"$hours$小时前更新",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"返回"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "clickdisableaa":{
+    "description":"Instruction on ad report page",
+    "message":"单击此选项: <a>禁用可接受广告</a>"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"应用的网域"
+  },
+  "adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"AdBlock更新"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "noresourcessend2":{
+    "description":"Resource list page: error message",
+    "message":"出错了。没有资源被发送。页面即将关闭。请尝试重新加载该网站。"
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"了解更多关于恶意软件的信息"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"网站:"
+  },
+  "filteracceptable_ads":{
+    "description":"A filter list",
+    "message":"可接受广告 (推荐)"
   },
   "catblock_replaceadswithcats":{
     "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
     "message":"Replace ads with pictures of cats"
   },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"看上去不错"
+  "safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"要在启用内容屏蔽的情况下暂停AdBlock，请选择 Safari (菜单栏中) > 偏好设置 > 扩展 > AdBlock，并取消\"启用AdBlock\"。"
   },
-  "disableforchromestepone":{
-    "description":"Step 1 for disabling Chrome extensions",
-    "message":"打开<a href='#'>扩展程序</a>页面。"
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock - 点击查看详情"
+  },
+  "disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"禁用除AdBlock之外的所有扩展:"
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,681 +1,175 @@
 {
-  "adblockreportinganad":{
-    "description":"Title of the ad report page",
-    "message":"AdBlock - 廣告回報"
+  "filterdanish":{
+    "description":"language",
+    "message":"丹麥文"
   },
-  "adblockinglist":{
-    "description":"List for subscribed ad blocking fiters",
-    "message":"廣告過濾清單"
+  "spread_the_word":{
+    "description":"Text of a share link",
+    "message":"將AdBlock推薦給更多人使用！"
   },
-  "modifydomain":{
-    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
-    "message":"網站:"
+  "questionoridea":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"有任何問題或者是新的點子？"
   },
   "catblock_whatmakesadblocktick":{
     "description":"Subtitle on the Support tab of the options",
     "message":"Want to see what makes CatBlock tick?"
   },
-  "malwarenotfound":{
-    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
-    "message":"沒有偵測到已知的惡意軟體"
-  },
-  "adblock_click_for_details":{
-    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
-    "message":"AdBlock-點擊查看詳情"
-  },
-  "catblock_disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
-  },
-  "updatedhoursago":{
-    "description":"Label for subscription",
-    "message":"$hours$ 小時前更新",
-    "placeholders":{
-      "hours":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "filterswedish":{
-    "description":"A filter list",
-    "message":"瑞典文"
-  },
-  "whatsnew":{
-    "description":"Link to display the changelog on the Support tab of the options",
-    "message":"在新版中有哪些新功能？ 請參考 <a style='cursor:pointer;'>更新日誌</a>！"
-  },
-  "blockmoreads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"阻擋更多廣告:"
-  },
-  "lang_russian":{
-    "description":"language",
-    "message":"俄文"
-  },
-  "pwyw":{
-    "description":"Text of a payment request link",
-    "message":"想付多少，就付多少！"
-  },
-  "unsubscribedlabel":{
-    "description":"Status label",
-    "message":"已取消訂閱。"
-  },
-  "linkblockadbyurl":{
-    "description":"Link on the 'Customize' tab",
-    "message":"依網址阻擋廣告"
-  },
-  "filtereasylist_plus_greek":{
-    "description":"language",
-    "message":"希臘文"
-  },
-  "filterchinese":{
-    "description":"language",
-    "message":"中文"
-  },
-  "linkhidesection":{
-    "description":"Link on the 'Customize' tab",
-    "message":"隱藏部分頁面"
-  },
-  "filtereasylist_plus_spanish":{
-    "description":"language",
-    "message":"西班牙文"
-  },
-  "filtermalware":{
-    "description":"A filter list",
-    "message":"惡意軟體防護"
-  },
-  "blacklisteroptions1":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"您認為下列哪個規則會在瀏覽頁面時阻擋此廣告？"
-  },
-  "enable_adblock":{
-    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
-    "message":"在此頁面上啟用AdBlock"
-  },
-  "buttonback":{
-    "description":"Back to previous wizard page button",
-    "message":"返回"
-  },
-  "catblock_malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"Should CatBlock notify you when it detects malware?"
-  },
-  "filterlistsrock":{
-    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
-    "message":"阻擋最多網站的過濾清單。 你可以:"
-  },
-  "sourcecode":{
-    "description":"Link to the source code of AdBlock on the Support tab of the options",
-    "message":"原始碼是<a> 開源的 </a>！"
-  },
-  "catblock_storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
-  },
-  "catblock_status_paused":{
-    "description":"Message shown in toolbar button when CatBlock is paused",
-    "message":"CatBlock is paused."
-  },
-  "linkunblock":{
-    "description":"Link on the 'Customize' tab",
-    "message":"顯示廣告在一個網頁或網域"
-  },
-  "blacklistersinglematch":{
-    "description":"Tells the user only one match was found",
-    "message":"頁面上只有 <b>1</b> 個匹配項目被阻擋。"
-  },
-  "filtersavewarning":{
-    "description":"Warning when blacklisting manually",
-    "message":"小心: 如果在這裡的設定出錯，包含官方的過濾清單，可能會失效！<br/>參閱<a>過濾規則語法教學</a>來正確地添加進階黑名單、白名單規則。"
-  },
-  "failedtofetchfilter":{
-    "description":"Error messagebox",
-    "message":"無法獲取此過濾清單！"
-  },
-  "generaloptions":{
-    "description":"Title of first tab page",
-    "message":"一般選項"
-  },
-  "adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
-    "message":"AdBlock 不會在符合此規則的網域啟用:"
-  },
-  "nodefaultfilter1":{
-    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
-    "message":"我們沒有這個語言的預設過濾清單。<br/>請嘗試尋找一個適合的清單來支援這個語言 $link$ 或者 自行在選項中『自訂』分頁加入過濾規則。",
-    "placeholders":{
-      "link":{
-        "example":"<a>here</a>",
-        "content":"<a id='link'></a>"
-      }
-    }
-  },
-  "subscribebutton":{
-    "description":"Subscribe to a list button",
-    "message":"訂閱"
-  },
-  "advanced_options2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"我是進階玩家，請顯示進階選項"
-  },
-  "catblock_disableallextensions":{
-    "description":"Instruction on ad report page",
-    "message":"Disable all extensions except for CatBlock."
-  },
-  "hide_this_button":{
-    "description":"Toolbar button menu entry to hide the AdBlock button",
-    "message":"隱藏這個按鈕"
-  },
-  "updatenowmessage2":{
-    "description":"Update filters text + button",
-    "message":"AdBlock會自動取得更新。 您也可以<a>現在馬上更新</a>"
-  },
-  "clickupdatefilters":{
-    "description":"Instruction on ad report page",
-    "message":"點選: <a>更新過濾清單！</a>"
-  },
-  "format_site1_site2_site3":{
-    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
-    "message":"格式: ~site1.com|~site2.com|~news.site3.org"
-  },
-  "blacklisteroptionstitle":{
-    "description":"Blacklister options page title",
-    "message":"最後一步：此廣告是由什麼組成的？"
-  },
-  "blacklistermatches":{
-    "description":"Tells the user multiple matches were found",
-    "message":"頁面上有 $matchcount$ 個匹配項目被阻擋。",
-    "placeholders":{
-      "matchcount":{
-        "example":"5",
-        "content":"$1"
-      }
-    }
-  },
-  "contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"也請參考我們的<a>網頁</a>來看看有哪些人對AdBlock做出了貢獻"
-  },
-  "filtereasylist_plus_indonesian":{
-    "description":"A filter list",
-    "message":"印尼文"
-  },
-  "headertype":{
-    "description":"Resource list page: title of a column",
-    "message":"類型"
-  },
-  "update_available":{
-    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
-    "message":"AdBlock 有更新摟！ 請至 $here$ 更新. <br> 注意： 如果你想要自動取得這些更新，您只需要點選 Safari > 設定 >  擴充 > 更新 <br> 然後選擇 『自動安裝更新』",
-    "placeholders":{
-      "here":{
-        "example":"<a>here</a>",
-        "content":"<a id='here'></a>"
-      }
-    }
-  },
-  "filterturkish":{
-    "description":"A filter list",
-    "message":"土耳其文"
-  },
-  "whats_this":{
-    "description":"Text of a link pointing to the explanation of a new feature",
-    "message":"這是？"
-  },
-  "catblock_pause_adblock":{
-    "description":"Menu entry to pause CatBlock",
-    "message":"Pause CatBlock"
-  },
-  "customfilters":{
-    "description":"List for custom filters the user subscribed to",
-    "message":"自訂過濾清單"
-  },
-  "filterlistlink":{
-    "description":"Explanation of the filter lists",
-    "message":"請不要訂閱過多清單，每新增一個清單都會讓瀏覽器的速度降低！更多詳細資訊和過濾清單可在<a>這裡</a>找到。"
-  },
-  "typestylesheet":{
+  "typeunknown":{
     "description":"A resource type",
-    "message":"style definition"
+    "message":"unknown"
   },
-  "blacklisternotsure":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"<b>不確定？</b>直接點選下方的 「阻擋」。"
-  },
-  "filtereasylist_plus_polish":{
-    "description":"language",
-    "message":"波蘭文"
-  },
-  "showcontextmenus2":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"在右鍵清單中顯示"
-  },
-  "flashads":{
-    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
-    "message":"影片和 Flash"
-  },
-  "block_this_ad":{
-    "description":"Context and popup menu entry",
-    "message":"阻擋這個廣告"
-  },
-  "updatedsecondsago":{
-    "description":"Label for subscription",
-    "message":"$seconds$ 秒前更新",
-    "placeholders":{
-      "seconds":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
-  },
-  "debuginfo":{
-    "description":"Users can click this link to provide debug information to AdBlock staff",
-    "message":"我們的研發團隊有像您索取除錯資訊(debug info) ?  <a href='#' id='debug'>點我</a>取得這些資訊 ！"
-  },
-  "typeobject_subrequest":{
-    "description":"A resource type",
-    "message":"object_subrequest"
-  },
-  "filterhungarian":{
-    "description":"language",
-    "message":"匈牙利文"
-  },
-  "invalidListUrl":{
-    "description":"Message when you subscribe to a non-list URL",
-    "message":"無效的清單網址。 它將會被刪除。"
-  },
-  "reportpubliclyavailable":{
-    "description":"Ad report page string, when you're about to submit a report",
-    "message":"注意： 您的報告可能會被公開。加入任何私人資料前小心留意。"
-  },
-  "reloadpageafterwhitelist":{
-    "description":"Checkbox on whitelist wizard",
-    "message":"重新載入該頁面"
-  },
-  "typepage":{
-    "description":"A resource type",
-    "message":"page"
-  },
-  "filterdutch":{
-    "description":"language",
-    "message":"荷蘭文"
-  },
-  "savereminder":{
-    "description":"Reminder to press save",
-    "message":"別忘了儲存！"
-  },
-  "blacklisterattrwillbe":{
-    "description":"Checkbox label",
-    "message":"$attribute$ 將為 $value$",
-    "placeholders":{
-      "attribute":{
-        "example":"class",
-        "content":"$1"
-      },
-      "value":{
-        "example":"AdBanner",
-        "content":"$2"
-      }
-    }
-  },
-  "close":{
-    "description":"Generic message for buttons that close a view or window",
-    "message":"關閉"
-  },
-  "blacklisterblockedelement":{
-    "description":"Tells the user what the blocked element is on the slider page",
-    "message":"被阻擋的頁面元素："
-  },
-  "blacklistereditinvalid1":{
-    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
-    "message":"無效的過濾規則: $exception$",
-    "placeholders":{
-      "exception":{
-        "example":"This filter is not supported",
-        "content":"$1"
-      }
-    }
-  },
-  "blacklisterwarningnofilter":{
-    "description":"Warns the user that no filter was specified",
-    "message":"警告：未指定過濾規則！"
-  },
-  "malwarenotificationcheckboxmessage":{
-    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
-    "message":"在 AdBlock 檢測到惡意軟體時發出通知"
-  },
-  "ad_report_please":{
-    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
-    "message":"如果你看到了廣告，請<a>回報廣告</a>而不是回報bug"
-  },
-  "show_ads_except_for":{
-    "description":"Section title for blacklisting section of Customize tab",
-    "message":"顯示廣告 <i>在所有網站</i> 除了這些網域..."
-  },
-  "wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"這個網站用了過時的技術，因此AdBlock 的功能無法在這個網站上運作。 你可以在選項頁中的『自訂』分頁中，手動把它們加入黑名單或者是白名單"
-  },
-  "show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
-    "message":"在選單中顯示 AdBlock 阻擋了多少廣告"
-  },
-  "options":{
-    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
-    "message":"選項"
-  },
-  "whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"不要在此網域使用 AdBlock..."
-  },
-  "typexmlhttprequest":{
-    "description":"A resource type",
-    "message":"xmlhttprequest"
-  },
-  "catblock_latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
-    "message":"CatBlock is up-to-date!"
-  },
-  "blocked_ads":{
-    "description":"Title for popup menu section showing number of ads blocked",
-    "message":"被阻擋的廣告："
-  },
-  "filteradblock_custom":{
-    "description":"A filter list",
-    "message":"AdBlock 自訂過濾清單 （推薦）"
-  },
-  "languagedropdowndescription":{
-    "description":"Dropdown list for language-specific filters",
-    "message":"替其他語言新增過濾清單 "
-  },
-  "filterlatvian":{
-    "description":"A filter list",
-    "message":"拉脫維亞文"
-  },
-  "enableotherextensionscomplete":{
-    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
-    "message":"所有先前停用的擴充已重新啟用"
-  },
-  "blockurlwithtext":{
-    "description":"Message of the url-blocking area",
-    "message":"阻擋包含以下字串的網址"
-  },
-  "csstomatch":{
-    "description":"Message of the css-hiding area",
-    "message":"符合的CSS"
-  },
-  "operabutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
-    "message":"如需隱藏按鈕，請到  opera://extensions 並且點選 『從工具列上隱藏』選項。 你可以取消該選項以顯示該按鈕"
-  },
-  "clickthead":{
-    "description":"When you have to click the ad to continue",
-    "message":"點選要阻擋的廣告，AdBlock 會協助您設定。"
-  },
-  "catblock_example_flickr_search":{
-    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
-    "message":"a search for photos (e.g. <i>sailboat race</i>)"
-  },
-  "report_ad_on_page":{
-    "description":"Entry in the AdBlock button menu",
-    "message":"回報這個頁面的廣告"
-  },
-  "catblock_excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"The domain or url where CatBlock shouldn't block anything"
-  },
-  "catblock_tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"Customize CatBlock"
-  },
-  "catblock_disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"CatBlock is disabled on this page."
-  },
-  "filterrussian":{
-    "description":"Language names for a filter list",
-    "message":"俄羅斯和烏克蘭"
-  },
-  "typescript":{
-    "description":"A resource type",
-    "message":"script"
-  },
-  "adblocksupport":{
-    "description":"Title of the support tab",
-    "message":"AdBlock 支援與協助"
-  },
-  "tabcustomizetitle":{
-    "description":"Title of the customize tab",
-    "message":"自訂 AdBlock"
-  },
-  "latest_version":{
-    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
-    "message":"AdBlock 是最新的！"
-  },
-  "dont_run_on_pages_on_domain":{
-    "description":"Menu entry to open the whitelist wizard",
-    "message":"不在這個網域的頁面使用"
-  },
-  "filterisraeli":{
-    "description":"language",
-    "message":"希伯來文"
-  },
-  "disabled_by_filter_lists":{
-    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
-    "message":"抱歉, 因為你的一個過濾清單，AdBlock 在這個頁面被關閉"
-  },
-  "catblock_safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
-  },
-  "catblock_add_more_photos":{
-    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
-    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
-  },
-  "undo_last_block":{
-    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
-    "message":"取消我在此網域上建立的阻擋規則"
-  },
-  "blacklistereditfilter":{
-    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
-    "message":"請在下面輸入正確的過濾規則，並點選 「確定」"
-  },
-  "updateddayago":{
-    "description":"Label for subscription",
-    "message":"1 天前更新"
-  },
-  "betalabel":{
-    "description":"Label for beta features in AdBlock Options",
-    "message":"Beta"
+  "tabgeneral":{
+    "description":"A tab on the options page",
+    "message":"一般"
   },
   "blocked_n_on_this_page":{
     "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked on this page. $count$ will be a number between 1 and 999.",
     "message":"$count$ 此頁面上",
     "placeholders":{
       "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123</a>"
+        "content":"<a>123</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
       }
     }
   },
-  "updatedhourago":{
-    "description":"Label for subscription",
-    "message":"1 小時前更新"
+  "invalidListUrl":{
+    "description":"Message when you subscribe to a non-list URL",
+    "message":"無效的清單網址。 它將會被刪除。"
   },
-  "optionsversion":{
-    "description":"Version number",
-    "message":"版本 $version$",
-    "placeholders":{
-      "version":{
-        "example":"2.0.9",
-        "content":"$1"
-      }
-    }
+  "filtereasylist_plus_polish":{
+    "description":"language",
+    "message":"波蘭文"
   },
-  "removefromlist":{
-    "description":"Label to remove a custom filter",
-    "message":"從清單列表中移除"
+  "generaloptions":{
+    "description":"Title of first tab page",
+    "message":"一般選項"
   },
-  "other":{
-    "description":"Multiple choice option",
-    "message":"其他"
+  "catblock_status_disabled":{
+    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
+    "message":"CatBlock can not run on this domain."
   },
-  "typehiding":{
-    "description":"A resource type",
-    "message":"hiding"
+  "csstomatch":{
+    "description":"Message of the css-hiding area",
+    "message":"符合的CSS"
   },
-  "tabfilterlists":{
-    "description":"A tab on the options page",
-    "message":"過濾清單"
-  },
-  "cantblockflashwarning":{
-    "description":"Text of the final ad report question",
-    "message":"該廣告是出現在影片或 Flash 遊戲等外掛程式中？"
-  },
-  "otherfilters":{
-    "description":"List for other filters the user subscribed to",
-    "message":"其他的過濾清單"
-  },
-  "orchrome":{
-    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
-    "message":"或是 Chrome"
-  },
-  "buttonblockit":{
-    "description":"Block button",
-    "message":"阻擋"
-  },
-  "subscribingfinished":{
-    "description":"abp: link subscriber result",
-    "message":"完成"
-  },
-  "block_an_ad_on_this_page":{
-    "description":"Toolbar button menu entry and context menu entry",
-    "message":"阻擋此頁面上的廣告"
+  "close":{
+    "description":"Generic message for buttons that close a view or window",
+    "message":"關閉"
   },
   "refusetocheck":{
     "description":"User is telling us they don't wish to investigate something for us",
     "message":"我不想檢查這個"
   },
-  "catblock_options":{
-    "description":"Title of the CatBlock options page tab",
-    "message":"CatBlock Options"
+  "adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"AdBlock 不會在符合此規則的網域啟用:"
   },
-  "lang_english":{
+  "show_ads_except_for":{
+    "description":"Section title for blacklisting section of Customize tab",
+    "message":"顯示廣告 <i>在所有網站</i> 除了這些網域..."
+  },
+  "filtersavewarning":{
+    "description":"Warning when blacklisting manually",
+    "message":"小心: 如果在這裡的設定出錯，包含官方的過濾清單，可能會失效！<br/>參閱<a>過濾規則語法教學</a>來正確地添加進階黑名單、白名單規則。"
+  },
+  "lang_slovak":{
     "description":"language",
-    "message":"英文"
+    "message":"斯洛伐克文"
   },
-  "tabcustomize":{
-    "description":"A tab on the options page",
-    "message":"自訂"
-  },
-  "pause_adblock":{
-    "description":"Menu entry to pause AdBlock",
-    "message":"暫停 AdBlock"
-  },
-  "subscribeconfirm":{
-    "description":"Prompt question before subscribing to the filter list",
-    "message":"您確定要訂閱 $title$ 過濾清單嗎",
+  "checkinfirefoxtitle":{
+    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
+    "message":"在 Firefox中檢查 $chrome$",
     "placeholders":{
-      "title":{
-        "example":"Prebake",
-        "content":"$1"
+      "chrome":{
+        "content":"<span id='chrome1'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
       }
     }
-  },
-  "manuallyenableotherextensions":{
-    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
-    "message":"請至擴充頁面來啟用您以前曾經停用的擴充"
-  },
-  "blockdomain":{
-    "description":"Message of the url and css -blocking area",
-    "message":"套用的網域"
-  },
-  "filtereasylist_plun_korean":{
-    "description":"language",
-    "message":"韓文"
-  },
-  "modifypath":{
-    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
-    "message":"頁面:"
-  },
-  "foundbug":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"發現了bug？"
-  },
-  "slidertitle":{
-    "description":"Blacklister slider page title",
-    "message":"第一步:找出要阻擋的目標"
-  },
-  "lang_czech":{
-    "description":"language",
-    "message":"捷克文"
-  },
-  "you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"使用越多的過濾清單會使 AdBlock 越慢。 過多的過濾清單會使瀏覽器在部份網站當機。 點選『確認』繼續。"
-  },
-  "oradblockforchrome":{
-    "description":"Used for placeholder in checkinfirefox_2 string",
-    "message":"或是 Chrome 版 AdBlock"
-  },
-  "blockanadtitle":{
-    "description":"Title of the first two dialogs of the blacklister",
-    "message":"阻擋廣告"
-  },
-  "catblock_contributors":{
-    "description":"Link to the contributors page on the Support tab of the options",
-    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
   },
   "catblock_debuginlogoption":{
     "description":"Checkbox on the 'General' tab of the Options page",
     "message":"Show debug statements in Console Log (which slows down CatBlock)"
   },
-  "filterdanish":{
+  "savebutton":{
+    "description":"Save button",
+    "message":"儲存"
+  },
+  "catblock_whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"Don't run CatBlock on..."
+  },
+  "filtereasylist_plus_romanian":{
     "description":"language",
-    "message":"丹麥文"
+    "message":"羅馬尼亞文"
   },
-  "typesub_frame":{
-    "description":"A resource type",
-    "message":"frame"
+  "chromebutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
+    "message":"如要隱藏按鈕，請按滑鼠右鍵並選擇隱藏按鈕。在 chrome://chrome/extensions 下，你可以再次顯示它。"
   },
-  "buttonedit":{
-    "description":"Edit filter manually button",
-    "message":"編輯"
+  "catblock_you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
   },
-  "findingads":{
-    "description":"When you press ctrl-shift-K the blacklister searches for ads",
-    "message":"正在尋找廣告...<br/><br/><i>這只需要一點時間。</i>"
+  "filterisraeli":{
+    "description":"language",
+    "message":"希伯來文"
   },
-  "excludedomainorurl":{
-    "description":"Message of the exclude area",
-    "message":"AdBlock　網域白名單"
+  "wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"這個網站用了過時的技術，因此AdBlock 的功能無法在這個網站上運作。 你可以在選項頁中的『自訂』分頁中，手動把它們加入黑名單或者是白名單"
   },
-  "sliderexplanation":{
-    "description":"Blacklister slider page message",
-    "message":"滑動控制器直到頁面上的廣告已被正確地阻擋。"
+  "filterczech":{
+    "description":"Language names for a filter list",
+    "message":"捷克和斯洛伐克"
   },
-  "blocked_n_in_total":{
-    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
-    "message":"$count$ 總阻擋數",
+  "catblock_wizardcantrunonframesets":{
+    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
+    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
+  },
+  "otherfilters":{
+    "description":"List for other filters the user subscribed to",
+    "message":"其他的過濾清單"
+  },
+  "options":{
+    "description":"The text of the link on chrome://chrome/extensions that gets you to the Options page for an extension",
+    "message":"選項"
+  },
+  "catblock_check_checkbox":{
+    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
+    "message":"Check the checkbox by the sets of pictures that you want to use."
+  },
+  "updatenowmessage2":{
+    "description":"Update filters text + button",
+    "message":"AdBlock會自動取得更新。 您也可以<a>現在馬上更新</a>"
+  },
+  "fetchinglabel":{
+    "description":"Status label",
+    "message":"正在獲取清單...請稍候。"
+  },
+  "linkunblock":{
+    "description":"Link on the 'Customize' tab",
+    "message":"顯示廣告在一個網頁或網域"
+  },
+  "filterturkish":{
+    "description":"A filter list",
+    "message":"土耳其文"
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "you_know_thats_a_bad_idea_right":{
+    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
+    "message":"使用越多的過濾清單會使 AdBlock 越慢。 過多的過濾清單會使瀏覽器在部份網站當機。 點選『確認』繼續。"
+  },
+  "nodefaultfilter1":{
+    "description":"Instructions on ad report page pointing users to EasyList subscriptions list. 'Customize' should be the same text as the name of the 'Customize' tab.",
+    "message":"我們沒有這個語言的預設過濾清單。<br/>請嘗試尋找一個適合的清單來支援這個語言 $link$ 或者 自行在選項中『自訂』分頁加入過濾規則。",
     "placeholders":{
-      "count":{
-        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating.",
-        "content":"<a>123,456</a>"
-      }
-    }
-  },
-  "reloadadpage":{
-    "description":"Instruction on ad report page",
-    "message":"重新載入出現廣告的頁面。"
-  },
-  "checkinfirefox_1":{
-    "description":"instruction for how to check Firefox/Chrome for a reported ad",
-    "message":"如果您尚未安裝的話，請先安裝 Firefox $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome2'></span>"
+      "link":{
+        "content":"<a id='link'></a>",
+        "example":"<a>here</a>"
       }
     }
   },
@@ -683,212 +177,351 @@
     "description":"Link text to un-whitelist a page, displayed immediately after 'CatBlock is disabled on this page'",
     "message":"Enable CatBlock on this page"
   },
+  "clickthead":{
+    "description":"When you have to click the ad to continue",
+    "message":"點選要阻擋的廣告，AdBlock 會協助您設定。"
+  },
+  "typestylesheet":{
+    "description":"A resource type",
+    "message":"style definition"
+  },
   "adblockupdates":{
     "description":"Subtitle on the Support tab of the options",
     "message":"AdBlock 更新狀態"
   },
-  "no":{
-    "description":"A negative response to a question",
-    "message":"否"
+  "disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"抱歉, 因為你的一個過濾清單，AdBlock 在這個頁面被關閉"
+  },
+  "malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"在 AdBlock 檢測到惡意軟體時發出通知"
+  },
+  "updateddayago":{
+    "description":"Label for subscription",
+    "message":"1 天前更新"
+  },
+  "catblock_show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
+    "message":"Show number of ads blocked on CatBlock menu"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "blacklisternofilter":{
+    "description":"Warning if the user hasn't specified a filter",
+    "message":"未指定過濾規則！"
+  },
+  "filtereasylist_plus_german":{
+    "description":"language",
+    "message":"德文"
+  },
+  "filterstabtitle":{
+    "description":"Title of the filter list tab",
+    "message":"訂閱過濾清單"
+  },
+  "filtereasylist_plus_greek":{
+    "description":"language",
+    "message":"希臘文"
+  },
+  "catblock_safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"You are using an old version of Safari. Get the latest version in order to use the CatBlock toolbar button to pause CatBlock, whitelist websites, and report ads. <a>Upgrade now</a>."
+  },
+  "updatedsecondsago":{
+    "description":"Label for subscription",
+    "message":"$seconds$ 秒前更新",
+    "placeholders":{
+      "seconds":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "blacklisternotsure":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"<b>不確定？</b>直接點選下方的 「阻擋」。"
+  },
+  "work_around_hulu_problems":{
+    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
+    "message":"套用變通方法以避開Hulu.com 無法正常播放的問題 （需要重新啟動瀏覽器）"
+  },
+  "supportsite":{
+    "description":"Link to the support site on the Support tab of the options",
+    "message":"請來我們的<a>技術與支援網站</a>讓我們聆聽您的意見！"
+  },
+  "only_block_ads_on_these_sites":{
+    "description":"Label for textbox where user enters a list of sites on Customize tab",
+    "message":"只在以下網站啟用:"
+  },
+  "catblock_you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"You can slide below to change exactly what pages CatBlock won't run on."
+  },
+  "tabcustomize":{
+    "description":"A tab on the options page",
+    "message":"自訂"
+  },
+  "checkinternetconnection":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
+    "message":"你必須連上網路才能回報廣告"
+  },
+  "buttonok":{
+    "description":"OK button",
+    "message":"確定"
+  },
+  "linkhidesection":{
+    "description":"Link on the 'Customize' tab",
+    "message":"隱藏部分頁面"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "show_on_adblock_menu":{
+    "description":"Label for checkbox letting user choose whether the AdBlock popup menu should show the number of ads blocked",
+    "message":"在選單中顯示 AdBlock 阻擋了多少廣告"
+  },
+  "adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"AdBlock - 廣告回報"
+  },
+  "filtereasylist_plus_bulgarian":{
+    "description":"language",
+    "message":"保加利亞文"
+  },
+  "dont_run_on_pages_on_domain":{
+    "description":"Menu entry to open the whitelist wizard",
+    "message":"不在這個網域的頁面使用"
+  },
+  "customfilters":{
+    "description":"List for custom filters the user subscribed to",
+    "message":"自訂過濾清單"
+  },
+  "blockmoreads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"阻擋更多廣告:"
   },
   "lang_ukranian":{
     "description":"language",
     "message":"烏克蘭文"
   },
-  "updatedminutesago":{
-    "description":"Label for subscription",
-    "message":"$minutes$ 分鐘前更新",
-    "placeholders":{
-      "minutes":{
-        "example":"15",
-        "content":"$1"
-      }
-    }
+  "blacklistertype":{
+    "description":"node name is called 'Type'",
+    "message":"類型"
+  },
+  "catblock_status_paused":{
+    "description":"Message shown in toolbar button when CatBlock is paused",
+    "message":"CatBlock is paused."
+  },
+  "excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"AdBlock　網域白名單"
+  },
+  "blacklisterwarningnofilter":{
+    "description":"Warns the user that no filter was specified",
+    "message":"警告：未指定過濾規則！"
+  },
+  "blockurlwithtext":{
+    "description":"Message of the url-blocking area",
+    "message":"阻擋包含以下字串的網址"
+  },
+  "buttonexclude":{
+    "description":"Button for excluding a domain in the whitelister dialog",
+    "message":"排除"
   },
   "filtereasylist_plus_french":{
     "description":"language",
     "message":"法文"
   },
-  "clickdisableotherextensions":{
-    "description":"On the ad report page, an alternative way to disable other extensions",
-    "message":"<b> 或者 </b>, 按下此按鈕以便完成上述所有操作: <a> 停用所有擴充 </a>"
+  "blacklisteroptionstitle":{
+    "description":"Blacklister options page title",
+    "message":"最後一步：此廣告是由什麼組成的？"
   },
-  "typeobject":{
-    "description":"A resource type",
-    "message":"interactive object"
+  "catblock_pause_adblock":{
+    "description":"Menu entry to pause CatBlock",
+    "message":"Pause CatBlock"
   },
-  "updatedrightnow":{
-    "description":"Label for subscription",
-    "message":"剛剛更新"
+  "buttonlooksgood":{
+    "description":"Looks good button",
+    "message":"看來不錯"
   },
-  "savebutton":{
-    "description":"Save button",
-    "message":"儲存"
+  "catblock_show_on_adblock_button":{
+    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
+    "message":"Show on CatBlock button"
   },
-  "warning_overrules_filters":{
-    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
-    "message":"警告: 你會在其他網站看見廣告!<br>你會在其他網站看見廣告。"
+  "tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"自訂 AdBlock"
   },
-  "malwarenotificationdisablethesemessages":{
-    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
-    "message":"停用這些通知"
+  "malwarenotfound":{
+    "description":"On the ad report page, the ads the user is seeing are probably not caused by malware/adware",
+    "message":"沒有偵測到已知的惡意軟體"
   },
-  "subscribingtitle":{
-    "description":"abp: link subscriber title",
-    "message":"正在訂閱過濾清單..."
+  "dont_run_on_this_page":{
+    "description":"Menu entry to whitelist a page",
+    "message":"不要在這個頁面使用"
+  },
+  "filtereasylist_plus_finnish":{
+    "description":"language",
+    "message":"芬蘭文"
+  },
+  "adblockinglist":{
+    "description":"List for subscribed ad blocking fiters",
+    "message":"廣告過濾清單"
   },
   "updateddaysago":{
     "description":"Label for subscription",
     "message":"$days$ 天前更新",
     "placeholders":{
       "days":{
-        "example":"15",
-        "content":"$1"
+        "content":"$1",
+        "example":"15"
       }
     }
   },
-  "typesubdocument":{
+  "typeobject":{
     "description":"A resource type",
-    "message":"frame"
+    "message":"interactive object"
   },
-  "filtereasyprivacy":{
-    "description":"A filter list",
-    "message":"EasyPrivacy (隱私保護)"
+  "blacklisteroptions1":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"您認為下列哪個規則會在瀏覽頁面時阻擋此廣告？"
   },
-  "malwarenotificationlearnmore":{
-    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
-    "message":"瞭解更多惡意軟體的相關資訊"
+  "blocked_ads":{
+    "description":"Title for popup menu section showing number of ads blocked",
+    "message":"被阻擋的廣告："
   },
-  "filterczech":{
-    "description":"Language names for a filter list",
-    "message":"捷克和斯洛伐克"
-  },
-  "optionstitle":{
-    "description":"Title for the options page",
-    "message":"AdBlock 選項"
-  },
-  "cleanuplist2":{
-    "description":"Option at the bottom of the 'Customize' options tab",
-    "message":"清空此清單"
-  },
-  "filterantisocial":{
-    "description":"A filter list",
-    "message":"反社群網站過濾器  （社群網站的按鈕會被自動過濾掉）"
-  },
-  "debuginlogoption":{
-    "description":"Checkbox on the 'General' tab of the Options page",
-    "message":"在 Console Log 中顯示除錯資訊（將會降低 AdBlock 效能）"
-  },
-  "dropboxerrorforfilters":{
-    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
-    "message":"你已經到達了 Dropbox 空間限制。 請在您的過濾清單中移除一些項目並再試一次"
-  },
-  "unpause_adblock":{
-    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
-    "message":"繼續AdBlock的運作"
-  },
-  "catblock_unpause_adblock":{
-    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
-    "message":"Unpause CatBlock"
-  },
-  "filtereasylist_plus_german":{
-    "description":"language",
-    "message":"德文"
-  },
-  "blacklisterblocksalloftype":{
-    "description":"Warns the user that all elements of type X will be blocked",
-    "message":"注意：此過濾規則會阻擋頁面上所有的 $elementtype$ 元素！",
-    "placeholders":{
-      "elementtype":{
-        "example":"DIV",
-        "content":"$1"
-      }
-    }
-  },
-  "here":{
-    "description":"This message is injected in other strings as a link/button",
-    "message":"這裡 "
-  },
-  "work_around_hulu_problems":{
-    "description":"Advanced Options page checkbox, which users only need to use if Hulu.com videos break. It directs the user to restart their browser in order for changes to the checkbox to take effect.",
-    "message":"套用變通方法以避開Hulu.com 無法正常播放的問題 （需要重新啟動瀏覽器）"
-  },
-  "buttonexclude":{
-    "description":"Button for excluding a domain in the whitelister dialog",
-    "message":"排除"
-  },
-  "pagelanguagecheck":{
-    "description":"Question on ad report page",
-    "message":"此頁面使用什麼語言？"
-  },
-  "catblock_whitelistertitle2":{
-    "description":"The title of the whitelister dialog",
-    "message":"Don't run CatBlock on..."
-  },
-  "typeimage":{
-    "description":"A resource type",
-    "message":"image"
-  },
-  "translator_credit":{
-    "description":"Will be followed by a list of translator names (separate string)",
-    "message":"翻譯貢獻:"
-  },
-  "loading":{
-    "description":"Generic message displayed during processes that take some time",
-    "message":"載入中..."
-  },
-  "blacklistclickmessage":{
-    "description":"Message at the top of the blacklist options tab",
-    "message":"右鍵點選頁面上的廣告來阻擋它 ─ 或在此處手動阻擋。"
-  },
-  "chromebutton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Chrome displays when you right click a toolbar button.",
-    "message":"如要隱藏按鈕，請按滑鼠右鍵並選擇隱藏按鈕。在 chrome://chrome/extensions 下，你可以再次顯示它。"
-  },
-  "filtereasylist_plus_romanian":{
-    "description":"language",
-    "message":"羅馬尼亞文"
-  },
-  "manualexcludefilteredit":{
-    "description":"Subtitle on the 'Customize' tab",
-    "message":"編輯被停用的清單："
-  },
-  "catblock_you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"You can slide below to change exactly what pages CatBlock won't run on."
-  },
-  "somethingwentwrong":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
-    "message":"在檢查更新的時候出了點錯誤"
-  },
-  "safaributton_how_to_hide2":{
-    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
-    "message":"如需隱藏此按鈕，請到  opera://extensions 並且點選 『從工具列上隱藏』選項。 你可以取消該選項以再次顯示此按鈕"
-  },
-  "updatedminuteago":{
-    "description":"Label for subscription",
-    "message":"1 分鐘前更新"
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   },
   "typemain_frame":{
     "description":"A resource type",
     "message":"page"
   },
-  "catblock_add_photos":{
-    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
-    "message":"Add Photos"
+  "filtereasylist_plun_korean":{
+    "description":"language",
+    "message":"韓文"
   },
-  "catblock_example_flickr_url":{
-    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
-    "message":"a Flickr photoset URL (e.g. $example$)",
+  "undo_last_block":{
+    "description":"Menu entry to let the user cancel the result of running the blacklist wizard",
+    "message":"取消我在此網域上建立的阻擋規則"
+  },
+  "manualfilteredit":{
+    "description":"Subtitle on the 'Customize' tab",
+    "message":"手動編輯您的過濾規則："
+  },
+  "filtereasylist":{
+    "description":"A filter list",
+    "message":"EasyList （推薦）"
+  },
+  "slidertitle":{
+    "description":"Blacklister slider page title",
+    "message":"第一步:找出要阻擋的目標"
+  },
+  "contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"也請參考我們的<a>網頁</a>來看看有哪些人對AdBlock做出了貢獻"
+  },
+  "modifydomain":{
+    "description":"Caption for the whitelist wizard slider that modifies the domain part of a URL",
+    "message":"網站:"
+  },
+  "here":{
+    "description":"This message is injected in other strings as a link/button",
+    "message":"這裡 "
+  },
+  "typepopup":{
+    "description":"A resource type",
+    "message":"彈出視窗"
+  },
+  "latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for AdBlock",
+    "message":"AdBlock 是最新的！"
+  },
+  "reloadpageafterwhitelist":{
+    "description":"Checkbox on whitelist wizard",
+    "message":"重新載入該頁面"
+  },
+  "englishonly":{
+    "description":"Lets the user know that a link/page is available in English only",
+    "message":"僅限英文"
+  },
+  "pagelanguagecheck":{
+    "description":"Question on ad report page",
+    "message":"此頁面使用什麼語言？"
+  },
+  "status_paused":{
+    "description":"Message shown in toolbar button when AdBlock is paused",
+    "message":"AdBlock 已暫停"
+  },
+  "clickdisableotherextensions":{
+    "description":"On the ad report page, an alternative way to disable other extensions",
+    "message":"<b> 或者 </b>, 按下此按鈕以便完成上述所有操作: <a> 停用所有擴充 </a>"
+  },
+  "whatsnew":{
+    "description":"Link to display the changelog on the Support tab of the options",
+    "message":"在新版中有哪些新功能？ 請參考 <a style='cursor:pointer;'>更新日誌</a>！"
+  },
+  "filterantisocial":{
+    "description":"A filter list",
+    "message":"反社群網站過濾器  （社群網站的按鈕會被自動過濾掉）"
+  },
+  "findingads":{
+    "description":"When you press ctrl-shift-K the blacklister searches for ads",
+    "message":"正在尋找廣告...<br/><br/><i>這只需要一點時間。</i>"
+  },
+  "advanced_options2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"我是進階玩家，請顯示進階選項"
+  },
+  "blockanadtitle":{
+    "description":"Title of the first two dialogs of the blacklister",
+    "message":"阻擋廣告"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "warning_overrules_filters":{
+    "description":"Message on the 'Customize' tab of the options page, explaining the danger of adding a blacklisting filter",
+    "message":"警告: 你會在其他網站看見廣告!<br>你會在其他網站看見廣告。"
+  },
+  "enableotherextensionscomplete":{
+    "description":"On the ad report page, alert notifying users that we've re-enabled extensions that were previously disabled",
+    "message":"所有先前停用的擴充已重新啟用"
+  },
+  "customfilterserrormessage":{
+    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
+    "message":"以下過濾器 <br/> $filter$ <br/> 有錯誤訊息：<br/> $message$",
     "placeholders":{
-      "example":{
-        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      "message":{
+        "content":"$2",
+        "example":"invalid filter"
+      },
+      "filter":{
+        "content":"$1",
+        "example":"@@.ad"
       }
     }
   },
-  "catblock_you_know_thats_a_bad_idea_right":{
-    "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
-    "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  "whatmakesadblocktick":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"想看看 AdBlock 是如何精益求精的嗎？"
+  },
+  "filteradblock_custom":{
+    "description":"A filter list",
+    "message":"AdBlock 自訂過濾清單 （推薦）"
+  },
+  "catblock_disableallextensions":{
+    "description":"Instruction on ad report page",
+    "message":"Disable all extensions except for CatBlock."
+  },
+  "whats_this":{
+    "description":"Text of a link pointing to the explanation of a new feature",
+    "message":"這是？"
   },
   "catblock_update_available":{
     "description":"On the Options > Support page, shows when there are updates available for CatBl",
@@ -900,265 +533,83 @@
       }
     }
   },
-  "orenteraurl":{
-    "description":"Link for custom subscription",
-    "message":"或輸入過濾清單網址："
+  "oradblockforchrome":{
+    "description":"Used for placeholder in checkinfirefox_2 string",
+    "message":"或是 Chrome 版 AdBlock"
   },
-  "safari50_updatenotice":{
-    "description":"A message shown to Safari 5.0 users urging them to upgrade",
-    "message":"你正在使用舊版的 Safari，請 <a>升級您的瀏覽器 </a> 以便使用在工具列按鈕中暫停 AdBlock，白名單，回報廣告等等最新的功能。"
+  "catblock_options":{
+    "description":"Title of the CatBlock options page tab",
+    "message":"CatBlock Options"
   },
-  "selectlanguage":{
-    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
-    "message":" --選擇語言-- "
+  "translator_credit":{
+    "description":"Will be followed by a list of translator names (separate string)",
+    "message":"翻譯貢獻:"
   },
-  "disableforsafaristepone":{
-    "description":"Step 1 for disabling Safari extensions",
-    "message":"選擇 Safari 選單 &rarr; 設定 &rarr; 擴充"
+  "format_site1_site2_site3":{
+    "description":"Example showing users how to input a list of sites on the Customize tab. You can translate the 'news' and 'siteN' but leave the '|'s and '~'s in place.",
+    "message":"格式: ~site1.com|~site2.com|~news.site3.org"
   },
-  "stop_blocking_ads":{
-    "description":"Section header on the 'Customize' tab",
-    "message":"停止阻擋廣告:"
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
   },
-  "description2":{
-    "description":"Extension description in manifest. Should not exceed 132 characters.",
-    "message":"最受歡迎的 Chrome 擴充，有超過四千萬名的用戶正在用 AdBlock 阻擋網頁上的廣告"
+  "flashads":{
+    "description":"Title of the final ad report question if the ad didn't appear in Firefox",
+    "message":"影片和 Flash"
   },
-  "adstillappear":{
-    "description":"Question on ad report page",
-    "message":"廣告是否還在？"
+  "filterlistsrock":{
+    "description":"Header text on the Customize tab. 'Filter lists' should be the same text as the name of the 'Filter lists' tab.",
+    "message":"阻擋最多網站的過濾清單。 你可以:"
   },
-  "tabsupport":{
-    "description":"A tab on the options page",
-    "message":"支援與協助"
+  "safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"如需隱藏此按鈕，請到  opera://extensions 並且點選 『從工具列上隱藏』選項。 你可以取消該選項以再次顯示此按鈕"
   },
-  "filtereasylist_plus_bulgarian":{
+  "dropboxerrorforfilters":{
+    "description":"Message to Dropbox sync users on the Customize tab, custom filters / disabled.",
+    "message":"你已經到達了 Dropbox 空間限制。 請在您的過濾清單中移除一些項目並再試一次"
+  },
+  "filterhungarian":{
     "description":"language",
-    "message":"保加利亞文"
+    "message":"匈牙利文"
   },
-  "whatmakesadblocktick":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"想看看 AdBlock 是如何精益求精的嗎？"
+  "orchrome":{
+    "description":"Used for placeholder in checkinfirefoxtitle and checkinfirefox_1 strings",
+    "message":"或是 Chrome"
   },
-  "subscribingfailed":{
-    "description":"abp: link subscriber result",
-    "message":"失敗"
+  "subscribebutton":{
+    "description":"Subscribe to a list button",
+    "message":"訂閱"
   },
-  "blacklisterthefilter":{
-    "description":"Blacklister attribute choosing page message",
-    "message":"即將套用的規則，仍可在選項中編輯："
+  "pwyw":{
+    "description":"Text of a payment request link",
+    "message":"想付多少，就付多少！"
   },
-  "manualfilteredit":{
+  "manualexcludefilteredit":{
     "description":"Subtitle on the 'Customize' tab",
-    "message":"手動編輯您的過濾規則："
-  },
-  "filteritalian":{
-    "description":"language",
-    "message":"義大利文"
-  },
-  "typepopup":{
-    "description":"A resource type",
-    "message":"彈出視窗"
-  },
-  "catblock_check_checkbox":{
-    "description":"Shown on the CatBlock tab on the options page. Don't translate the word CatBlock.",
-    "message":"Check the checkbox by the sets of pictures that you want to use."
-  },
-  "blacklistertype":{
-    "description":"node name is called 'Type'",
-    "message":"類型"
-  },
-  "lang_slovak":{
-    "description":"language",
-    "message":"斯洛伐克文"
-  },
-  "filterstabtitle":{
-    "description":"Title of the filter list tab",
-    "message":"訂閱過濾清單"
-  },
-  "dont_run_on_this_page":{
-    "description":"Menu entry to whitelist a page",
-    "message":"不要在這個頁面使用"
-  },
-  "only_block_ads_on_these_sites":{
-    "description":"Label for textbox where user enters a list of sites on Customize tab",
-    "message":"只在以下網站啟用:"
-  },
-  "supportsite":{
-    "description":"Link to the support site on the Support tab of the options",
-    "message":"請來我們的<a>技術與支援網站</a>讓我們聆聽您的意見！"
-  },
-  "status_paused":{
-    "description":"Message shown in toolbar button when AdBlock is paused",
-    "message":"AdBlock 已暫停"
-  },
-  "storage_quota_exceeded":{
-    "description":"Message shown when the user uses more storage than allowed by the browser",
-    "message":"你超出了 AdBlock 能使用的儲存空間。 請取消訂閱一些清單!"
-  },
-  "cantblockflash":{
-    "description":"Result of the final ad report question",
-    "message":"目前還無法阻擋在 Flash 或其他外掛程式中的廣告。此功能尚在等待瀏覽器與 WebKit 支援。"
-  },
-  "buttonok":{
-    "description":"OK button",
-    "message":"確定"
-  },
-  "fixityourself":{
-    "description":"Telling users who won't report an ad to us how to handle it for themselves",
-    "message":"您還是可以在「黑名單」頁面中手動阻擋此廣告。"
-  },
-  "tabgeneral":{
-    "description":"A tab on the options page",
-    "message":"一般"
-  },
-  "catblock_status_disabled":{
-    "description":"Message shown in toolbar button on web pages that disallow extensions, such as the Extensions Gallery or about:blank",
-    "message":"CatBlock can not run on this domain."
-  },
-  "catblock_wizardcantrunonframesets":{
-    "description":"Message (alert) shown when the user tries to use a blacklist/whitelist wizard on an old website",
-    "message":"This feature does not work on this site because it uses out of date technology. You can blacklist or whitelist resources manually in the 'Customize' tab of the options page."
-  },
-  "typeother":{
-    "description":"A resource type",
-    "message":"其他"
-  },
-  "blacklisternofilter":{
-    "description":"Warning if the user hasn't specified a filter",
-    "message":"未指定過濾規則！"
-  },
-  "catblock_show_on_adblock_button":{
-    "description":"Label for checkbox letting user choose whether the toolbar button should show a badge with the number of ads blocked",
-    "message":"Show on CatBlock button"
-  },
-  "typeunknown":{
-    "description":"A resource type",
-    "message":"unknown"
-  },
-  "filtereasylist_plus_finnish":{
-    "description":"language",
-    "message":"芬蘭文"
-  },
-  "catblock_show_on_adblock_menu":{
-    "description":"Label for checkbox letting user choose whether the CatBlock popup menu should show the number of ads blocked",
-    "message":"Show number of ads blocked on CatBlock menu"
-  },
-  "disabled_on_this_page":{
-    "description":"Message shown in toolbar button on web pages that have been whitelisted",
-    "message":"AdBlock 在這個頁面關閉。"
-  },
-  "typemedia":{
-    "description":"A resource type",
-    "message":"audio/video"
-  },
-  "filterjapanese":{
-    "description":"language",
-    "message":"日文"
-  },
-  "catblock_disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+    "message":"編輯被停用的清單："
   },
   "reportfilterlistproblem":{
     "description":"Telling the user to report an ad to a filter list maintainer",
     "message":"這是廣告過濾清單方面的問題。請在這裡回報： $link$",
     "placeholders":{
       "link":{
-        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>",
-        "content":"$1"
+        "content":"$1",
+        "example":"EXAMPLE 1: <a href='mailto:someguy@list.com'>John Doe</a>  EXAMPLE 2: <a href='http://easylist.org'>EasyList forums</a>"
       }
     }
   },
-  "disableforchromeandsafaristeptwo":{
-    "description":"Step 2 for disabling Chrome and Safari extensions",
-    "message":"除了<b> AdBlock 維持勾選</b>以外，<b>取消所有其他擴充</b>的『啟用』核取方塊"
+  "blacklisterblockedelement":{
+    "description":"Tells the user what the blocked element is on the slider page",
+    "message":"被阻擋的頁面元素："
   },
-  "englishonly":{
-    "description":"Lets the user know that a link/page is available in English only",
-    "message":"僅限英文"
+  "reportpubliclyavailable":{
+    "description":"Ad report page string, when you're about to submit a report",
+    "message":"注意： 您的報告可能會被公開。加入任何私人資料前小心留意。"
   },
-  "buttoncancel":{
-    "description":"Cancel button",
-    "message":"取消"
-  },
-  "spread_the_word":{
-    "description":"Text of a share link",
-    "message":"將AdBlock推薦給更多人使用！"
-  },
-  "you_can_slide_to_change":{
-    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
-    "message":"你可以滑動來改變 AdBlock 網域白名單。"
-  },
-  "checkinfirefoxtitle":{
-    "description":"Tell a user to see if a reported ad also appears in Firefox/Chrome",
-    "message":"在 Firefox中檢查 $chrome$",
-    "placeholders":{
-      "chrome":{
-        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)",
-        "content":"<span id='chrome1'></span>"
-      }
-    }
-  },
-  "disableyoutubestreamingads":{
-    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
-    "message":"啟用 ClickToFlash 相容性模式"
-  },
-  "retryaftersubscribe":{
-    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
-    "message":"先訂閱此過濾清單，然後重試一次：$list_title$",
-    "placeholders":{
-      "list_title":{
-        "example":"French filters",
-        "content":"$1"
-      }
-    }
-  },
-  "checkinternetconnection":{
-    "description":"Displayed when AdBlock is checking the newest available version and an error occurs while reporting an ad on adreport page",
-    "message":"你必須連上網路才能回報廣告"
-  },
-  "filtereasylist":{
-    "description":"A filter list",
-    "message":"EasyList （推薦）"
-  },
-  "catblock_adblockupdates":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"CatBlock updates"
-  },
-  "yes":{
-    "description":"A positive response to a question",
-    "message":"是"
-  },
-  "customfilterserrormessage":{
-    "description":"Error message when there is an issue with a custom filter on the 'Customize' tab of the Options page",
-    "message":"以下過濾器 <br/> $filter$ <br/> 有錯誤訊息：<br/> $message$",
-    "placeholders":{
-      "filter":{
-        "example":"@@.ad",
-        "content":"$1"
-      },
-      "message":{
-        "example":"invalid filter",
-        "content":"$2"
-      }
-    }
-  },
-  "fetchinglabel":{
-    "description":"Status label",
-    "message":"正在獲取清單...請稍候。"
-  },
-  "catblock_replaceadswithcats":{
-    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
-    "message":"Replace ads with pictures of cats"
-  },
-  "buttonlooksgood":{
-    "description":"Looks good button",
-    "message":"看來不錯"
-  },
-  "questionoridea":{
-    "description":"Subtitle on the Support tab of the options",
-    "message":"有任何問題或者是新的點子？"
+  "typepage":{
+    "description":"A resource type",
+    "message":"page"
   },
   "catblock_example_flickr_id":{
     "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
@@ -1168,5 +619,594 @@
         "content":"<i>346406</i>"
       }
     }
+  },
+  "adstillappear":{
+    "description":"Question on ad report page",
+    "message":"廣告是否還在？"
+  },
+  "typeother":{
+    "description":"A resource type",
+    "message":"其他"
+  },
+  "clickupdatefilters":{
+    "description":"Instruction on ad report page",
+    "message":"點選: <a>更新過濾清單！</a>"
+  },
+  "filteritalian":{
+    "description":"language",
+    "message":"義大利文"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "operabutton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Hide Button' should match the text that Opera displays on the Extensions page.",
+    "message":"如需隱藏按鈕，請到  opera://extensions 並且點選 『從工具列上隱藏』選項。 你可以取消該選項以顯示該按鈕"
+  },
+  "somethingwentwrong":{
+    "description":"Displayed when AdBlock is checking the newest available version and an error occurs",
+    "message":"在檢查更新的時候出了點錯誤"
+  },
+  "disableforsafaristepone":{
+    "description":"Step 1 for disabling Safari extensions",
+    "message":"選擇 Safari 選單 &rarr; 設定 &rarr; 擴充"
+  },
+  "typeobject_subrequest":{
+    "description":"A resource type",
+    "message":"object_subrequest"
+  },
+  "modifypath":{
+    "description":"Caption for the whitelist wizard slider that modifies the path part of a URL",
+    "message":"頁面:"
+  },
+  "catblock_malwarenotificationcheckboxmessage":{
+    "description":"Checkbox displayed when subscribing to the Malware filter list on the Filter lists tab of the Options page",
+    "message":"Should CatBlock notify you when it detects malware?"
+  },
+  "reloadadpage":{
+    "description":"Instruction on ad report page",
+    "message":"重新載入出現廣告的頁面。"
+  },
+  "unsubscribedlabel":{
+    "description":"Status label",
+    "message":"已取消訂閱。"
+  },
+  "typemedia":{
+    "description":"A resource type",
+    "message":"audio/video"
+  },
+  "catblock_example_flickr_url":{
+    "description":"Second example of a custom image list that a user can add. Leave the $example$ alone. e.g. is shorthand for \"for example\".",
+    "message":"a Flickr photoset URL (e.g. $example$)",
+    "placeholders":{
+      "example":{
+        "content":"<i>www.flickr.com/photos/michael_hughes/sets/346406/</i>"
+      }
+    }
+  },
+  "filterlatvian":{
+    "description":"A filter list",
+    "message":"拉脫維亞文"
+  },
+  "block_an_ad_on_this_page":{
+    "description":"Toolbar button menu entry and context menu entry",
+    "message":"阻擋此頁面上的廣告"
+  },
+  "buttonblockit":{
+    "description":"Block button",
+    "message":"阻擋"
+  },
+  "stop_blocking_ads":{
+    "description":"Section header on the 'Customize' tab",
+    "message":"停止阻擋廣告:"
+  },
+  "disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"除了<b> AdBlock 維持勾選</b>以外，<b>取消所有其他擴充</b>的『啟用』核取方塊"
+  },
+  "catblock_tabcustomizetitle":{
+    "description":"Title of the customize tab",
+    "message":"Customize CatBlock"
+  },
+  "removefromlist":{
+    "description":"Label to remove a custom filter",
+    "message":"從清單列表中移除"
+  },
+  "failedtofetchfilter":{
+    "description":"Error messagebox",
+    "message":"無法獲取此過濾清單！"
+  },
+  "cantblockflash":{
+    "description":"Result of the final ad report question",
+    "message":"目前還無法阻擋在 Flash 或其他外掛程式中的廣告。此功能尚在等待瀏覽器與 WebKit 支援。"
+  },
+  "catblock_adblockupdates":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"CatBlock updates"
+  },
+  "you_can_slide_to_change":{
+    "description":"Instructions for how to use the whitelister slider controls. Sometimes only one slider will show, and sometimes two will show, and if possible the text should handle both cases.",
+    "message":"你可以滑動來改變 AdBlock 網域白名單。"
+  },
+  "typehiding":{
+    "description":"A resource type",
+    "message":"hiding"
+  },
+  "disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"AdBlock 在這個頁面關閉。"
+  },
+  "cantblockflashwarning":{
+    "description":"Text of the final ad report question",
+    "message":"該廣告是出現在影片或 Flash 遊戲等外掛程式中？"
+  },
+  "filterrussian":{
+    "description":"Language names for a filter list",
+    "message":"俄羅斯和烏克蘭"
+  },
+  "filtereasylist_plus_spanish":{
+    "description":"language",
+    "message":"西班牙文"
+  },
+  "block_this_ad":{
+    "description":"Context and popup menu entry",
+    "message":"阻擋這個廣告"
+  },
+  "catblock_disabled_on_this_page":{
+    "description":"Message shown in toolbar button on web pages that have been whitelisted",
+    "message":"CatBlock is disabled on this page."
+  },
+  "blacklisterblocksalloftype":{
+    "description":"Warns the user that all elements of type X will be blocked",
+    "message":"注意：此過濾規則會阻擋頁面上所有的 $elementtype$ 元素！",
+    "placeholders":{
+      "elementtype":{
+        "content":"$1",
+        "example":"DIV"
+      }
+    }
+  },
+  "disableyoutubestreamingads":{
+    "description":"Checkbox on the 'General' tab of the Options page. Allow AdBlock and the ClickToFlash Safari extension to work simultaneously on YouTube.",
+    "message":"啟用 ClickToFlash 相容性模式"
+  },
+  "no":{
+    "description":"A negative response to a question",
+    "message":"否"
+  },
+  "enable_adblock":{
+    "description":"Link text to un-whitelist a page, displayed immediately after 'AdBlock is disabled on this page'",
+    "message":"在此頁面上啟用AdBlock"
+  },
+  "blacklisterthefilter":{
+    "description":"Blacklister attribute choosing page message",
+    "message":"即將套用的規則，仍可在選項中編輯："
+  },
+  "hide_this_button":{
+    "description":"Toolbar button menu entry to hide the AdBlock button",
+    "message":"隱藏這個按鈕"
+  },
+  "subscribingfailed":{
+    "description":"abp: link subscriber result",
+    "message":"失敗"
+  },
+  "pause_adblock":{
+    "description":"Menu entry to pause AdBlock",
+    "message":"暫停 AdBlock"
+  },
+  "retryaftersubscribe":{
+    "description":"Instructions on ad report page telling users to subscribe to a filter list and then check again to see whether the ad exists",
+    "message":"先訂閱此過濾清單，然後重試一次：$list_title$",
+    "placeholders":{
+      "list_title":{
+        "content":"$1",
+        "example":"French filters"
+      }
+    }
+  },
+  "lang_english":{
+    "description":"language",
+    "message":"英文"
+  },
+  "showcontextmenus2":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"在右鍵清單中顯示"
+  },
+  "fixityourself":{
+    "description":"Telling users who won't report an ad to us how to handle it for themselves",
+    "message":"您還是可以在「黑名單」頁面中手動阻擋此廣告。"
+  },
+  "lang_russian":{
+    "description":"language",
+    "message":"俄文"
+  },
+  "ad_report_please":{
+    "description":"Link to the ad report page on our support site. This is found on the Support tab of the options.",
+    "message":"如果你看到了廣告，請<a>回報廣告</a>而不是回報bug"
+  },
+  "safari50_updatenotice":{
+    "description":"A message shown to Safari 5.0 users urging them to upgrade",
+    "message":"你正在使用舊版的 Safari，請 <a>升級您的瀏覽器 </a> 以便使用在工具列按鈕中暫停 AdBlock，白名單，回報廣告等等最新的功能。"
+  },
+  "filtereasyprivacy":{
+    "description":"A filter list",
+    "message":"EasyPrivacy (隱私保護)"
+  },
+  "catblock_storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"You exceeded the amount of storage CatBlock can use. Please unsubscribe from some filter lists!"
+  },
+  "typexmlhttprequest":{
+    "description":"A resource type",
+    "message":"xmlhttprequest"
+  },
+  "blacklisterattrwillbe":{
+    "description":"Checkbox label",
+    "message":"$attribute$ 將為 $value$",
+    "placeholders":{
+      "attribute":{
+        "content":"$1",
+        "example":"class"
+      },
+      "value":{
+        "content":"$2",
+        "example":"AdBanner"
+      }
+    }
+  },
+  "orenteraurl":{
+    "description":"Link for custom subscription",
+    "message":"或輸入過濾清單網址："
+  },
+  "subscribingfinished":{
+    "description":"abp: link subscriber result",
+    "message":"完成"
+  },
+  "unpause_adblock":{
+    "description":"Link text to unpause AdBlock, displayed immediately after 'AdBlock is paused'",
+    "message":"繼續AdBlock的運作"
+  },
+  "languagedropdowndescription":{
+    "description":"Dropdown list for language-specific filters",
+    "message":"替其他語言新增過濾清單 "
+  },
+  "loading":{
+    "description":"Generic message displayed during processes that take some time",
+    "message":"載入中..."
+  },
+  "blacklistclickmessage":{
+    "description":"Message at the top of the blacklist options tab",
+    "message":"右鍵點選頁面上的廣告來阻擋它 ─ 或在此處手動阻擋。"
+  },
+  "catblock_disableforchromeandsafaristeptwo":{
+    "description":"Step 2 for disabling Chrome and Safari extensions",
+    "message":"Uncheck the 'Enabled' checkbox next to every extension <b>except</b> for CatBlock.  <b>Leave CatBlock enabled</b>."
+  },
+  "filtermalware":{
+    "description":"A filter list",
+    "message":"惡意軟體防護"
+  },
+  "report_ad_on_page":{
+    "description":"Entry in the AdBlock button menu",
+    "message":"回報這個頁面的廣告"
+  },
+  "debuginlogoption":{
+    "description":"Checkbox on the 'General' tab of the Options page",
+    "message":"在 Console Log 中顯示除錯資訊（將會降低 AdBlock 效能）"
+  },
+  "checkinfirefox_1":{
+    "description":"instruction for how to check Firefox/Chrome for a reported ad",
+    "message":"如果您尚未安裝的話，請先安裝 Firefox $chrome$",
+    "placeholders":{
+      "chrome":{
+        "content":"<span id='chrome2'></span>",
+        "example":"'or Chrome' (This will only be shown in Safari. Chrome users will not see this.)"
+      }
+    }
+  },
+  "storage_quota_exceeded":{
+    "description":"Message shown when the user uses more storage than allowed by the browser",
+    "message":"你超出了 AdBlock 能使用的儲存空間。 請取消訂閱一些清單!"
+  },
+  "description2":{
+    "description":"Extension description in manifest. Should not exceed 132 characters.",
+    "message":"最受歡迎的 Chrome 擴充，有超過四千萬名的用戶正在用 AdBlock 阻擋網頁上的廣告"
+  },
+  "foundbug":{
+    "description":"Subtitle on the Support tab of the options",
+    "message":"發現了bug？"
+  },
+  "lang_czech":{
+    "description":"language",
+    "message":"捷克文"
+  },
+  "catblock_excludedomainorurl":{
+    "description":"Message of the exclude area",
+    "message":"The domain or url where CatBlock shouldn't block anything"
+  },
+  "typescript":{
+    "description":"A resource type",
+    "message":"script"
+  },
+  "catblock_add_more_photos":{
+    "description":"Introduction to the examples of custom image lists. Leave the <b> and </b> as they are.",
+    "message":"<b>Add some photos</b> from Flickr!  You can enter:"
+  },
+  "tabfilterlists":{
+    "description":"A tab on the options page",
+    "message":"過濾清單"
+  },
+  "malwarenotificationdisablethesemessages":{
+    "description":"Button on the malware notification to disable future notifications. Message should be under 45 characters!",
+    "message":"停用這些通知"
+  },
+  "filterchinese":{
+    "description":"language",
+    "message":"中文"
+  },
+  "blacklistereditinvalid1":{
+    "description":"Messagebox if the manually edited filter is invalid. Error messages are not translated.",
+    "message":"無效的過濾規則: $exception$",
+    "placeholders":{
+      "exception":{
+        "content":"$1",
+        "example":"This filter is not supported"
+      }
+    }
+  },
+  "subscribingtitle":{
+    "description":"abp: link subscriber title",
+    "message":"正在訂閱過濾清單..."
+  },
+  "manuallyenableotherextensions":{
+    "description":"On the ad report page, alert notifying users that they will need to manually reenable the extensions",
+    "message":"請至擴充頁面來啟用您以前曾經停用的擴充"
+  },
+  "blacklistermatches":{
+    "description":"Tells the user multiple matches were found",
+    "message":"頁面上有 $matchcount$ 個匹配項目被阻擋。",
+    "placeholders":{
+      "matchcount":{
+        "content":"$1",
+        "example":"5"
+      }
+    }
+  },
+  "updatedhourago":{
+    "description":"Label for subscription",
+    "message":"1 小時前更新"
+  },
+  "catblock_add_photos":{
+    "description":"Shown on the CatBlock tab of the options page. Users click this button to add a new list of images.",
+    "message":"Add Photos"
+  },
+  "selectlanguage":{
+    "description":"Text for the first option in Langage Dropdown for Filter Lists tab in options. Include the ' -- ' on either side of your translation.",
+    "message":" --選擇語言-- "
+  },
+  "sliderexplanation":{
+    "description":"Blacklister slider page message",
+    "message":"滑動控制器直到頁面上的廣告已被正確地阻擋。"
+  },
+  "filtereasylist_plus_indonesian":{
+    "description":"A filter list",
+    "message":"印尼文"
+  },
+  "typeimage":{
+    "description":"A resource type",
+    "message":"image"
+  },
+  "buttonedit":{
+    "description":"Edit filter manually button",
+    "message":"編輯"
+  },
+  "catblock_example_flickr_search":{
+    "description":"First example of a custom image list that a user can add. Leave the <i> and </i> as they are. e.g. is shorthand for \"for example\".",
+    "message":"a search for photos (e.g. <i>sailboat race</i>)"
+  },
+  "blocked_n_in_total":{
+    "description":"Shown below the 'Blocked ads:' message. Shows the number of ads blocked since AdBlock was installed. $count$ will be a number between 1 and 999,999,999.",
+    "message":"$count$ 總阻擋數",
+    "placeholders":{
+      "count":{
+        "content":"<a>123,456</a>",
+        "example":"The number of ads blocked. Do not make any changes to this placeholder when translating."
+      }
+    }
+  },
+  "tabsupport":{
+    "description":"A tab on the options page",
+    "message":"支援與協助"
+  },
+  "linkblockadbyurl":{
+    "description":"Link on the 'Customize' tab",
+    "message":"依網址阻擋廣告"
+  },
+  "buttoncancel":{
+    "description":"Cancel button",
+    "message":"取消"
+  },
+  "savereminder":{
+    "description":"Reminder to press save",
+    "message":"別忘了儲存！"
+  },
+  "catblock_unpause_adblock":{
+    "description":"Link text to unpause CatBlock, displayed immediately after 'CatBlock is paused'",
+    "message":"Unpause CatBlock"
+  },
+  "catblock_contributors":{
+    "description":"Link to the contributors page on the Support tab of the options",
+    "message":"We've got a <a>page</a> to help you find out about the people behind CatBlock, as well!"
+  },
+  "optionsversion":{
+    "description":"Version number",
+    "message":"版本 $version$",
+    "placeholders":{
+      "version":{
+        "content":"$1",
+        "example":"2.0.9"
+      }
+    }
+  },
+  "catblock_replaceadswithcats":{
+    "description":"Option on General tab used for enabling replacement of ads by pictures of cats",
+    "message":"Replace ads with pictures of cats"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "subscribeconfirm":{
+    "description":"Prompt question before subscribing to the filter list",
+    "message":"您確定要訂閱 $title$ 過濾清單嗎",
+    "placeholders":{
+      "title":{
+        "content":"$1",
+        "example":"Prebake"
+      }
+    }
+  },
+  "sourcecode":{
+    "description":"Link to the source code of AdBlock on the Support tab of the options",
+    "message":"原始碼是<a> 開源的 </a>！"
+  },
+  "filterdutch":{
+    "description":"language",
+    "message":"荷蘭文"
+  },
+  "blacklistereditfilter":{
+    "description":"Text if the user wants to manually edit a filter. 'OK' is the standard javascript popup button text.",
+    "message":"請在下面輸入正確的過濾規則，並點選 「確定」"
+  },
+  "yes":{
+    "description":"A positive response to a question",
+    "message":"是"
+  },
+  "update_available":{
+    "description":"On the Options > Support page, shows when there are updates available for AdBlock",
+    "message":"AdBlock 有更新摟！ 請至 $here$ 更新. <br> 注意： 如果你想要自動取得這些更新，您只需要點選 Safari > 設定 >  擴充 > 更新 <br> 然後選擇 『自動安裝更新』",
+    "placeholders":{
+      "here":{
+        "content":"<a id='here'></a>",
+        "example":"<a>here</a>"
+      }
+    }
+  },
+  "blacklistersinglematch":{
+    "description":"Tells the user only one match was found",
+    "message":"頁面上只有 <b>1</b> 個匹配項目被阻擋。"
+  },
+  "catblock_disabled_by_filter_lists":{
+    "description":"Message shown when a user tries to unwhitelist a web page that has been whitelisted by a rule in a subscribed filter list",
+    "message":"Sorry, CatBlock is disabled on this page by one of your filter lists."
+  },
+  "filterjapanese":{
+    "description":"language",
+    "message":"日文"
+  },
+  "cleanuplist2":{
+    "description":"Option at the bottom of the 'Customize' options tab",
+    "message":"清空此清單"
+  },
+  "updatedhoursago":{
+    "description":"Label for subscription",
+    "message":"$hours$ 小時前更新",
+    "placeholders":{
+      "hours":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "buttonback":{
+    "description":"Back to previous wizard page button",
+    "message":"返回"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "optionstitle":{
+    "description":"Title for the options page",
+    "message":"AdBlock 選項"
+  },
+  "betalabel":{
+    "description":"Label for beta features in AdBlock Options",
+    "message":"Beta"
+  },
+  "catblock_latest_version":{
+    "description":"On the Options > Support page, shows when there are no updates available for CatBlock",
+    "message":"CatBlock is up-to-date!"
+  },
+  "filterlistlink":{
+    "description":"Explanation of the filter lists",
+    "message":"請不要訂閱過多清單，每新增一個清單都會讓瀏覽器的速度降低！更多詳細資訊和過濾清單可在<a>這裡</a>找到。"
+  },
+  "other":{
+    "description":"Multiple choice option",
+    "message":"其他"
+  },
+  "blockdomain":{
+    "description":"Message of the url and css -blocking area",
+    "message":"套用的網域"
+  },
+  "updatedrightnow":{
+    "description":"Label for subscription",
+    "message":"剛剛更新"
+  },
+  "debuginfo":{
+    "description":"Users can click this link to provide debug information to AdBlock staff",
+    "message":"我們的研發團隊有像您索取除錯資訊(debug info) ?  <a href='#' id='debug'>點我</a>取得這些資訊 ！"
+  },
+  "updatedminutesago":{
+    "description":"Label for subscription",
+    "message":"$minutes$ 分鐘前更新",
+    "placeholders":{
+      "minutes":{
+        "content":"$1",
+        "example":"15"
+      }
+    }
+  },
+  "malwarenotificationlearnmore":{
+    "description":"Button on the malware notification that opens a page about malware on our website. Message should be under 45 characters!",
+    "message":"瞭解更多惡意軟體的相關資訊"
+  },
+  "filterswedish":{
+    "description":"A filter list",
+    "message":"瑞典文"
+  },
+  "adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"AdBlock 支援與協助"
+  },
+  "headertype":{
+    "description":"Resource list page: title of a column",
+    "message":"類型"
+  },
+  "typesubdocument":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "updatedminuteago":{
+    "description":"Label for subscription",
+    "message":"1 分鐘前更新"
+  },
+  "typesub_frame":{
+    "description":"A resource type",
+    "message":"frame"
+  },
+  "adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"AdBlock-點擊查看詳情"
+  },
+  "whitelistertitle2":{
+    "description":"The title of the whitelister dialog",
+    "message":"不要在此網域使用 AdBlock..."
   }
 }

--- a/background.html
+++ b/background.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="UTF-8">
         <script type="text/javascript" src="lib/punycode.min.js"></script>
         <script type="text/javascript" src="lib/jquery.min.js"></script>
         <script type="text/javascript" src="js/port.js"></script>

--- a/button/popup.html
+++ b/button/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html>
   <head>
+    <meta charset="UTF-8">
     <link rel="stylesheet" href="popup.css"/>
     <script src="../lib/punycode.min.js"></script>
     <script src="../lib/jquery.min.js"></script>

--- a/button/popup.js
+++ b/button/popup.js
@@ -199,7 +199,7 @@ $(function() {
 
     $("#div_pause_adblock").click(function() {
         if (BG.get_settings().safari_content_blocking) {
-            alert(translate('safaricontentblockingpausemessage'));
+            alert(translate('catblock_safaricontentblockingpausemessage'));
         } else {
             BG.adblock_is_paused(true);
             if (!SAFARI) {
@@ -270,7 +270,7 @@ $(function() {
         if (OPERA) {
             $("#help_hide_explanation").text(translate("operabutton_how_to_hide2")).slideToggle();
         } else if (SAFARI) {
-            $("#help_hide_explanation").text(translate("safaributton_how_to_hide2")).
+            $("#help_hide_explanation").text(translate("catblock_safaributton_how_to_hide2")).
             slideToggle(function() {
                 var popupheight = $("body").outerHeight();
                 safari.extension.popovers[0].height = popupheight;

--- a/button/popup.js
+++ b/button/popup.js
@@ -102,6 +102,12 @@ $(function() {
             }
         }
 
+        // Currently there's no way,
+        // how to hide the extension button
+        if (FIREFOX) {
+            $("#div_help_hide_start").hide();
+        }
+
     });
 
     if (SAFARI) {

--- a/catblock/_locales/af/messages.json
+++ b/catblock/_locales/af/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/ar/messages.json
+++ b/catblock/_locales/ar/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/ca/messages.json
+++ b/catblock/_locales/ca/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/cs/messages.json
+++ b/catblock/_locales/cs/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/da/messages.json
+++ b/catblock/_locales/da/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/de/messages.json
+++ b/catblock/_locales/de/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/el/messages.json
+++ b/catblock/_locales/el/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/en/messages.json
+++ b/catblock/_locales/en/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
-  }
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
+  },
 }

--- a/catblock/_locales/en/messages.json
+++ b/catblock/_locales/en/messages.json
@@ -160,8 +160,8 @@
     "message":"CatBlock Support"
   },
   "catblock_adblock_outdated_chrome":{
-    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome://chrome/extensions/'",
-    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page</a>, enable 'Developer mode' and click 'Update extensions now'"
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
   },
   "catblock_safaributton_how_to_hide2":{
     "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
@@ -176,7 +176,7 @@
     "message":"CatBlock - click for details"
   },
   "catblock_adblock_wont_run_on_pages_matching":{
-    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com/reader/*'.  The URL will appear on the next line.",
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
     "message":"CatBlock won't run on any page matching:"
   },
   "catblock_filteradblock_custom":{

--- a/catblock/_locales/en/messages.json
+++ b/catblock/_locales/en/messages.json
@@ -190,5 +190,5 @@
   "catblock_safaricontentblockingpausemessage":{
     "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
     "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
-  },
+  }
 }

--- a/catblock/_locales/es-ES/messages.json
+++ b/catblock/_locales/es-ES/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"Mientras más listas de filtros uses, CatBlock ejecutará más lento. Usar demasiadas listas puede incluso crashear tu explorador en algunos sitios. Pulse OK para suscribirse a esta lista de todos modos."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/fi/messages.json
+++ b/catblock/_locales/fi/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/fr/messages.json
+++ b/catblock/_locales/fr/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/he/messages.json
+++ b/catblock/_locales/he/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/hu/messages.json
+++ b/catblock/_locales/hu/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/it/messages.json
+++ b/catblock/_locales/it/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/ja/messages.json
+++ b/catblock/_locales/ja/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/ko/messages.json
+++ b/catblock/_locales/ko/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/ms/messages.json
+++ b/catblock/_locales/ms/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/nl/messages.json
+++ b/catblock/_locales/nl/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/no/messages.json
+++ b/catblock/_locales/no/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/pl/messages.json
+++ b/catblock/_locales/pl/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/pt-BR/messages.json
+++ b/catblock/_locales/pt-BR/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/pt-PT/messages.json
+++ b/catblock/_locales/pt-PT/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/ro/messages.json
+++ b/catblock/_locales/ro/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/ru/messages.json
+++ b/catblock/_locales/ru/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/sk/messages.json
+++ b/catblock/_locales/sk/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"Čím viac filtrov prihlásite, tým bude CatBlock pomalší. Použitie príliš veľa filtrov môže dokonca spôsobiť pád prehliadača na niektorých stránkach. Pre potvrdenie prihlásenia stlačte tlačidlo OK."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/sr/messages.json
+++ b/catblock/_locales/sr/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/sv-SE/messages.json
+++ b/catblock/_locales/sv-SE/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/tr/messages.json
+++ b/catblock/_locales/tr/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/uk/messages.json
+++ b/catblock/_locales/uk/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/vi/messages.json
+++ b/catblock/_locales/vi/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/zh-CN/messages.json
+++ b/catblock/_locales/zh-CN/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/catblock/_locales/zh-TW/messages.json
+++ b/catblock/_locales/zh-TW/messages.json
@@ -150,5 +150,45 @@
   "catblock_you_know_thats_a_bad_idea_right":{
     "description":"Confirmation message shown to user if they try to subscribe to too many lists. The user will have two options: OK and Cancel.",
     "message":"The more filter lists you use, the slower CatBlock runs. Using too many lists can even crash your browser on some websites. Press OK to subscribe to this list anyway."
+  },
+  "catblock_safarinotificationbody":{
+    "description":"Body of a notification shown to Safari Content Blocking users with too many filter list rules",
+    "message":"Please disable some filter lists. More information in CatBlock's Options."
+  },
+  "catblock_adblocksupport":{
+    "description":"Title of the support tab",
+    "message":"CatBlock Support"
+  },
+  "catblock_adblock_outdated_chrome":{
+    "description":"Ad report page instructions to update AdBlock in Chrome. The link will point to 'chrome:\/\/chrome\/extensions\/'",
+    "message":"You are using an old version of CatBlock. Please go to <a href='#'>the extensions page<\/a>, enable 'Developer mode' and click 'Update extensions now'"
+  },
+  "catblock_safaributton_how_to_hide2":{
+    "description":"Message explaining how to hide the AdBlock toolbar button. 'Customize Toolbar' should match the text that Safari displays in the toolbar's context menu.",
+    "message":"To hide the button, right click Safari's toolbar and choose Customize Toolbar, then drag the CatBlock button out of the toolbar. You can show it again by dragging it back into the toolbar."
+  },
+  "catblock_adblockreportinganad":{
+    "description":"Title of the ad report page",
+    "message":"CatBlock - Reporting an ad"
+  },
+  "catblock_adblock_click_for_details":{
+    "description":"Tooltip on the AdBlock button, to help users understand that they can click the button, and that they can control the number badge that appears on the button.",
+    "message":"CatBlock - click for details"
+  },
+  "catblock_adblock_wont_run_on_pages_matching":{
+    "description":"Message displayed when the whitelister dialog will whitelist part of an entire website, for example '*.google.com\/reader\/*'.  The URL will appear on the next line.",
+    "message":"CatBlock won't run on any page matching:"
+  },
+  "catblock_filteradblock_custom":{
+    "description":"A filter list",
+    "message":"CatBlock custom filters (recommended)"
+  },
+  "catblock_malwarenotificationmessage":{
+    "description":"Notification when a malware request has been blocked. This message should be under 90 characters!",
+    "message":"CatBlock has blocked a download from a site known to host malware."
+  },
+  "catblock_safaricontentblockingpausemessage":{
+    "description":"Alert displayed after clicking 'Pause AdBlock' in the AdBlock menu while Safari Content blocking is enabled",
+    "message":"To pause CatBlock with Content Blocking enabled, please select Safari (in the menu bar) > Preferences > Extensions > CatBlock, and uncheck 'Enable CatBlock'."
   }
 }

--- a/filtering/myfilters.js
+++ b/filtering/myfilters.js
@@ -743,12 +743,11 @@ MyFilters.prototype._make_subscription_options = function() {
     // When modifying a list, IDs mustn't change!
     return {
         "adblock_custom": { // AdBlock custom filters
-            url: "https://cdn.adblockcdn.com/filters/adblock_custom.txt",
+            url: "https://cdn.adblockcdn.com/filters/adblock_custom.txt"
         },
         "easylist": { // EasyList
             url: "https://easylist-downloads.adblockplus.org/easylist.txt",
-            safariJSON_URL: "https://cdn.adblockcdn.com/filters/easylist.json",
-            safariJSON_URL_AA: "https://cdn.adblockcdn.com/filters/easylist_aa.json",
+            safariJSON_URL: "https://cdn.adblockcdn.com/filters/easylist.json"
         },
         "easylist_plus_bulgarian": { // Additional Bulgarian filters
             url: "http://stanev.org/abp/adblock_bg.txt",

--- a/js/adblock_start_chrome.js
+++ b/js/adblock_start_chrome.js
@@ -107,7 +107,7 @@ adblock_begin({
         chrome.runtime.onMessage.removeListener(elementPurger.onPurgeRequest);
     },
     handleHiding: function(data) {
-        if (data.hiding)
+        if (data && data.hiding)
             block_list_via_css(data.selectors);
     }
 });

--- a/js/background.js
+++ b/js/background.js
@@ -1283,7 +1283,7 @@ createMalwareNotification = function() {
                 iconUrl: chrome.runtime.getURL('img/icon48.png'),
                 type: 'basic',
                 priority: 2,
-                message: translate('malwarenotificationmessage'),
+                message: translate('catblock_malwarenotificationmessage'),
                 buttons: [{title:translate('malwarenotificationlearnmore'),
                            iconUrl:chrome.runtime.getURL('img/icon24.png')},
                           {title:translate('malwarenotificationdisablethesemessages'),

--- a/js/background.js
+++ b/js/background.js
@@ -1349,6 +1349,9 @@ if (!SAFARI) {
     }
 
     chrome.tabs.onCreated.addListener(function(tab) {
+        if (chrome.runtime.lastError || !tab || !tab.id) {
+            return;
+        }
         chrome.tabs.get(tab.id, function(tabs) {
             if (tabs && tabs.url && tabs.id) {
                 runChannelWhitelist(tabs.url, tabs.id);

--- a/js/functions.js
+++ b/js/functions.js
@@ -253,7 +253,7 @@ var createRuleLimitExceededSafariNotification = function() {
     if (SAFARI && ("Notification" in window)) {
         sessionstorage_set("contentblockingerror", translate("safaricontentblockinglimitexceeded"));
         chrome.runtime.sendMessage({command: "contentblockingmessageupdated"});
-        var note = new Notification(translate("safarinotificationtitle") , { 'body' : translate("safarinotificationbody"), 'tag' : 1 });
+        var note = new Notification(translate("safarinotificationtitle") , { 'body' : translate("catblock_safarinotificationbody"), 'tag' : 1 });
         note.onclick = function() {
             openTab("options/index.html?tab=0");
         };

--- a/js/ytchannel.js
+++ b/js/ytchannel.js
@@ -8,6 +8,7 @@ if (!/ab_channel/.test(url)) {
         xhr.open("GET",
                  "https://www.googleapis.com/youtube/v3/channels?part=snippet&id=" + getChannelId(url) +
                  "&key=" + atob("QUl6YVN5QzJKMG5lbkhJZ083amZaUUYwaVdaN3BKd3dsMFczdUlz"), true);
+        xhr.overrideMimeType("application/json");
         xhr.onload = function() {
             if (xhr.readyState === 4 && xhr.status === 200) {
                 var json = JSON.parse(xhr.response);
@@ -23,6 +24,7 @@ if (!/ab_channel/.test(url)) {
         xhr.open("GET",
                  "https://www.googleapis.com/youtube/v3/videos?part=snippet&id=" + getVideoId(url) +
                  "&key=" + atob("QUl6YVN5QzJKMG5lbkhJZ083amZaUUYwaVdaN3BKd3dsMFczdUlz"), true);
+        xhr.overrideMimeType("application/json");
         xhr.onload = function() {
             if (xhr.readyState === 4 && xhr.status === 200) {
                 var json = JSON.parse(xhr.response);

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
       "38": "img/icon38.png"
     },
     "default_popup": "button/popup.html",
-    "default_title": "__MSG_adblock_click_for_details__"
+    "default_title": "__MSG_catblock_adblock_click_for_details__"
   },
   "content_scripts": [
     {

--- a/options/index.html
+++ b/options/index.html
@@ -333,7 +333,7 @@
                 </div>
             </div>
             <div id='support' class="options">
-                <h2 i18n="adblocksupport"></h2>
+                <h2 i18n="catblock_adblocksupport"></h2>
 
                 <h3 i18n="foundbug"></h3>
                 <p>

--- a/options/index.html
+++ b/options/index.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title i18n="optionstitle"></title>
+        <meta charset="UTF-8">
         <link rel="stylesheet" href="options.css" />
         <link rel="stylesheet" href="../catblock/options/catblock.css" />
         <script src="../lib/punycode.min.js"></script>

--- a/options/index.js
+++ b/options/index.js
@@ -75,7 +75,8 @@ function displayTranslationCredit() {
     if (navigator.language.substring(0, 2) != "en") {
         var translators = [];
         var xhr = new XMLHttpRequest();
-        xhr.open("GET", chrome.runtime.getURL('translators.json'), true);
+        xhr.open("GET", chrome.runtime.getURL("translators.json"), true);
+        xhr.overrideMimeType("application/json");
         xhr.onload = function() {
             var text = JSON.parse(this.responseText);
             var lang = navigator.language;

--- a/options/support.js
+++ b/options/support.js
@@ -59,6 +59,7 @@ $(document).ready(function() {
     $("#whatsnew a").click(function() {
         var xhr = new XMLHttpRequest();
         xhr.open("GET", chrome.runtime.getURL("CHANGELOG.txt"), true);
+        xhr.overrideMimeType("text/plain");
         xhr.onreadystatechange = function() {
             if (this.readyState === 4 && this.responseText !== "") {
                 $("#changes").text(xhr.responseText).css({width: "670px", height: "200px"}).fadeIn();

--- a/pages/adreport.html
+++ b/pages/adreport.html
@@ -7,6 +7,7 @@ chrome-extension://gighmmpiobklfepjocnamgkkbiglidom/pages/adreport.html
 <html>
   <head>
     <title i18n="adblockreportinganad"></title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" href="../options/options.css" />
     <link rel="stylesheet" href="adreport.css" />
     <script src="../lib/jquery.min.js" type="text/javascript"></script>

--- a/pages/adreport.html
+++ b/pages/adreport.html
@@ -6,7 +6,7 @@ chrome-extension://gighmmpiobklfepjocnamgkkbiglidom/pages/adreport.html
 <!doctype html>
 <html>
   <head>
-    <title i18n="adblockreportinganad"></title>
+    <title i18n="catblock_adblockreportinganad"></title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../options/options.css" />
     <link rel="stylesheet" href="adreport.css" />

--- a/pages/adreport.js
+++ b/pages/adreport.js
@@ -485,6 +485,7 @@ var fetchMalware = function() {
     // The timestamp is add to the URL to prevent caching by the browser
     xhr.open("GET", "https://data.getadblock.com/filters/domains.json?timestamp=" + new Date()
              .getTime(), true);
+    xhr.overrideMimeType("application/json");
     xhr.onload = function() {
         if (xhr.readyState === 4 && xhr.status === 200) {
             var parsedText = JSON.parse(xhr.responseText);

--- a/pages/adreport.js
+++ b/pages/adreport.js
@@ -14,6 +14,10 @@ $(function() {
                 chrome.tabs.create({
                     url: 'opera://extensions/'
                 });
+            } else if (FIREFOX) {
+                chrome.tabs.create({
+                    url: 'about:addons'
+                });
             } else {
                 chrome.tabs.create({
                     url: 'chrome://extensions/'
@@ -541,9 +545,17 @@ $("#step_update_filters_no").click(function() {
 $("#step_update_filters_yes").click(function() {
     $("#step_update_filters")
         .html("<span class='answer' chosen='yes'>" + translate("yes") + "</span>");
-    $("#step_disable_extensions_DIV")
+    // TODO: Add support for Edge once it will have
+    // a page with installed extensions
+    if (!FIREFOX && !EDGE) {
+        $("#step_disable_extensions_DIV")
         .fadeIn()
         .css("display", "block");
+    } else {
+        $("#step_language_DIV")
+        .fadeIn()
+        .css("display", "block");
+    }
 });
 
 
@@ -583,9 +595,8 @@ $("#step_disable_extensions_yes").click(function() {
 
 //Automatically disable / enable other extensions
 $("#OtherExtensions").click(function() {
-    $("#OtherExtensions")
-        .prop("disabled", true);
-    if (!SAFARI) {
+    $("#OtherExtensions").prop("disabled", true);
+    if (chrome.permissions && chrome.permissions.request) {
         chrome.permissions.request({
             permissions: ['management']
         }, function(granted) {
@@ -600,11 +611,12 @@ $("#OtherExtensions").click(function() {
                         if (result[i].enabled &&
                             result[i].mayDisable &&
                             result[i].id !== "mdcgnhlfpnbeieiiccmebgkfdebafodo" &&
-                            result[i].id !== "aobdicepooefnbaeokijohmhjlleamfj") { // TODO: add opera id
+                            result[i].id !== "pejeadkbfbppoaoinpmkeonebmngpnkk") {
                             //if the extension is a developer version, continue, don't disable.
                             if (result[i].installType === "development" &&
                                 result[i].type === "extension" &&
-                                result[i].name === "AdBlock with CatBlock") {
+                                (result[i].name === "AdBlock with CatBlock" ||
+                                 result[i].name === "CatBlock")) {
                                 continue;
                             }
                             chrome.management.setEnabled(result[i].id, false);
@@ -669,21 +681,18 @@ $("#step_language_lang")
     }
     contact = required_lists[required_lists.length - 1];
 
+    $("#checkinfirefox1").html(translate("checkinfirefox_1"));
+    $("#checkinfirefox2").html(translate("checkinfirefox_2"));
+    $("#checkinfirefox").html(translate("checkinfirefoxtitle"));
+
+    if (SAFARI || FIREFOX || EDGE) {
+        $("#chrome1, #chrome2").html(translate("orchrome"));
+        $("#adblockforchrome").html(translate("oradblockforchrome"));
+    }
+
     $("#step_firefox_DIV")
         .fadeIn()
         .css("display", "block");
-    $("#checkinfirefox1")
-        .html(translate("checkinfirefox_1"));
-    $("#checkinfirefox2")
-        .html(translate("checkinfirefox_2"));
-    $("#checkinfirefox")
-        .html(translate("checkinfirefoxtitle"));
-    if (SAFARI) {
-        $("#chrome1, #chrome2")
-            .html(translate("orchrome"));
-        $("#adblockforchrome")
-            .html(translate("oradblockforchrome"));
-    }
 });
 
 // STEP 5: also in Firefox

--- a/pages/resourceblock.html
+++ b/pages/resourceblock.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title i18n="resourceblocktitle"></title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+    <meta charset="UTF-8">
     <link rel="stylesheet" href="../options/options.css" />
     <link rel="stylesheet" href="resourceblock.css" />
     <script src="../lib/punycode.min.js"></script>

--- a/pages/subscribe.html
+++ b/pages/subscribe.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>AdBlock</title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" href="subscribe.css" />
     <script src="../lib/jquery.min.js"></script>
     <script src="../js/port.js" type="text/javascript"></script>

--- a/tools/tests/safari_test.html
+++ b/tools/tests/safari_test.html
@@ -40,7 +40,7 @@
 
       see http://blanketjs.org/ for more information.
    -->
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta charset="UTF-8">
   <title>AdBlock test cases</title>
   <link rel="Stylesheet" media="screen" href="qunit.css" />
 

--- a/tools/tests/test.html
+++ b/tools/tests/test.html
@@ -38,7 +38,7 @@
       see http://blanketjs.org/ for more information.
 
    -->
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta charset="UTF-8">
   <title>AdBlock test cases</title>
   <link rel="Stylesheet" media="screen" href="qunit.css" />
 

--- a/uiscripts/top_open_whitelist_ui.js
+++ b/uiscripts/top_open_whitelist_ui.js
@@ -54,7 +54,7 @@ function top_open_whitelist_ui() {
         btns[translate("buttoncancel")] = function() { page.dialog('close');}
 
         var page = $("<div>").
-        append('<span>' + translate('adblock_wont_run_on_pages_matching') +
+        append('<span>' + translate('catblock_adblock_wont_run_on_pages_matching') +
                '</span>').
         append('<br/><br/><i id="domainpart"></i><i id="pathpart"></i>').
         append('<br/><br/><br/><span id="whitelister_dirs">' +


### PR DESCRIPTION
Signed-off-by: Tomáš Taro tomas@getadblock.com
- Added meta tags in HTML documents indicating UTF-8 encoding
- Added MIME types for XHR
- Don’t show a step for disabling extensions on Firefox and Edge
- Don’t show “how-to hide popup button” in popup’s menu on Firefox (currently, there’s no way how to hide a popup button on FF)
- Updated translations
