### PR TITLE
Fix undefined URL in popup menu

### DIFF
--- a/button/popup.js
+++ b/button/popup.js
@@ -15,6 +15,7 @@ $(function() {
             tab = info.tab;
         } else {
             tab = safari.application.activeBrowserWindow.activeTab;
+            tab.unicodeUrl = getUnicodeUrl(tab.url);
         }
         var shown = {};
         function show(L) { L.forEach(function(x) { shown[x] = true;  }); }


### PR DESCRIPTION
This is a regression of #56.

Signed-off-by: Tomáš Taro tomas@getadblock.com
