### PR TITLE
Don't ignore "enabled" setting while loading channels

### DIFF
--- a/catblock/channels.js
+++ b/catblock/channels.js
@@ -47,7 +47,7 @@ Channels.prototype = {
         this._channelGuide[id] = {
             name: data.name,
             param: data.param,
-            enabled: true,
+            enabled: data.enabled,
             channel: channel
         };
         this._saveToStorage();


### PR DESCRIPTION
Fixes #74 

“Enabled” property stores a boolean value, which tells us whether a channel should be re-enabled or not. It was set to true by default, even after disabling a channel in the first place, which led to an unexpected behaviour.

@kpeckett Please, review by following these steps:
1. Disable some channel in CB Options
2. Restart your browser
3. Check, whether a channel, which was disabled in step #1 hasn’t been re-enabled.

Thanks :)
