### PR TITLE
Wildcard is not supported when defining minimal version of Firefox

### DIFF
--- a/tools/make_release.py
+++ b/tools/make_release.py
@@ -37,7 +37,7 @@ def main():
                     "applications": {
                         "gecko": {
                             "id": "catblock@catblock.tk",
-                            "strict_min_version": "48.*"
+                            "strict_min_version": "48.0"
                         }
                     }
                 }


### PR DESCRIPTION
@kpeckett In new Firefox Nightly, an error is thrown when parsing minimal version needed for running our extension. Looks like this was the issue which caused to not get a preliminary approval, because reviewer was unable to install our extension.
