### PR TITLE
Don't enable CATS on Safari and Edge

### DIFF
--- a/js/cats.js
+++ b/js/cats.js
@@ -2,6 +2,14 @@ var CATS = {
     init: function(callback) {
         var self = this;
 
+        // Don't enable Project CATS on Safari and Edge
+        if (SAFARI || EDGE) {
+            if (self.isEnabled() === undefined) {
+                self.disable();
+                callback();
+            }
+        }
+
         // First-time running code after installation, set "CATS" to disabled by default
         // Opening up installed page, which will determine,
         // whether CATS should be enabled or not


### PR DESCRIPTION
@kpeckett Just making sure that CATS will be disabled on Safari and Edge. Could you review?

Thanks :)
