### PR TITLE
All parameters are mandatory in `initEvent`

### DIFF
--- a/js/adblock_start_safari.js
+++ b/js/adblock_start_safari.js
@@ -76,7 +76,7 @@ function beforeLoadHandler(event) {
             }
             setTimeout(function() {
                 var evt = document.createEvent("Event");
-                evt.initEvent(eventName);
+                evt.initEvent(eventName, false, false);
                 event.target.dispatchEvent(evt);
             }, 0);
         }


### PR DESCRIPTION
Fixes #101 
