### PR TITLE
Hide commands when running Setup.cmd

### DIFF
--- a/tools/Setup.cmd
+++ b/tools/Setup.cmd
@@ -1,3 +1,5 @@
+@ECHO OFF
+
 SET SourcePath="%CD%\catblock"
 
 ECHO Attempting to set access permissions on directory . . .


### PR DESCRIPTION
@tomasko126 could you review?

Test steps:
1. Make the edge ZIP file
2. Extract and run Setup.cmd
3. Watch the CMD window - you shouldn't see the input prompt, and just the text output by @tomasko126's script.

Fixes #109 
