### PR TITLE
parseURI v2 - use standardized URL constructor

### DIFF
--- a/button/popup.js
+++ b/button/popup.js
@@ -15,7 +15,7 @@ $(function() {
             tab = info.tab;
         } else {
             tab = safari.application.activeBrowserWindow.activeTab;
-            tab.unicodeUrl = getUnicodeUrl(tab.url);
+            tab.unicodeUrl = parseURI.getUnicodeURL(tab.url);
         }
 
         var paused = BG.adblock_is_paused();
@@ -46,7 +46,7 @@ $(function() {
             $("#total_blocked_count").text(info.total_blocked);
         }
 
-        var host = parseUri(tab.unicodeUrl).host;
+        var host = new parseURI(tab.unicodeUrl).hostname;
         var advanced_option = BG.get_settings().show_advanced_options;
         var eligible_for_undo = !paused && (info.disabled_site || !info.whitelisted);
         var url_to_check_for_undo = info.disabled_site ? undefined : host;
@@ -69,8 +69,7 @@ $(function() {
             /ab_channel/.test(tab.unicodeUrl) &&
             eligible_for_undo &&
             BG.get_settings().youtube_channel_whitelist) {
-            $("#div_whitelist_channel").html(translate("whitelist_youtube_channel",
-                                                       parseUri.parseSearch(tab.unicodeUrl).ab_channel));
+            $("#div_whitelist_channel").html(translate("whitelist_youtube_channel", parseURI.parseSearch(tab.unicodeUrl).ab_channel));
             show(["div_whitelist_channel"]);
         }
 
@@ -173,7 +172,7 @@ $(function() {
     });
 
     $("#div_undo").click(function() {
-        var host = parseUri(tab.unicodeUrl).host;
+        var host = new parseURI(tab.unicodeUrl).hostname;
         BG.confirm_removal_of_custom_filters_on_host(host, tab);
         closeAndReloadPopup();
     });

--- a/button/popup.js
+++ b/button/popup.js
@@ -15,7 +15,7 @@ $(function() {
             tab = info.tab;
         } else {
             tab = safari.application.activeBrowserWindow.activeTab;
-            tab.unicodeUrl = parseURI.getUnicodeURL(tab.url);
+            tab.unicodeUrl = new parseURI(tab.url).href;
         }
 
         var paused = BG.adblock_is_paused();

--- a/filtering/filternormalizer.js
+++ b/filtering/filternormalizer.js
@@ -226,7 +226,7 @@ var FilterNormalizer = {
                 continue;
             }
             // Convert punycode domains to Unicode
-            domain = getUnicodeDomain(domain);
+            domain = parseURI.getUnicodeDomain(domain);
             if (/^([a-z0-9\-_\u00DF-\u00F6\u00F8-\uFFFFFF]+\.)*[a-z0-9\u00DF-\u00F6\u00F8-\uFFFFFF]+\.?$/i.test(domain) === false) {
                 throw new Error("Invalid domain: " + domain);
             }

--- a/filtering/filterset.js
+++ b/filtering/filterset.js
@@ -60,7 +60,7 @@ class FilterSet {
     // domain, and return it with the given map function applied. This function
     // is for hiding rules only
     filtersFor(domain) {
-        domain = getUnicodeDomain(domain);
+        domain = parseURI.getUnicodeDomain(domain);
         var limited = this._viewFor(domain);
         var data = {};
         // data = set(limited.items)
@@ -128,8 +128,8 @@ class BlockingFilterSet {
     // Inputs: the two domains
     // Returns: true if third-party, false otherwise
     static checkThirdParty(domain1, domain2) {
-        var match1 = parseUri.secondLevelDomainOnly(domain1, false);
-        var match2 = parseUri.secondLevelDomainOnly(domain2, false);
+        var match1 = parseURI.secondLevelDomainOnly(domain1, false);
+        var match2 = parseURI.secondLevelDomainOnly(domain2, false);
         return (match1 !== match2);
     }
 
@@ -151,7 +151,7 @@ class BlockingFilterSet {
     //          'blocked' - true or false
     //          'text' - text of matching pattern/whitelist filter, null if no match
     matches(url, elementType, frameDomain, returnFilter, returnTuple) {
-        var urlDomain = getUnicodeDomain(parseUri(url).hostname);
+        var urlDomain = new parseURI(url).hostname;
         var isThirdParty = BlockingFilterSet.checkThirdParty(urlDomain, frameDomain);
 
         // matchCache approach taken from ABP

--- a/js/adblock_start_chrome.js
+++ b/js/adblock_start_chrome.js
@@ -11,7 +11,7 @@ var elementPurger = {
     // |request.url|.  Will try again if none are found unless |lastTry|.
     _purgeElements: function(request, lastTry) {
         var elType = request.elType;
-        var url = parseURI.getUnicodeURL(request.url);
+        var url = new parseURI(request.url).href;
 
         log("[DEBUG]", "Purging:", lastTry, elType, url);
 

--- a/js/adblock_start_chrome.js
+++ b/js/adblock_start_chrome.js
@@ -11,7 +11,7 @@ var elementPurger = {
     // |request.url|.  Will try again if none are found unless |lastTry|.
     _purgeElements: function(request, lastTry) {
         var elType = request.elType;
-        var url = getUnicodeUrl(request.url);
+        var url = parseURI.getUnicodeURL(request.url);
 
         log("[DEBUG]", "Purging:", lastTry, elType, url);
 
@@ -65,7 +65,7 @@ var elementPurger = {
         // NB: <img src="a#b"> causes a request for "a", not "a#b".  I'm
         // intentionally ignoring IMG tags that uselessly specify a fragment.
         // AdBlock will fail to hide them after blocking the image.
-        var url_parts = parseUri(url), page_parts = this._page_location;
+        var url_parts = new parseURI(url), page_parts = this._page_location;
         var results = [];
         // Case 1: absolute (of the form "abc://de.f/ghi" or "//de.f/ghi")
         results.push({ op:"$=", text: url.match(/\:(\/\/.*)$/)[1] });

--- a/js/adblock_start_common.js
+++ b/js/adblock_start_common.js
@@ -172,7 +172,7 @@ function handleABPLinkClicks() {
         event.preventDefault();
         var searchquery = this.href.replace(/^.+?\?/, "?");
         if (searchquery) {
-            var queryparts = parseUri.parseSearch(searchquery);
+            var queryparts = parseURI.parseSearch(searchquery);
             var loc = queryparts.location;
             var reqLoc = queryparts.requiresLocation;
             var reqList = (reqLoc ? "url:" + reqLoc : undefined);

--- a/js/background.js
+++ b/js/background.js
@@ -223,7 +223,7 @@ if (!SAFARI) {
             fd[tabId][frameId] = {
                 url: url,
                 // Cache these as they'll be needed once per request
-                domain: parseUri(url).hostname,
+                domain: new parseURI(url).hostname,
                 resources: {}
             };
             fd[tabId][frameId].whitelisted = page_is_whitelisted(url);
@@ -295,7 +295,7 @@ if (!SAFARI) {
         }
 
         // Convert punycode domain to Unicode - GH #472
-        details.url = getUnicodeUrl(details.url);
+        details.url = parseURI.getUnicodeURL(details.url);
 
         if (!frameData.track(details)) {
             return { cancel: false };
@@ -376,7 +376,7 @@ if (!SAFARI) {
         if (details.url === "about:blank") {
             details.url = opener.url;
         }
-        var url = getUnicodeUrl(details.url);
+        var url = parseURI.getUnicodeURL(details.url);
         var match = _myfilters.blocking.matches(url, ElementTypes.popup, opener.domain);
         if (match) {
             chrome.tabs.remove(details.tabId);
@@ -408,7 +408,7 @@ if (!SAFARI) {
                 if (tabData &&
                     tabData.url !== details.url) {
                     details.type = "main_frame";
-                    details.url = getUnicodeUrl(details.url);
+                    details.url = parseURI.getUnicodeURL(details.url);
                     frameData.track(details);
                 }
             }
@@ -420,7 +420,7 @@ function debug_report_elemhide(selector, matches, sender) {
     if (!window.frameData) {
         return;
     }
-    var frameDomain = parseUri(sender.url || sender.tab.url).hostname;
+    var frameDomain = new parseURI(sender.url || sender.tab.url).hostname;
     frameData.storeResource(sender.tab.id, sender.frameId || 0, selector, "selector", frameDomain);
 
     var data = frameData.get(sender.tab.id, sender.frameId || 0);
@@ -715,7 +715,7 @@ function page_is_unblockable(url) {
     if (!url) { // Safari empty/bookmarks/top sites page
         return true;
     } else {
-        var scheme = parseUri(url).protocol;
+        var scheme = new parseURI(url).protocol;
         return (scheme !== "http:" && scheme !== "https:" && scheme !== "feed:");
     }
 }
@@ -786,7 +786,7 @@ function getCurrentTabInfo(callback, secondTime) {
             }
 
             // GH #472
-            tab.unicodeUrl = getUnicodeUrl(tab.url);
+            tab.unicodeUrl = parseURI.getUnicodeURL(tab.url);
 
             var disabled_site = page_is_unblockable(tab.unicodeUrl);
             var total_blocked = blockCounts.getTotalAdsBlocked();
@@ -812,7 +812,7 @@ function getCurrentTabInfo(callback, secondTime) {
     } else {
         var browserWindow = safari.application.activeBrowserWindow;
         var tab = browserWindow.activeTab;
-        tab.unicodeUrl = getUnicodeUrl(tab.url); // GH #472
+        tab.unicodeUrl = parseURI.getUnicodeURL(tab.url); // GH #472
         var disabled_site = page_is_unblockable(tab.unicodeUrl);
 
         var result = {
@@ -841,13 +841,13 @@ function page_is_whitelisted(url, type) {
     if (get_settings().safari_content_blocking) {
         return false;
     }
-    url = getUnicodeUrl(url);
+    url = parseURI.getUnicodeURL(url);
     url = url.replace(/\#.*$/, ""); // Remove anchors
     if (!type) {
         type = ElementTypes.document;
     }
     var whitelist = _myfilters.blocking.whitelist;
-    return whitelist.matches(url, type, parseUri(url).hostname, false);
+    return whitelist.matches(url, type, new parseURI(url).hostname, false);
 }
 
 if (!SAFARI) {
@@ -950,7 +950,7 @@ if (!SAFARI) {
                 openTab("options/index.html");
             });
 
-            var host = getUnicodeDomain(parseUri(info.tab.unicodeUrl).host);
+            var host = new parseURI(info.tab.unicodeUrl).hostname;
             var custom_filter_count = count_cache.getCustomFilterCount(host);
             if (custom_filter_count) {
                 addMenu(translate("undo_last_block"), function() {
@@ -1346,7 +1346,7 @@ if (!SAFARI) {
         for (var i=0; i<tabs.length; i++) {
             var currentTab = tabs[i], tabId = currentTab.id;
             if (!frameData.get(tabId)) { // unknown tab
-                currentTab.url = getUnicodeUrl(currentTab.url);
+                currentTab.url = parseURI.getUnicodeURL(currentTab.url);
                 frameData.track({url: currentTab.url, tabId: tabId, type: "main_frame"});
             }
             updateBadge(tabId);
@@ -1363,9 +1363,9 @@ if (!SAFARI) {
 // Script injection logic for Safari is done in safari_bg.js
 if (!SAFARI) {
     function runChannelWhitelist(tabUrl, tabId) {
-        if (parseUri(tabUrl).hostname === "www.youtube.com" &&
+        if (new parseURI(tabUrl).hostname === "www.youtube.com" &&
             get_settings().youtube_channel_whitelist &&
-            !parseUri.parseSearch(tabUrl).ab_channel) {
+            !parseURI.parseSearch(tabUrl).ab_channel) {
             chrome.tabs.executeScript(tabId, { file: "js/ytchannel.js", runAt: "document_start" });
         }
     }

--- a/js/background.js
+++ b/js/background.js
@@ -295,7 +295,7 @@ if (!SAFARI) {
         }
 
         // Convert punycode domain to Unicode - GH #472
-        details.url = parseURI.getUnicodeURL(details.url);
+        details.url = new parseURI(details.url).href;
 
         if (!frameData.track(details)) {
             return { cancel: false };
@@ -376,7 +376,7 @@ if (!SAFARI) {
         if (details.url === "about:blank") {
             details.url = opener.url;
         }
-        var url = parseURI.getUnicodeURL(details.url);
+        var url = new parseURI(details.url).href;
         var match = _myfilters.blocking.matches(url, ElementTypes.popup, opener.domain);
         if (match) {
             chrome.tabs.remove(details.tabId);
@@ -408,7 +408,7 @@ if (!SAFARI) {
                 if (tabData &&
                     tabData.url !== details.url) {
                     details.type = "main_frame";
-                    details.url = parseURI.getUnicodeURL(details.url);
+                    details.url = new parseURI(details.url).href;
                     frameData.track(details);
                 }
             }
@@ -786,7 +786,7 @@ function getCurrentTabInfo(callback, secondTime) {
             }
 
             // GH #472
-            tab.unicodeUrl = parseURI.getUnicodeURL(tab.url);
+            tab.unicodeUrl = new parseURI(tab.url).href;
 
             var disabled_site = page_is_unblockable(tab.unicodeUrl);
             var total_blocked = blockCounts.getTotalAdsBlocked();
@@ -812,7 +812,7 @@ function getCurrentTabInfo(callback, secondTime) {
     } else {
         var browserWindow = safari.application.activeBrowserWindow;
         var tab = browserWindow.activeTab;
-        tab.unicodeUrl = parseURI.getUnicodeURL(tab.url); // GH #472
+        tab.unicodeUrl = new parseURI(tab.url).href; // GH #472
         var disabled_site = page_is_unblockable(tab.unicodeUrl);
 
         var result = {
@@ -841,7 +841,7 @@ function page_is_whitelisted(url, type) {
     if (get_settings().safari_content_blocking) {
         return false;
     }
-    url = parseURI.getUnicodeURL(url);
+    url = new parseURI(url).href;
     url = url.replace(/\#.*$/, ""); // Remove anchors
     if (!type) {
         type = ElementTypes.document;
@@ -1346,7 +1346,7 @@ if (!SAFARI) {
         for (var i=0; i<tabs.length; i++) {
             var currentTab = tabs[i], tabId = currentTab.id;
             if (!frameData.get(tabId)) { // unknown tab
-                currentTab.url = parseURI.getUnicodeURL(currentTab.url);
+                currentTab.url = new parseURI(currentTab.url).href;
                 frameData.track({url: currentTab.url, tabId: tabId, type: "main_frame"});
             }
             updateBadge(tabId);

--- a/js/functions.js
+++ b/js/functions.js
@@ -136,18 +136,6 @@ class parseURI {
         return parsedURL;
     }
 
-    // Returns punycode URL encoded in Unicode
-    static getUnicodeURL(url) {
-        // URLs encoded in Punycode contain xn-- prefix
-        if (url && url.indexOf("xn--") > 0) {
-            var parsed = parseUri(url);
-            // IDN domains have just hostnames encoded in punycode
-            parsed.href = parsed.href.replace(parsed.hostname, punycode.toUnicode(parsed.hostname));
-            return parsed.href;
-        }
-        return url;
-    }
-
     // Returns punycode domain encoded in Unicode
     static getUnicodeDomain(domain) {
         return punycode.toUnicode(domain);

--- a/js/functions.js
+++ b/js/functions.js
@@ -101,74 +101,90 @@ function localizePage() {
     }
 }
 
-// Parse a URL. Based upon http://blog.stevenlevithan.com/archives/parseuri
-// parseUri 1.2.2, (c) Steven Levithan <stevenlevithan.com>, MIT License
+// Parse an URL.
+// The difference between URL constructor and parseURI constructor
+// is that parseURI constructor allows us to store Unicode-encoded URIs.
 // Inputs: url: the URL you want to parse
 // Outputs: object containing all parts of |url| as attributes
-function parseUri(url) {
-    var matches = /^(([^:]+(?::|$))(?:(?:\w+:)?\/\/)?(?:[^:@\/]*(?::[^:@\/]*)?@)?(([^:\/?#]*)(?::(\d*))?))((?:[^?#\/]*\/)*[^?#]*)(\?[^#]*)?(\#.*)?/.exec(url);
-    // The key values are identical to the JS location object values for that key
-    var keys = ["href", "origin", "protocol", "host", "hostname", "port",
-                "pathname", "search", "hash"];
-    var uri = {};
-    for (var i=0; (matches && i<keys.length); i++) {
-        uri[keys[i]] = matches[i] || "";
-    }
-    return uri;
-}
+class parseURI {
+    constructor(url) {
+        // Pass given |url| to the URL constructor
+        var originURL = new URL(url);
 
-// Parses the search part of a URL into an key: value object.
-// e.g., ?hello=world&ext=adblock would become {hello:"world", ext:"adblock"}
-// Inputs: search: the search query of a URL. Must have &-separated values.
-parseUri.parseSearch = function(search) {
-    // Fails if a key exists twice (e.g., ?a=foo&a=bar would return {a:"bar"}
-    search = search.substring(search.indexOf("?")+1).split("&");
-    var params = {}, pair;
-    for (var i = 0; i < search.length; i++) {
-        pair = search[i].split("=");
-        if (pair[0] && !pair[1]) {
-            pair[1] = "";
+        // Create an object, in which we'll store
+        // href/origin/host/hostname in Unicode encoding
+        var parsedURL = {};
+
+        // Convert following values from punycode to Unicode
+        parsedURL.href = punycode.toUnicode(originURL.href);
+        parsedURL.origin = punycode.toUnicode(originURL.origin);
+        parsedURL.host = punycode.toUnicode(originURL.host);
+        parsedURL.hostname = punycode.toUnicode(originURL.hostname);
+
+        // Push every key/value from |originURL| to our |parsedURL| object
+        // except of href/origin/host/hostname, which we already have included
+        for (var key in originURL) {
+            if (key === "href" || key === "origin" || key === "host" || key === "hostname") {
+                continue;
+            }
+            parsedURL[key] = originURL[key];
         }
-        if (!params[decodeURIComponent(pair[0])] && decodeURIComponent(pair[1]) === "undefined") {
-            continue;
-        } else {
-            params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+
+        // Delete unneeded toString() method
+        delete parsedURL.toString;
+
+        return parsedURL;
+    }
+
+    // Returns punycode URL encoded in Unicode
+    static getUnicodeURL(url) {
+        // URLs encoded in Punycode contain xn-- prefix
+        if (url && url.indexOf("xn--") > 0) {
+            var parsed = parseUri(url);
+            // IDN domains have just hostnames encoded in punycode
+            parsed.href = parsed.href.replace(parsed.hostname, punycode.toUnicode(parsed.hostname));
+            return parsed.href;
         }
+        return url;
     }
-    return params;
-};
 
-// Strip third+ level domain names from the domain and return the result.
-// Inputs: domain: the domain that should be parsed
-//         keepDot: true if trailing dots should be preserved in the domain
-// Returns: the parsed domain
-parseUri.secondLevelDomainOnly = function(domain, keepDot) {
-    if (domain) {
-        var match = domain.match(/([^\.]+\.(?:co\.)?[^\.]+)\.?$/) || [domain, domain];
-        return match[keepDot ? 0 : 1].toLowerCase();
-    }
-    return domain;
-};
-
-// Return |domain| encoded in Unicode
-function getUnicodeDomain(domain) {
-    if (domain) {
+    // Returns punycode domain encoded in Unicode
+    static getUnicodeDomain(domain) {
         return punycode.toUnicode(domain);
-    } else {
+    }
+
+    // Parses the search part of a URL into a key: value object.
+    // e.g., ?hello=world&ext=adblock would become {hello:"world", ext:"adblock"}
+    // Inputs: search: the search query of a URL. Must have &-separated values.
+    static parseSearch(search) {
+        // Fails if a key exists twice (e.g., ?a=foo&a=bar would return {a:"bar"}
+        search = search.substring(search.indexOf("?") + 1).split("&");
+        var params = {}, pair;
+        for (var i = 0; i < search.length; i++) {
+            pair = search[i].split("=");
+            if (pair[0] && !pair[1]) {
+                pair[1] = "";
+            }
+            if (!params[decodeURIComponent(pair[0])] && decodeURIComponent(pair[1]) === "undefined") {
+                continue;
+            } else {
+                params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+            }
+        }
+        return params;
+    }
+
+    // Strip third+ level domain names from the domain and return the result.
+    // Inputs: domain: the domain that should be parsed
+    //         keepDot: true if trailing dots should be preserved in the domain
+    // Returns: the parsed domain
+    static secondLevelDomainOnly(domain, keepDot) {
+        if (domain) {
+            var match = domain.match(/([^\.]+\.(?:co\.)?[^\.]+)\.?$/) || [domain, domain];
+            return match[keepDot ? 0 : 1].toLowerCase();
+        }
         return domain;
     }
-}
-
-// Return |url| encoded in Unicode
-function getUnicodeUrl(url) {
-    // URLs encoded in Punycode contain xn-- prefix
-    if (url && url.indexOf("xn--") > 0) {
-        var parsed = parseUri(url);
-        // IDN domains have just hostnames encoded in punycode
-        parsed.href = parsed.href.replace(parsed.hostname, punycode.toUnicode(parsed.hostname));
-        return parsed.href;
-    }
-    return url;
 }
 
 // TODO: move back into background.js since Safari can't use this

--- a/js/port.js
+++ b/js/port.js
@@ -250,7 +250,7 @@ if (typeof SAFARI === "undefined") {
                         }
 
                         if (info.top_level) {
-                            tab[info.visible ? "visible_url" : "invisible_url"] = parseURI.getUnicodeURL(info.url);
+                            tab[info.visible ? "visible_url" : "invisible_url"] = new parseURI(info.url).href;
                         }
                     },
 
@@ -263,7 +263,7 @@ if (typeof SAFARI === "undefined") {
                     info: function(tab, visible) {
                         return {
                             id: tab.id,
-                            url: (visible ? parseURI.getUnicodeURL(tab.visible_url) : parseURI.getUnicodeURL(tab.invisible_url))
+                            url: (visible ? new parseURI(tab.visible_url).href : new parseURI(tab.invisible_url).href)
                         };
                     }
                 },

--- a/js/port.js
+++ b/js/port.js
@@ -250,7 +250,7 @@ if (typeof SAFARI === "undefined") {
                         }
 
                         if (info.top_level) {
-                            tab[info.visible ? "visible_url" : "invisible_url"] = getUnicodeUrl(info.url);
+                            tab[info.visible ? "visible_url" : "invisible_url"] = parseURI.getUnicodeURL(info.url);
                         }
                     },
 
@@ -263,7 +263,7 @@ if (typeof SAFARI === "undefined") {
                     info: function(tab, visible) {
                         return {
                             id: tab.id,
-                            url: (visible ? getUnicodeUrl(tab.visible_url) : getUnicodeUrl(tab.invisible_url))
+                            url: (visible ? parseURI.getUnicodeURL(tab.visible_url) : parseURI.getUnicodeURL(tab.invisible_url))
                         };
                     }
                 },
@@ -417,7 +417,7 @@ if (typeof SAFARI === "undefined") {
             // should return "com.betafish.adblockforsafari-UAMUU452D9"
             Object.defineProperty(chrome.runtime, "id", {
                 get: function() {
-                    return parseUri(safari.extension.baseURI).host;
+                    return new parseURI(safari.extension.baseURI).hostname;
                 },
                 set: undefined
             });

--- a/js/safari_bg.js
+++ b/js/safari_bg.js
@@ -35,7 +35,7 @@ var frameData = (function() {
             var tracker = frameData[tabId];
 
             // We need to handle IDN URLs properly
-            url = parseURI.getUnicodeURL(url);
+            url = new parseURI(url).href;
             domain = parseURI.getUnicodeDomain(domain);
 
             var shouldTrack = !tracker || tracker.url !== url;
@@ -111,7 +111,7 @@ safari.application.addEventListener("message", function(messageEvent) {
     }
 
     if (!isPopup) {
-        var url = parseURI.getUnicodeURL(messageEvent.message.url);
+        var url = new parseURI(messageEvent.message.url).href;
         var elType = messageEvent.message.elType;
         var frameDomain = parseURI.getUnicodeDomain(messageEvent.message.frameDomain);
         var isMatched = url && (_myfilters.blocking.matches(url, elType, frameDomain));

--- a/js/safari_bg.js
+++ b/js/safari_bg.js
@@ -23,7 +23,7 @@ var frameData = (function() {
         //   tabId: Integer - id of the tab you want to add in the frameData
         //   url: new URL for the tab
         reset: function(tabId, url) {
-            var domain = parseUri(url).hostname;
+            var domain = new parseURI(url).hostname;
             return frameData._initializeMap(tabId, url, domain);
         },
         // Initialize map
@@ -35,8 +35,8 @@ var frameData = (function() {
             var tracker = frameData[tabId];
 
             // We need to handle IDN URLs properly
-            url = getUnicodeUrl(url);
-            domain = getUnicodeDomain(domain);
+            url = parseURI.getUnicodeURL(url);
+            domain = parseURI.getUnicodeDomain(domain);
 
             var shouldTrack = !tracker || tracker.url !== url;
             if (shouldTrack) {
@@ -111,9 +111,9 @@ safari.application.addEventListener("message", function(messageEvent) {
     }
 
     if (!isPopup) {
-        var url = getUnicodeUrl(messageEvent.message.url);
+        var url = parseURI.getUnicodeURL(messageEvent.message.url);
         var elType = messageEvent.message.elType;
-        var frameDomain = getUnicodeDomain(messageEvent.message.frameDomain);
+        var frameDomain = parseURI.getUnicodeDomain(messageEvent.message.frameDomain);
         var isMatched = url && (_myfilters.blocking.matches(url, elType, frameDomain));
         if (isMatched) {
             log("SAFARI TRUE BLOCK " + url + ": " + isMatched);
@@ -122,7 +122,7 @@ safari.application.addEventListener("message", function(messageEvent) {
         // Popup blocking support
         if (messageEvent.message.referrer) {
             var isMatched = _myfilters.blocking.matches(sendingTab.url, ElementTypes.popup,
-                                                        parseUri(getUnicodeUrl(messageEvent.message.referrer)).hostname);
+                                                        new parseURI(messageEvent.message.referrer).hostname);
             if (isMatched) {
                 tab.close();
             }
@@ -240,7 +240,7 @@ safari.application.addEventListener("beforeNavigate", function(event) {
         safari.extension.removeContentScript(safari.extension.baseURI + "js/bandaids.js");
     }
     // YouTube Channel Whitelist
-    if (/youtube.com/.test(event.url) && get_settings().youtube_channel_whitelist && !parseUri.parseSearch(event.url).ab_channel) {
+    if (/youtube.com/.test(event.url) && get_settings().youtube_channel_whitelist && !parseURI.parseSearch(event.url).ab_channel) {
         safari.extension.addContentScriptFromURL(safari.extension.baseURI + "js/ytchannel.js", [], [], false);
     } else {
         safari.extension.removeContentScript(safari.extension.baseURI + "js/ytchannel.js");
@@ -265,7 +265,7 @@ safari.application.addEventListener("command", function(event) {
         openTab("options/index.html", false, browserWindow);
     } else if (command === "undo-last-block") {
         var tab = browserWindow.activeTab;
-        var host = parseUri(tab.url).host;
+        var host = new parseURI(tab.url).hostname;
         confirm_removal_of_custom_filters_on_host(host, tab);
     } else if (command in {"show-whitelist-wizard": 1, "show-blacklist-wizard": 1, "show-clickwatcher-ui": 1 }) {
         browserWindow.activeTab.page.dispatchMessage(command);
@@ -303,7 +303,7 @@ safari.application.addEventListener("contextmenu", function(event) {
     event.contextMenu.appendContextMenuItem("show-blacklist-wizard", translate("block_this_ad"));
     event.contextMenu.appendContextMenuItem("show-clickwatcher-ui", translate("block_an_ad_on_this_page"));
 
-    var host = parseUri(url).host;
+    var host = new parseURI(url).hostname;
     if (count_cache.getCustomFilterCount(host)) {
         event.contextMenu.appendContextMenuItem("undo-last-block", translate("undo_last_block"));
     }

--- a/js/ytchannel.js
+++ b/js/ytchannel.js
@@ -3,19 +3,19 @@ var url = document.location.href;
 
 // Get id of the channel
 function getChannelId(url) {
-    return parseUri(url).pathname.split("/")[2];
+    return new parseURI(url).pathname.split("/")[2];
 }
 
 // Get id of the video
 function getVideoId(url) {
-    return parseUri.parseSearch(url).v;
+    return parseURI.parseSearch(url).v;
 }
 
 // Function which: - adds name of the channel on the end of the URL, e.g. &ab_channel=nameofthechannel
 //                 - reload the page, so AdBlock can properly whitelist the page (just if channel is whitelisted by user)
 function updateURL(channelName, shouldReload) {
     var updatedUrl = "";
-    if (parseUri(url).search.indexOf("?") === -1) {
+    if (new parseURI(url).search.indexOf("?") === -1) {
         updatedUrl = url + "?&ab_channel=" + channelName.replace(/\s/g, "");
     } else {
         updatedUrl = url + "&ab_channel=" + channelName.replace(/\s/g, "");

--- a/manifest.json
+++ b/manifest.json
@@ -44,6 +44,7 @@
             "matches": ["http://*/*", "https://*/*"],
             "js": [
                 "lib/jquery.min.js",
+                "lib/punycode.min.js",
                 "js/port.js",
                 "js/functions.js",
                 "filtering/filteroptions.js",

--- a/pages/adreport.js
+++ b/pages/adreport.js
@@ -67,7 +67,7 @@ $(function() {
 });
 
 // Fetching the options...
-var options = parseUri.parseSearch(document.location.search);
+var options = parseURI.parseSearch(document.location.search);
 var tabId = options.tabId.replace(/[^0-9]/g, "");
 
 // Get the list of all unsubscribed default filters
@@ -148,8 +148,7 @@ function sendReport() {
 
     var domain = "";
     if (options.url) {
-        domain = parseUri(options.url)
-            .hostname;
+        domain = new parseURI(options.url).hostname;
         report_data.title = report_data.title + ": " + domain;
         report_data.url = options.url;
     }
@@ -418,16 +417,12 @@ function checkmalware() {
                     var resource = key.split(":|:");
                     if (resource &&
                         resource.length === 2 &&
-                        extracted_domains.indexOf(parseUri(resource[1])
-                                                  .hostname) === -1) {
-                        extracted_domains.push(parseUri(resource[1])
-                                               .hostname);
+                        extracted_domains.indexOf(new parseURI(resource[1]).hostname) === -1) {
+                        extracted_domains.push(new parseURI(resource[1]).hostname);
                     }
                 } else {
-                    if (extracted_domains.indexOf(parseUri(key)
-                                                  .hostname) === -1) {
-                        extracted_domains.push(parseUri(key)
-                                               .hostname);
+                    if (extracted_domains.indexOf(new parseURI(key).hostname) === -1) {
+                        extracted_domains.push(new parseURI(key).hostname);
                     }
                 }
             }

--- a/pages/resourceblock.js
+++ b/pages/resourceblock.js
@@ -4,7 +4,7 @@
 $("body").fadeIn();
 
 // Get tabId from URL
-var tabId = parseUri.parseSearch(document.location.href).tabId;
+var tabId = parseURI.parseSearch(document.location.href).tabId;
 tabId = parseInt(tabId);
 
 // Convert element type to request type
@@ -77,7 +77,7 @@ BGcall("reset_matchCache", function(matchCache) {
                                 res.frameDomain = resource.split(":|:")[2].replace("www.", "");
 
                                 if (res.elType !== "selector") {
-                                    res.thirdParty = BlockingFilterSet.checkThirdParty(parseUri(res.url).hostname, res.frameDomain);
+                                    res.thirdParty = BlockingFilterSet.checkThirdParty(new parseURI(res.url).hostname, res.frameDomain);
                                 }
                             }
                         }

--- a/tools/tests/test.js
+++ b/tools/tests/test.js
@@ -85,45 +85,46 @@ BGcall("get_settings", function(data) {
     });
 
     QUnit.module("Parsing URLs: parseURI");
-    QUnit.test("parseUri", function(assert) {
+    QUnit.test("parseURI", function(assert) {
+        var searchParams = new URL("https://foo.bar/").searchParams;
         assert.expect(17);
-        assert.deepEqual(parseUri("https://foo.bar/"), {"hash": "", "host": "foo.bar", "hostname": "foo.bar", "href": "https://foo.bar/", "origin": "https://foo.bar", "pathname": "/", "port": "", "protocol": "https:", "search": ""});
-        assert.deepEqual(parseUri("https://foo.bar:80/"), {"hash": "", "host": "foo.bar:80", "hostname": "foo.bar", "href": "https://foo.bar:80/", "origin": "https://foo.bar:80", "pathname": "/", "port": "80", "protocol": "https:", "search": ""});
-        assert.deepEqual(parseUri("https://foo.bar/?http://www.google.nl/search?"), {"hash": "", "host": "foo.bar", "hostname": "foo.bar", "href": "https://foo.bar/?http://www.google.nl/search?", "origin": "https://foo.bar", "pathname": "/", "port": "", "protocol": "https:", "search": "?http://www.google.nl/search?"});
-        assert.deepEqual(parseUri("https:foo.bar/?http://www.google.nl/search?"), {"hash": "", "host": "foo.bar", "hostname": "foo.bar", "href": "https:foo.bar/?http://www.google.nl/search?", "origin": "https:foo.bar", "pathname": "/", "port": "", "protocol": "https:", "search": "?http://www.google.nl/search?"});
-        assert.deepEqual(parseUri("http://usr:@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top"), {"hash": "#top", "host": "www.test.com:81", "hostname": "www.test.com", "href": "http://usr:@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top", "origin": "http://usr:@www.test.com:81", "pathname": "/dir/dir.2/index.htm", "port": "81", "protocol": "http:", "search": "?q1=0&&test1&test2=value"});
-        assert.deepEqual(parseUri("http://usr:pass@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top"), {"hash": "#top", "host": "www.test.com:81", "hostname": "www.test.com", "href": "http://usr:pass@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top", "origin": "http://usr:pass@www.test.com:81", "pathname": "/dir/dir.2/index.htm", "port": "81", "protocol": "http:", "search": "?q1=0&&test1&test2=value"});
-        assert.deepEqual(parseUri("http://usr:pass@www.test.com/dir/dir.2/index.htm?q1=0&&test1&test2=value#top"), {"hash": "#top", "host": "www.test.com", "hostname": "www.test.com", "href": "http://usr:pass@www.test.com/dir/dir.2/index.htm?q1=0&&test1&test2=value#top", "origin": "http://usr:pass@www.test.com", "pathname": "/dir/dir.2/index.htm", "port": "", "protocol": "http:", "search": "?q1=0&&test1&test2=value"});
-        assert.deepEqual(parseUri("http://www.test.com/dir/dir.2/index.htm?q1=0&&test1&test2=value#top"), {"hash": "#top", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir.2/index.htm?q1=0&&test1&test2=value#top", "origin": "http://www.test.com", "pathname": "/dir/dir.2/index.htm", "port": "", "protocol": "http:", "search": "?q1=0&&test1&test2=value"});
-        assert.deepEqual(parseUri("http://www.test.com/dir/dir@2/index.htm#top"), {"hash": "#top", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir@2/index.htm#top", "origin": "http://www.test.com", "pathname": "/dir/dir@2/index.htm", "port": "", "protocol": "http:", "search": ""});
-        assert.deepEqual(parseUri("http://www.test.com/dir/dir@2/index#top"), {"hash": "#top", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir@2/index#top", "origin": "http://www.test.com", "pathname": "/dir/dir@2/index", "port": "", "protocol": "http:", "search": ""});
-        assert.deepEqual(parseUri("http://test.com/dir/dir@2/#top"), {"hash": "#top", "host": "test.com", "hostname": "test.com", "href": "http://test.com/dir/dir@2/#top", "origin": "http://test.com", "pathname": "/dir/dir@2/", "port": "", "protocol": "http:", "search": ""});
-        assert.deepEqual(parseUri("http://www.test.com/dir/dir@2/?top"), {"hash": "", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir@2/?top", "origin": "http://www.test.com", "pathname": "/dir/dir@2/", "port": "", "protocol": "http:", "search": "?top"});
-        assert.deepEqual(parseUri("http://www.test.com/dir/dir@2/"), {"hash": "", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir@2/", "origin": "http://www.test.com", "pathname": "/dir/dir@2/", "port": "", "protocol": "http:", "search": ""});
-        assert.deepEqual(parseUri("feed:https://www.test.com/dir/dir@2/"), {"hash": "", "host": "www.test.com", "hostname": "www.test.com", "href": "feed:https://www.test.com/dir/dir@2/", "origin": "feed:https://www.test.com", "pathname": "/dir/dir@2/", "port": "", "protocol": "feed:", "search": ""});
-        assert.deepEqual(parseUri("feed:https://www.test.com:80/dir/dir@2/"), {"hash": "", "host": "www.test.com:80", "hostname": "www.test.com", "href": "feed:https://www.test.com:80/dir/dir@2/", "origin": "feed:https://www.test.com:80", "pathname": "/dir/dir@2/", "port": "80", "protocol": "feed:", "search": ""});
-        assert.deepEqual(parseUri("feed:https://www.test.com/dir/dir2/?http://foo.bar/"), {"hash": "", "host": "www.test.com", "hostname": "www.test.com", "href": "feed:https://www.test.com/dir/dir2/?http://foo.bar/", "origin": "feed:https://www.test.com", "pathname": "/dir/dir2/", "port": "", "protocol": "feed:", "search": "?http://foo.bar/"});
-        assert.deepEqual(parseUri("chrome-extension://longidentifier/tools/tests/index.html?notrycatch=true"), {"hash": "", "host": "longidentifier", "hostname": "longidentifier", "href": "chrome-extension://longidentifier/tools/tests/index.html?notrycatch=true", "origin": "chrome-extension://longidentifier", "pathname": "/tools/tests/index.html", "port": "", "protocol": "chrome-extension:", "search": "?notrycatch=true"});
+        assert.deepEqual(new parseURI("https://foo.bar/"), {"hash": "", "host": "foo.bar", "hostname": "foo.bar", "href": "https://foo.bar/", "origin": "https://foo.bar", "pathname": "/", "password": "", "port": "", "protocol": "https:", "search": "", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("https://foo.bar:80/"), {"hash": "", "host": "foo.bar:80", "hostname": "foo.bar", "href": "https://foo.bar:80/", "origin": "https://foo.bar:80", "password": "", "pathname": "/", "port": "80", "protocol": "https:", "search": "", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("https://foo.bar/?http://www.google.nl/search?"), {"hash": "", "host": "foo.bar", "hostname": "foo.bar", "href": "https://foo.bar/?http://www.google.nl/search?", "origin": "https://foo.bar", "password": "", "pathname": "/", "port": "", "protocol": "https:", "search": "?http://www.google.nl/search?", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("https:foo.bar/?http://www.google.nl/search?"), {"hash": "", "host": "foo.bar", "hostname": "foo.bar", "href": "https://foo.bar/?http://www.google.nl/search?", "origin": "https://foo.bar", "password": "", "pathname": "/", "port": "", "protocol": "https:", "search": "?http://www.google.nl/search?", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("http://usr:@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top"), {"hash": "#top", "host": "www.test.com:81", "hostname": "www.test.com", "href": "http://usr@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top", "origin": "http://www.test.com:81", "password": "", "pathname": "/dir/dir.2/index.htm", "port": "81", "protocol": "http:", "search": "?q1=0&&test1&test2=value", "searchParams": searchParams, "username": "usr"});
+        assert.deepEqual(new parseURI("http://usr:pass@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top"), {"hash": "#top", "host": "www.test.com:81", "hostname": "www.test.com", "href": "http://usr:pass@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top", "origin": "http://www.test.com:81", "password": "pass", "pathname": "/dir/dir.2/index.htm", "port": "81", "protocol": "http:", "search": "?q1=0&&test1&test2=value", "searchParams": searchParams, "username": "usr"});
+        assert.deepEqual(new parseURI("http://usr:pass@www.test.com/dir/dir.2/index.htm?q1=0&&test1&test2=value#top"), {"hash": "#top", "host": "www.test.com", "hostname": "www.test.com", "href": "http://usr:pass@www.test.com/dir/dir.2/index.htm?q1=0&&test1&test2=value#top", "origin": "http://www.test.com", "password": "pass", "pathname": "/dir/dir.2/index.htm", "port": "", "protocol": "http:", "search": "?q1=0&&test1&test2=value", "searchParams": searchParams, "username": "usr"});
+        assert.deepEqual(new parseURI("http://www.test.com/dir/dir.2/index.htm?q1=0&&test1&test2=value#top"), {"hash": "#top", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir.2/index.htm?q1=0&&test1&test2=value#top", "origin": "http://www.test.com", "password": "", "pathname": "/dir/dir.2/index.htm", "port": "", "protocol": "http:", "search": "?q1=0&&test1&test2=value", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("http://www.test.com/dir/dir@2/index.htm#top"), {"hash": "#top", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir@2/index.htm#top", "origin": "http://www.test.com", "password": "", "pathname": "/dir/dir@2/index.htm", "port": "", "protocol": "http:", "search": "", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("http://www.test.com/dir/dir@2/index#top"), {"hash": "#top", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir@2/index#top", "origin": "http://www.test.com", "password": "", "pathname": "/dir/dir@2/index", "port": "", "protocol": "http:", "search": "", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("http://test.com/dir/dir@2/#top"), {"hash": "#top", "host": "test.com", "hostname": "test.com", "href": "http://test.com/dir/dir@2/#top", "origin": "http://test.com", "password": "", "pathname": "/dir/dir@2/", "port": "", "protocol": "http:", "search": "", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("http://www.test.com/dir/dir@2/?top"), {"hash": "", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir@2/?top", "origin": "http://www.test.com", "password": "", "pathname": "/dir/dir@2/", "port": "", "protocol": "http:", "search": "?top", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("http://www.test.com/dir/dir@2/"), {"hash": "", "host": "www.test.com", "hostname": "www.test.com", "href": "http://www.test.com/dir/dir@2/", "origin": "http://www.test.com", "password": "", "pathname": "/dir/dir@2/", "port": "", "protocol": "http:", "search": "", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("feed:https://www.test.com/dir/dir@2/"), {"hash": "", "host": "", "hostname": "", "href": "feed:https://www.test.com/dir/dir@2/", "origin": "feed://", "password": "", "pathname": "https://www.test.com/dir/dir@2/", "port": "", "protocol": "feed:", "search": "", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("feed:https://www.test.com:80/dir/dir@2/"), {"hash": "", "host": "", "hostname": "", "href": "feed:https://www.test.com:80/dir/dir@2/", "origin": "feed://", "password": "", "pathname": "https://www.test.com:80/dir/dir@2/", "port": "", "protocol": "feed:", "search": "", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("feed:https://www.test.com/dir/dir2/?http://foo.bar/"), {"hash": "", "host": "", "hostname": "", "href": "feed:https://www.test.com/dir/dir2/?http://foo.bar/", "origin": "feed://", "password": "", "pathname": "https://www.test.com/dir/dir2/", "port": "", "protocol": "feed:", "search": "?http://foo.bar/", "searchParams": searchParams, "username": ""});
+        assert.deepEqual(new parseURI("chrome-extension://longidentifier/tools/tests/index.html?notrycatch=true"), {"hash": "", "host": "longidentifier", "hostname": "longidentifier", "href": "chrome-extension://longidentifier/tools/tests/index.html?notrycatch=true", "origin": "chrome-extension://longidentifier", "password": "", "pathname": "/tools/tests/index.html", "port": "", "protocol": "chrome-extension:", "search": "?notrycatch=true", "searchParams": searchParams, "username": ""});
     });
 
     QUnit.test("parseSearch", function(assert) {
         assert.expect(11);
-        assert.deepEqual(parseUri.parseSearch("?hello=world&ext=adblock&time=bedtime"), {"ext": "adblock", "hello": "world", "time": "bedtime"});
-        assert.deepEqual(parseUri.parseSearch(""), {});
-        assert.deepEqual(parseUri.parseSearch("?"), {});
-        assert.deepEqual(parseUri.parseSearch("?hello"), {"hello": ""});
-        assert.deepEqual(parseUri.parseSearch("?hello=world"), {"hello": "world"});
-        assert.deepEqual(parseUri.parseSearch("?hello&ext=adblock"), {"ext": "adblock", "hello": ""});
-        assert.deepEqual(parseUri.parseSearch("?ext=adblock&hello"), {"ext": "adblock", "hello": ""});
-        assert.deepEqual(parseUri.parseSearch("?hello=world&hello=earth"), {"hello": "earth"});
-        assert.deepEqual(parseUri.parseSearch("?hello=&ext=adblock"), {"ext": "adblock", "hello": ""});
-        assert.deepEqual(parseUri.parseSearch("?hello=world&&ext=adblock"), {"ext": "adblock", "hello": "world"});
-        assert.deepEqual(parseUri.parseSearch("?hello&&&&ext=adblock"), {"ext": "adblock", "hello": ""});
+        assert.deepEqual(parseURI.parseSearch("?hello=world&ext=adblock&time=bedtime"), {"ext": "adblock", "hello": "world", "time": "bedtime"});
+        assert.deepEqual(parseURI.parseSearch(""), {});
+        assert.deepEqual(parseURI.parseSearch("?"), {});
+        assert.deepEqual(parseURI.parseSearch("?hello"), {"hello": ""});
+        assert.deepEqual(parseURI.parseSearch("?hello=world"), {"hello": "world"});
+        assert.deepEqual(parseURI.parseSearch("?hello&ext=adblock"), {"ext": "adblock", "hello": ""});
+        assert.deepEqual(parseURI.parseSearch("?ext=adblock&hello"), {"ext": "adblock", "hello": ""});
+        assert.deepEqual(parseURI.parseSearch("?hello=world&hello=earth"), {"hello": "earth"});
+        assert.deepEqual(parseURI.parseSearch("?hello=&ext=adblock"), {"ext": "adblock", "hello": ""});
+        assert.deepEqual(parseURI.parseSearch("?hello=world&&ext=adblock"), {"ext": "adblock", "hello": "world"});
+        assert.deepEqual(parseURI.parseSearch("?hello&&&&ext=adblock"), {"ext": "adblock", "hello": ""});
     });
 
     QUnit.test("parseSecondLevelDomain", function(assert) {
         assert.expect(5);
-        var secondLevelDomainOnly = parseUri.secondLevelDomainOnly;
+        var secondLevelDomainOnly = parseURI.secondLevelDomainOnly;
         assert.deepEqual(secondLevelDomainOnly("appspot.google.com"), "google.com");
         assert.deepEqual(secondLevelDomainOnly("foo.bar.com"), "bar.com");
         assert.deepEqual(secondLevelDomainOnly("https://www.google.com.ph"), "com.ph");
@@ -133,18 +134,17 @@ BGcall("get_settings", function(data) {
 
     QUnit.module("Parsing URLs: ");
     QUnit.test("IDN conversions", function(assert) {
-        assert.expect(11);
-        assert.equal(getUnicodeDomain('google.com'), 'google.com');
-        assert.equal(getUnicodeDomain('xn--maana-pta.com'), 'mañana.com');
-        assert.equal(getUnicodeDomain('xn--bcher-kva.com'), "bücher.com");
-        assert.equal(getUnicodeDomain('xn--bcher-kva.com'), 'b\xFCcher.com');
-        assert.equal(getUnicodeDomain('xn----dqo34k.com'), "☃-⌘.com");
-        assert.equal(getUnicodeDomain('xn--ls8h.la'), "💩.la");
-        assert.equal(getUnicodeDomain('\u0434\u0436\u0443\u043C\u043B\u0430@xn--p-8sbkgc5ag7bhce.xn--ba-lmcq'), '\u0434\u0436\u0443\u043C\u043B\u0430@\u0434\u0436p\u0443\u043C\u043B\u0430\u0442\u0435\u0441\u0442.b\u0440\u0444a');
-        assert.equal(getUnicodeUrl('http://www.xn--maana-pta.com'), "http://www.mañana.com");
-        assert.equal(getUnicodeUrl('http://www.xn----dqo34k.com'), "http://www.☃-⌘.com");
-        assert.equal(getUnicodeUrl('http://www.xn----dqo34k.com/foo/blah?t=is#here'), "http://www.☃-⌘.com/foo/blah?t=is#here");
-        assert.equal(getUnicodeUrl('http://www.google.com/foo/blah?t=is#here'), 'http://www.google.com/foo/blah?t=is#here');
+        assert.expect(10);
+        assert.equal(new parseURI("https://google.com").href, 'https://google.com/');
+        assert.equal(new parseURI('https://www.xn--maana-pta.com').href, 'https://www.mañana.com/');
+        assert.equal(new parseURI('https://www.xn--bcher-kva.com').href, "https://www.bücher.com/");
+        assert.equal(new parseURI('https://www.xn--bcher-kva.com').href, 'https://www.b\xFCcher.com/');
+        assert.equal(new parseURI('https://www.xn----dqo34k.com').href, "https://www.☃-⌘.com/");
+        assert.equal(new parseURI('https://www.xn--ls8h.la').href, "https://www.💩.la/");
+        assert.equal(new parseURI('http://www.xn--maana-pta.com').href, "http://www.mañana.com/");
+        assert.equal(new parseURI('http://www.xn----dqo34k.com').href, "http://www.☃-⌘.com/");
+        assert.equal(new parseURI('http://www.xn----dqo34k.com/foo/blah?t=is#here').href, "http://www.☃-⌘.com/foo/blah?t=is#here");
+        assert.equal(new parseURI('http://www.google.com/foo/blah?t=is#here').href, 'http://www.google.com/foo/blah?t=is#here');
     });
 
     QUnit.module("Global Functions");
@@ -737,7 +737,7 @@ BGcall("get_settings", function(data) {
             QUnit.module("Purging the remainders of ads using CSS selectors");
 
             function runme(page, url) {
-                elementPurger._page_location = parseUri(page);
+                elementPurger._page_location = new parseURI(page);
                 return elementPurger._srcsFor(url);
             }
 
@@ -760,9 +760,9 @@ BGcall("get_settings", function(data) {
                     {"op": "=", "text": "./e.html#f"}]);
                 assert.deepEqual(runme("http://a.com/b/c/#", "http://a.com/b/c/d/#"), [
                     {"op": "$=", "text": "//a.com/b/c/d/#"},
-                    {"op": "=", "text": "/b/c/d/#"},
-                    {"op": "=", "text": "d/#"},
-                    {"op": "=", "text": "./d/#"}]);
+                    {"op": "=", "text": "/b/c/d/"},
+                    {"op": "=", "text": "d/"},
+                    {"op": "=", "text": "./d/"}]);
             });
 
             QUnit.test("Ignore queryparameters in page but not in url", function(assert) {

--- a/uiscripts/blacklisting/blacklistui.js
+++ b/uiscripts/blacklisting/blacklistui.js
@@ -194,7 +194,7 @@ class BlacklistUi {
             click: function() {
                 var rule = $("#summary", that._ui_page2).text();
                 if (rule.length > 0) {
-                    var filter = getUnicodeDomain(document.location.hostname) + "##" + rule;
+                    var filter = parseURI.getUnicodeDomain(document.location.hostname) + "##" + rule;
                     BGcall("add_custom_filter", filter, function() {
                         block_list_via_css([rule]);
                         that._ui_page2.dialog("close");
@@ -208,7 +208,7 @@ class BlacklistUi {
 
         if (that._advanced_user) {
             btns[translate("buttonedit")] = function() {
-                var custom_filter = getUnicodeDomain(document.location.hostname) + "##" + $("#summary", that._ui_page2).text();
+                var custom_filter = parseURI.getUnicodeDomain(document.location.hostname) + "##" + $("#summary", that._ui_page2).text();
                 that._ui_page2.dialog("close");
                 custom_filter = prompt(translate("blacklistereditfilter"), custom_filter);
                 if (custom_filter) { //null => user clicked cancel
@@ -306,7 +306,7 @@ class BlacklistUi {
         var attrs = ["id", "class", "name", "src", "href", "data"];
         for (var i in attrs) {
             if ($("input[type='checkbox']#ck" + attrs[i], detailsDiv).is(":checked")) {
-                result.push("[" + attrs[i] + "=" + getUnicodeUrl(JSON.stringify(el.attr(attrs[i]))) + "]");
+                result.push("[" + attrs[i] + "=" + parseURI.getUnicodeURL(JSON.stringify(el.attr(attrs[i]))) + "]");
             }
         }
 
@@ -443,7 +443,7 @@ class BlacklistUi {
             size = 50;
         }
 
-        value = getUnicodeUrl(value);
+        value = parseURI.getUnicodeURL(value);
 
         var half = size / 2 - 2; // With ellipsis, the total length will be ~= size
 

--- a/uiscripts/blacklisting/blacklistui.js
+++ b/uiscripts/blacklisting/blacklistui.js
@@ -306,7 +306,7 @@ class BlacklistUi {
         var attrs = ["id", "class", "name", "src", "href", "data"];
         for (var i in attrs) {
             if ($("input[type='checkbox']#ck" + attrs[i], detailsDiv).is(":checked")) {
-                result.push("[" + attrs[i] + "=" + parseURI.getUnicodeURL(JSON.stringify(el.attr(attrs[i]))) + "]");
+                result.push("[" + attrs[i] + "=" + new parseURI(JSON.stringify(el.attr(attrs[i]))).href + "]");
             }
         }
 
@@ -443,7 +443,7 @@ class BlacklistUi {
             size = 50;
         }
 
-        value = parseURI.getUnicodeURL(value);
+        value = new parseURI(value).href;
 
         var half = size / 2 - 2; // With ellipsis, the total length will be ~= size
 

--- a/uiscripts/top_open_blacklist_ui.js
+++ b/uiscripts/top_open_blacklist_ui.js
@@ -22,7 +22,7 @@ function top_open_blacklist_ui(options) {
         // If they right clicked in a frame in Chrome, use the frame instead
         if (options.info && options.info.frameUrl) {
             var frame = $("iframe").filter(function(i, el) {
-                return el.src === getUnicodeDomain(options.info.frameUrl);
+                return el.src === options.info.frameUrl;
             });
             if (frame.length === 1) {
                 rightclicked_item = frame[0];

--- a/uiscripts/top_open_whitelist_ui.js
+++ b/uiscripts/top_open_whitelist_ui.js
@@ -10,7 +10,7 @@ function top_open_whitelist_ui() {
 
     may_open_dialog_ui = false;
 
-    var domain = getUnicodeDomain(document.location.host);
+    var domain = parseURI.getUnicodeDomain(document.location.hostname);
 
     // Safari's document.location breaks in the feed reader if the feed is fetched via https. Normal
     // feeds have URLs with scheme replaced with "feed", but HTTPS feeds have the scheme replaced with
@@ -18,7 +18,7 @@ function top_open_whitelist_ui() {
     // so its domain property will be empty; fortunately, it puts a proper https url into the pathname
     // property and we can use it.
     if (SAFARI && domain === "" && document.location.href.indexOf("feed:https") === 0) {
-        domain = parseUri(document.location.pathname).host;
+        domain = new parseURI(document.location.pathname).hostname;
     }
 
     // Get Flash objects out of the way of our UI
@@ -86,7 +86,7 @@ function top_open_whitelist_ui() {
         $(".adblock-whitelist-dialog").parent().css({ position: "relative" });
         $(".adblock-whitelist-dialog").css({ top: 200, left: 200, position: "fixed" });
 
-        var fixedDomainPart = parseUri.secondLevelDomainOnly(domain, true);
+        var fixedDomainPart = parseURI.secondLevelDomainOnly(domain, true);
         var domainparts = domain.substr(0, domain.lastIndexOf(fixedDomainPart)).split(".");
         domainparts.splice(domainparts.length-1, 1, fixedDomainPart);
 


### PR DESCRIPTION
Instead of having our own regex for extracting parts of URL, use standardised [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.