### PR TITLE
Send non-issues to support

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### So you've found a problem in CatBlock?
 #### Answer these questions to help us solve the case!
-(If you have a problem that isn't a bug, or want to suggest a feature, do so at <http://catblock.tenderapp.com>
+(If you have a problem that isn't a bug, or want to suggest a feature, do so at <http://support.getcatblock.com>
 
 #### 1. List some steps we can follow to make the bug happen on our end.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,24 +1,25 @@
-## So you've found a problem in CatBlock?
-### Answer these questions to help us solve the case!
+### So you've found a problem in CatBlock?
+#### Answer these questions to help us solve the case!
+(If you have a problem that isn't a bug, or want to suggest a feature, do so at <http://catblock.tenderapp.com>
 
-### 1. List some steps we can follow to make the bug happen on our end.
+#### 1. List some steps we can follow to make the bug happen on our end.
 
 1. 
 2. 
 3. 
 
-### 2. When you followed these steps above, what did you think should happen?
+#### 2. When you followed these steps above, what did you think should happen?
 
 
 
-### 3. What actually happened instead?
+#### 3. What actually happened instead?
 
 
-### 4. Finally, click the CatBlock button, then Options, then Support on the page that appears. Provide us with the **debug info** from that page.
+#### 4. Finally, click the CatBlock button, then Options, then Support on the page that appears. Provide us with the **debug info** from that page.
 
 ```
 <Copy and paste it over this line.>
 ```
 
-### 5. Any other information you think might be useful for us to know?
+#### 5. Any other information you think might be useful for us to know?
 


### PR DESCRIPTION
As some people may come to GitHub to get help or suggest a feature, let's send them to <http://support.getcatblock.com> instead to keep things cleaner on here.